### PR TITLE
Add new infix AND and OR boolean logic

### DIFF
--- a/guidance/_program.py
+++ b/guidance/_program.py
@@ -751,6 +751,8 @@ _built_ins = {
     "len": commands.len,
     "range": commands.range,
     "UNARY_OPERATOR_not": commands.not_,
+    "BINARY_OPERATOR_and": commands.and_,
+    "BINARY_OPERATOR_or": commands.or_,
 }
 
 class DisplayThrottler():

--- a/guidance/library/__init__.py
+++ b/guidance/library/__init__.py
@@ -28,3 +28,5 @@ from ._callable import callable
 from ._range import range
 from ._len import len
 from ._not import not_
+from ._and import and_
+from ._or import or_

--- a/guidance/library/_and.py
+++ b/guidance/library/_and.py
@@ -1,0 +1,4 @@
+def and_(left, right):
+    ''' boolean AND comparison
+    '''
+    return left and right

--- a/guidance/library/_or.py
+++ b/guidance/library/_or.py
@@ -1,0 +1,4 @@
+def or_(left, right):
+    ''' boolean OR comparison
+    '''
+    return left or right

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -71,3 +71,11 @@ def test_special_var_index():
     assert str(prompt(arr=["there"])) == "there!"
     prompt = guidance("{{#geneach 'out' num_iterations=1}}{{arr[@index]}}{{/each}}!")
     assert str(prompt(arr=["there"])) == "there!"
+
+def test_infix_and():
+    prompt = guidance("Boolean logic True and False: {{True and False}}")
+    assert str(prompt()) == "Boolean logic True and False: False"
+
+def test_infix_or():
+    prompt = guidance("Boolean logic True or False: {{True or False}}")
+    assert str(prompt()) == "Boolean logic True or False: True"


### PR DESCRIPTION
Guidance lack of very basic condition logic infix is "and" and "or"
This PR just add this basic infix operator

Example use case:
`prompt = guidance("""Answer 'Yes' or 'No': '{{#if (True and False)}}Yes{{elif 1==1 or 1==0}}maybe{{else}}No{{/if}}'""")`
Output:
Answer 'Yes' or 'No': 'maybe'
