### PR TITLE
add timeout parameter in requests post

### DIFF
--- a/guidance/generators.py
+++ b/guidance/generators.py
@@ -143,9 +143,15 @@ class OpenAI():
         }
 
         # Send a POST request and get the response
-        response = requests.post(self.endpoint, headers=headers, json=data)
-        if response.status_code != 200:
-            raise Exception("Response is not 200: " + response.text)
+        # timeout exception is raised if the server has not issued a response for 10 seconds
+        try:
+            response = requests.post(self.endpoint, headers=headers, json=data, timeout=10)
+            if response.status_code != 200:
+                raise Exception("Response is not 200: " + response.text)
+        except requests.Timeout:
+            raise Exception("Request timed out.")
+        except requests.ConnectionError:
+            raise Exception("Connection error occurred.")
         return response.json()
 
     def tokenize(self, strings):


### PR DESCRIPTION
Add timeout parameter in requests post, with its value set to 10. This is to handle the situation when the server has not issued a response for 10 seconds, i.e. no bytes have been received on the underlying socket for 10 seconds. Making this configurable did not seem necessary at this point.