### PR TITLE
Retry OpenaAI call if `openai.error.APIConnectionError` is raised

### DIFF
--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -666,7 +666,7 @@ class OpenAISession(LLMSession):
                         call_args["logit_bias"] = {str(k): v for k,v in logit_bias.items()} # convert keys to strings since that's the open ai api's format
                     out = await self.llm.caller(**call_args)
 
-                except (openai.error.RateLimitError, openai.error.ServiceUnavailableError, openai.error.APIError, openai.error.Timeout):
+                except (openai.error.RateLimitError, openai.error.ServiceUnavailableError, openai.error.APIError, openai.error.Timeout, openai.error.APIConnectionError):
                     await asyncio.sleep(3)
                     try_again = True
                     fail_count += 1


### PR DESCRIPTION
Error I'm randomly getting from the OpenAI API: `openai.error.APIConnectionError: Error communicating with OpenAI`. This PR adds APIConnectionError to the list of errors that cause an OpenAI API request retry