### PR TITLE
[DOCs] Custom directory for caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,3 +724,6 @@ See a more elaborate example [here](notebooks/chat.ipynb).
 
 ### Using tools
 See the 'Using a search API' example in [this notebook](notebooks/chat.ipynb).
+
+### Custom cache directory
+We can set custom directory for caching with the `XDG_CACHE_HOME` environment variable.


### PR DESCRIPTION
`XDG_CACHE_HOME` environment variable can be used to set custom cache directory.