### PR TITLE
Add support for PaLM models, such as chat-bison and text-bison

### DIFF
--- a/guidance/library/__init__.py
+++ b/guidance/library/__init__.py
@@ -15,6 +15,10 @@ from ._subtract import subtract
 from ._role import role
 from ._user import user
 from ._system import system
+from ._context import context
+from ._example import example
+from ._input import input_
+from ._output import output_
 from ._assistant import assistant
 from ._function import function
 from ._break import break_

--- a/guidance/library/_context.py
+++ b/guidance/library/_context.py
@@ -1,0 +1,14 @@
+from ._role import role
+
+async def context(hidden=False, _parser_context=None, **kwargs):
+    ''' A chat role block for the 'context' role.
+
+    This is just a shorthand for {{#role 'context'}}...{{/role}}.
+
+    Parameters
+    ----------
+    hidden : bool
+        Whether to include the assistant block in future LLM context. 
+    '''
+    return await role(role_name="context", hidden=hidden, _parser_context=_parser_context, **kwargs)
+context.is_block = True

--- a/guidance/library/_example.py
+++ b/guidance/library/_example.py
@@ -1,0 +1,15 @@
+from ._role import role
+
+async def example(hidden=False, _parser_context=None, **kwargs):
+    ''' A chat role block for the 'example' role.
+
+    This is just a shorthand for {{#role 'example'}}...{{/role}}.
+
+    Parameters
+    ----------
+    hidden : bool
+        Whether to include the block in future LLM context. 
+    '''
+    return await role(role_name="example", hidden=hidden, _parser_context=_parser_context, **kwargs)
+
+example.is_block = True

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -93,7 +93,7 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
 
         # auto-detect role stop tags
         if stop is None:
-            m = re.match(r"^{{~?/\w*(user|assistant|system|role|function)\w*~?}}.*", next_text)
+            m = re.match(r"^{{~?/\w*(user|assistant|system|role|function|context|example)\w*~?}}.*", next_text)
             if m:
                 stop = parser.program.llm.role_end(m.group(1))
 

--- a/guidance/library/_input.py
+++ b/guidance/library/_input.py
@@ -1,0 +1,27 @@
+from .._utils import ContentCapture
+
+async def input_(hidden=False, _parser_context=None, **kwargs):
+    ''' A google input block.
+    '''
+    block_content = _parser_context['block_content']
+    parser = _parser_context['parser']
+    variable_stack = _parser_context['variable_stack']
+
+    # capture the content of the block
+    with ContentCapture(variable_stack, hidden) as new_content:
+        
+        # send the role-start special tokens
+        new_content += parser.program.llm.input_start(**kwargs)
+
+        # visit the block content
+        new_content += await parser.visit(
+            block_content,
+            variable_stack,
+            next_node=_parser_context["block_close_node"],
+            prev_node=_parser_context["prev_node"],
+            next_next_node=_parser_context["next_node"]
+        )
+
+        # send the role-end special tokens
+        new_content += parser.program.llm.input_end()
+input_.is_block = True

--- a/guidance/library/_output.py
+++ b/guidance/library/_output.py
@@ -1,0 +1,27 @@
+from .._utils import ContentCapture
+
+async def output_(hidden=False, _parser_context=None, **kwargs):
+    ''' A google output block.
+    '''
+    block_content = _parser_context['block_content']
+    parser = _parser_context['parser']
+    variable_stack = _parser_context['variable_stack']
+
+    # capture the content of the block
+    with ContentCapture(variable_stack, hidden) as new_content:
+        
+        # send the role-start special tokens
+        new_content += parser.program.llm.output_start(**kwargs)
+
+        # visit the block content
+        new_content += await parser.visit(
+            block_content,
+            variable_stack,
+            next_node=_parser_context["block_close_node"],
+            prev_node=_parser_context["prev_node"],
+            next_next_node=_parser_context["next_node"]
+        )
+
+        # send the role-end special tokens
+        new_content += parser.program.llm.output_end()
+output_.is_block = True

--- a/guidance/llms/__init__.py
+++ b/guidance/llms/__init__.py
@@ -3,5 +3,6 @@ from ._transformers import Transformers
 from ._mock import Mock
 from ._llm import LLM, LLMSession, SyncSession
 from ._deep_speed import DeepSpeed
+from ._palm import PaLM
 from . import transformers
 from . import caches

--- a/guidance/llms/_palm.py
+++ b/guidance/llms/_palm.py
@@ -1,0 +1,707 @@
+import vertexai.language_models as palm
+import os
+import time
+import requests
+import aiohttp
+import copy
+import time
+import asyncio
+import types
+import collections
+import json
+import re
+import regex
+import os
+import string
+
+from ._llm import LLM, LLMSession, SyncSession
+
+class MalformedPromptException(Exception):
+    pass
+
+import pyparsing as pp
+
+role_start_tag = pp.Suppress(pp.Optional(pp.White()) + pp.Literal("<|im_start|>"))
+role_start_name = pp.Word(pp.alphanums + "_")("role_name")
+role_kwargs = pp.Suppress(pp.Optional(" ")) + pp.Dict(pp.Group(pp.Word(pp.alphanums + "_") + pp.Suppress("=") + pp.QuotedString('"')))("kwargs")
+role_start = (role_start_tag + role_start_name + pp.Optional(role_kwargs) + pp.Suppress("\n")).leave_whitespace()
+role_end = pp.Suppress(pp.Literal("<|im_end|>"))
+role_content = pp.Combine(pp.ZeroOrMore(pp.CharsNotIn("<") | pp.Literal("<") + ~pp.FollowedBy("|im_end|>")))("role_content")
+role_group = pp.Group(role_start + role_content + role_end)("role_group").leave_whitespace()
+partial_role_group = pp.Group(role_start + role_content)("role_group").leave_whitespace()
+roles_grammar = pp.ZeroOrMore(role_group) + pp.Optional(partial_role_group) + pp.StringEnd()
+
+input_start_tag = pp.Suppress(pp.Optional(pp.White()) + pp.Literal("<|input_start|>"))
+input_start = (input_start_tag + pp.Suppress("\n")).leave_whitespace()
+input_end = pp.Suppress(pp.Literal("<|input_end|>"))
+input_content = pp.Combine(pp.ZeroOrMore(pp.CharsNotIn("<") | pp.Literal("<") + ~pp.FollowedBy("|input_end|>") + ~pp.FollowedBy("|im_end|>")))("input_content")
+input_group = pp.Group(input_start + input_content + input_end)("input_group").leave_whitespace()
+
+output_start_tag = pp.Suppress(pp.Optional(pp.White()) + pp.Literal("<|output_start|>"))
+output_start = (output_start_tag + pp.Suppress("\n")).leave_whitespace()
+output_end = pp.Suppress(pp.Literal("<|output_end|>"))
+output_content = pp.Combine(pp.ZeroOrMore(pp.CharsNotIn("<") | pp.Literal("<") + ~pp.FollowedBy("|output_end|>") + ~pp.FollowedBy("|im_end|>")))("output_content")
+output_group = pp.Group(output_start + output_content + output_end)("output_group").leave_whitespace()
+input_output_grammar = input_group + output_group + pp.StringEnd()
+
+
+def prompt_to_messages(prompt):
+    messages = []
+
+    assert prompt.endswith("<|im_start|>assistant\n"), "When calling PaLM chat models you must generate only directly inside the assistant role! The PaLM API does not currently support partial assistant prompting."
+
+    parsed_prompt = roles_grammar.parse_string(prompt)
+
+    # pattern = r'<\|im_start\|>([^\n]+)\n(.*?)(?=<\|im_end\|>|$)'
+    # matches = re.findall(pattern, prompt, re.DOTALL)
+
+    # if not matches:
+    #     return [{'role': 'user', 'content': prompt}]
+
+    for role in parsed_prompt:
+        if len(role["role_content"]) > 0: # only add non-empty messages
+            message = {'role': role["role_name"], 'content': role["role_content"]}
+            if "kwargs" in role:
+                for k, v in role["kwargs"].items():
+                    message[k] = v
+            messages.append(message)
+
+    return messages
+
+async def convert_to_guidance_names_generator(chat_mode):
+    for resp in chat_mode:
+        if resp.is_blocked:
+            #raise Exception("The model blocked the request")
+            # on streams, google allows the last one to have blocked=True
+            break
+        yield {'choices': [{'text': resp.text}]}
+
+async def convert_to_guidance_names_agenerator(chat_mode):
+    async for resp in chat_mode:
+        safety_attributes = resp["outputs"][0]["structVal"]["safetyAttributes"]
+        if "listVal" in safety_attributes:
+            safety_attributes = safety_attributes["listVal"][0]
+        if safety_attributes["structVal"]["blocked"]["boolVal"][0]:
+            #raise Exception("The model blocked the request")
+            # on streams, google allows the last one to have blocked=True
+            break
+        output = resp["outputs"][0]["structVal"]
+        if "content" in output:
+            yield {"choices": [{"text": output["content"]["stringVal"][0]}]}
+        else:
+            output = output["candidates"]
+            yield {"choices": [{"text": v["structVal"]["content"]["stringVal"][0]} for v in output["listVal"]]}
+    
+    
+def convert_to_guidance_names(chat_mode):
+    if isinstance(chat_mode, (palm.TextGenerationResponse)):
+        chat_mode = {'choices': [{'text': chat_mode.text}]}
+    elif isinstance(chat_mode, (types.AsyncGeneratorType)):
+        return convert_to_guidance_names_agenerator(chat_mode)
+    elif isinstance(chat_mode, (types.GeneratorType)):
+        return convert_to_guidance_names_generator(chat_mode)
+    else:
+        if "predictions" in chat_mode:
+            chat_mode = chat_mode['predictions'][0]
+            if "candidates" in chat_mode:
+                for c in chat_mode['candidates']:
+                    c['text'] = c.pop('content')
+                chat_mode['choices'] = chat_mode.pop("candidates")
+            else:
+                chat_mode["choices"] = [{"text": chat_mode["content"]}]
+        else:
+            return {"choices": [{"text": chat_mode[0]["outputs"][0]["structVal"]["content"]["stringVal"][0]}]}
+    return chat_mode
+    
+def aggregate_messages(messages):
+        """ Aggregates all system messages to form the context and aggregates all examples in the prompt.
+        Returns the context string, the examples and the message list.
+        """
+        context = ""
+        examples = []
+        aggregated_messages = []
+        for message in messages:
+            if message["role"] == "system" or message["role"] == "context":
+                context += message["content"]
+            elif message["role"] == "example":
+                parsed_example = input_output_grammar.parse_string(message["content"])
+                examples.append({"input": {"content":parsed_example[0]["input_content"]}, "output": {"content":parsed_example[1]["output_content"]}})
+            else:
+                aggregated_messages.append({"author": message["role"], "content": message["content"]})
+        return context, examples, aggregated_messages
+
+class PaLM(LLM):
+    llm_name: str = "palm"
+
+    def __init__(self, model=None, caching=True, max_retries=5, max_calls_per_min=60,
+                 api_key=None, api_type=None, api_base=None, api_version=None, 
+                 temperature=0.0, chat_mode="auto", project_id=None, rest_call=False,
+                 allowed_special_tokens={"<calc>","</calc>"},
+                 endpoint="https://us-central1-aiplatform.googleapis.com/v1/projects/{project_id}/locations/us-central1/publishers/google/models/{model}"):
+        super().__init__()
+
+        if endpoint is not None:
+            if api_base is None:
+                api_base = endpoint
+
+        ##########################
+        ### FINDING MODEL NAME ###
+        ##########################
+        if model is None:
+            model = os.environ.get("PALM_MODEL", None)
+        if model is None:
+            try:
+                with open(os.path.expanduser('~/.palm_model'), 'r') as file:
+                    model = file.read().replace('\n', '')
+            except:
+                pass
+
+        ##########################
+        ### FINDING CHAT MODE  ###
+        ##########################
+        if chat_mode == "auto":
+            # parse to determin if the model need to use the chat completion API
+            chat_model_pattern = r'chat-bison|chat-bison-32k'
+            if re.match(chat_model_pattern, model):
+                chat_mode = True
+            else:
+                chat_mode = False
+        
+
+        ##########################
+        ###  FINDING API KEY   ###
+        ##########################
+        if api_key is None: # get from environment variable
+            api_key = os.environ.get("GOOGLE_API_KEY", getattr(palm, "api_key", None))
+        if api_key is not None and not api_key.startswith("sk-") and os.path.exists(os.path.expanduser(api_key)): # get from file
+            with open(os.path.expanduser(api_key), 'r') as file:
+                api_key = file.read().replace('\n', '')
+        if api_key is None: # get from default file location
+            try:
+                with open(os.path.expanduser('~/.google_api_key'), 'r') as file:
+                    api_key = file.read().replace('\n', '')
+            except:
+                pass
+
+        ##################################
+        ###  FINDING GCP CREDENTIALS   ###
+        ##################################
+        gcp_credentials = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", None)
+
+        ##########################
+        ### FINDING PROJECT ID ###
+        ##########################
+        if project_id is None:
+            project_id = os.environ.get("GOOGLE_PROJECT_ID", None)
+
+        ##########################
+        ###  FINDING ENDPOINT  ###
+        ##########################
+        if api_base is None:
+            api_base = os.environ.get("PALM_API_BASE", None) or os.environ.get("PALM_ENDPOINT", None) # ENDPOINT is deprecated
+            if api_base is not None:
+                with api_base.rfind(":") as rcolon_index: 
+                  if rcolon_index != -1 and (api_base[rcolon_index+1:] == "serverStreamingPredict" or api_base[rcolon_index+1:] == "predict"):
+                    api_base = api_base[:rcolon_index]
+        
+        # TODO: TOKENIZER?
+
+        self.chat_mode = chat_mode
+        
+        self.allowed_special_tokens = allowed_special_tokens
+        self.model_name = model
+        self.caching = caching
+        self.max_retries = max_retries
+        self.max_calls_per_min = max_calls_per_min
+        if isinstance(api_key, str):
+            api_key = api_key.replace("Bearer ", "")
+        self.api_key = api_key
+        self.api_type = api_type
+        self.api_base = api_base
+        self.api_version = api_version
+        self.current_time = time.time()
+        self.call_history = collections.deque()
+        self.temperature = temperature
+        self.project_id = project_id
+        self.rest_call = rest_call
+        self.endpoint = endpoint
+        self.gcp_credentials = gcp_credentials
+
+        if not self.rest_call:
+            self.caller = self._library_call
+            if self.chat_mode:
+                self.chat_model = palm.ChatModel.from_pretrained(self.model_name)
+            else:
+                self.generation_model = palm.TextGenerationModel.from_pretrained(self.model_name)
+        else:
+            self.caller = self._rest_call
+            self._rest_headers = {
+                "Content-Type": "application/json"
+            }
+
+    def session(self, asynchronous=False):
+        if asynchronous:
+            return PALMSession(self)
+        else:
+            return SyncSession(PALMSession(self))
+
+    def role_start(self, role_name, **kwargs):
+        assert self.chat_mode, "role_start() can only be used in chat mode"
+        return "<|im_start|>"+role_name+"".join([f' {k}="{v}"' for k,v in kwargs.items()])+"\n"
+    
+    def role_end(self, role=None):
+        assert self.chat_mode, "role_end() can only be used in chat mode"
+        return "<|im_end|>"
+    
+    def input_start(self, **kwargs):
+        assert self.chat_mode, "input_start() can only be used in chat mode"
+        return "<|input_start|>"+"\n"
+    
+    def input_end(self):
+        assert self.chat_mode, "input_end() can only be used in chat mode"
+        return "<|input_end|>"
+    
+    def output_start(self, **kwargs):
+        assert self.chat_mode, "output_start() can only be used in chat mode"
+        return "<|output_start|>"+"\n"
+    
+    def output_end(self):
+        assert self.chat_mode, "output_end() can only be used in chat mode"
+        return "<|output_end|>"
+    
+    @classmethod
+    async def stream_then_save(cls, gen, key, stop_regex, n):
+        list_out = []
+        cached_out = None
+
+        # init stop_regex variables
+        if stop_regex is not None:
+            if isinstance(stop_regex, str):
+                stop_patterns = [regex.compile(stop_regex)]
+            else:
+                stop_patterns = [regex.compile(pattern) for pattern in stop_regex]
+
+            current_strings = ["" for _ in range(n)]
+            # last_out_pos = ["" for _ in range(n)]
+        
+        # iterate through the stream
+        all_done = False
+        async for curr_out in gen:
+
+            # if we have a cached output, extend it with the current output
+            if cached_out is not None:
+                out = merge_stream_chunks(cached_out, curr_out)
+            else:
+                out = curr_out
+            
+            # check if we have stop_regex matches
+            found_partial = False
+            if stop_regex is not None:
+
+                # keep track of the generated text so far
+                for i,choice in enumerate(curr_out['choices']):
+                    current_strings[i] += choice['text']
+
+                # check if all of the strings match a stop string (and hence we can stop the batch inference)
+                all_done = True
+                for i in range(len(current_strings)):
+                    found = False
+                    for s in stop_patterns:
+                        if s.search(current_strings[i]):
+                            found = True
+                    if not found:
+                        all_done = False
+                        break
+
+                # find where trim off the stop regex matches if needed (and look for partial matches)
+                stop_pos = [1e10 for _ in range(n)]
+                stop_text = [None for _ in range(n)]
+                for i in range(len(current_strings)):
+                    for s in stop_patterns:
+                        m = s.search(current_strings[i], partial=True)
+                        if m:
+                            span = m.span()
+                            if span[1] > span[0]:
+                                if m.partial: # we might be starting a stop sequence, so we can't emit anything yet
+                                    found_partial = True
+                                    break
+                                else:
+                                    stop_text[i] = current_strings[i][span[0]:span[1]]
+                                    stop_pos[i] = min(span[0], stop_pos[i])
+                    if stop_pos != 1e10:
+                        stop_pos[i] = stop_pos[i] - len(current_strings[i]) # convert to relative position from the end
+            
+            # if we might be starting a stop sequence, we need to cache the output and continue to wait and see
+            if found_partial:
+                cached_out = out
+                continue
+            
+            # if we get here, we are not starting a stop sequence, so we can emit the output
+            else:
+                cached_out = None
+
+                if stop_regex is not None:
+                    for i in range(len(out['choices'])):
+                        if stop_pos[i] < len(out['choices'][i]['text']):
+                            out['choices'][i]['text'] = out['choices'][i]['text'][:stop_pos[i]]
+                            out['choices'][i]['stop_text'] = stop_text[i]
+                            out['choices'][i]['finish_reason'] = "stop"
+            
+                list_out.append(out)
+                yield out
+                if all_done:
+                    gen.aclose()
+                    break
+        
+        # if we have a cached output, emit it
+        if cached_out is not None:
+            list_out.append(cached_out)
+            yield out
+
+        cls.cache[key] = list_out
+    
+    def _stream_completion(self):
+        pass
+
+    def end_of_text(self):
+        return "<|endoftext|>"
+
+    # Define a function to add a call to the deque
+    def add_call(self):
+        # Get the current timestamp in seconds
+        now = time.time()
+        # Append the timestamp to the right of the deque
+        self.call_history.append(now)
+
+    # Define a function to count the calls in the last 60 seconds
+    def count_calls(self):
+        # Get the current timestamp in seconds
+        now = time.time()
+        # Remove the timestamps that are older than 60 seconds from the left of the deque
+        while self.call_history and self.call_history[0] < now - 60:
+            self.call_history.popleft()
+        # Return the length of the deque as the number of calls
+        return len(self.call_history)
+
+    async def _library_call(self, **kwargs):
+        """ Call the PaLM API using the python package.
+        """
+
+        # candidate count is not used on library calls
+        del kwargs['function_call']
+        del kwargs['candidate_count']
+        kwargs['temperature'] = float(kwargs["temperature"])
+        stream = kwargs.pop("stream",False)
+        kwargs["stop_sequences"] = kwargs.get("stop_sequences",[])
+        if type(kwargs["stop_sequences"]) == str:
+            kwargs["stop_sequences"] = [kwargs["stop_sequences"]]
+        if self.chat_mode: 
+            context, examples, messages = aggregate_messages(prompt_to_messages(kwargs.pop('prompt')))
+            messages = [palm.ChatMessage(author=x["author"], content=x["content"]) for x in messages]
+            examples = [palm.InputOutputTextPair(input_text=x["input"]["content"], output_text=x["output"]["content"]) for x in examples]
+            kwargs['context'] = context
+            kwargs['message_history'] = messages[:-1]
+            kwargs['examples'] = examples
+            chat = self.chat_model.start_chat(**kwargs)
+            if len(messages)==0:
+                messages.append(palm.ChatMessage(author="user", content="\t"))
+            if stream:
+                out = chat.send_message_streaming(messages[-1].content)
+            else:
+                out = chat.send_message(messages[-1].content)
+        else:
+            if stream:
+                kwargs.pop("stop_sequences")
+                out = self.generation_model.predict_streaming(**kwargs)
+            else:
+                out = self.generation_model.predict(**kwargs)
+        return convert_to_guidance_names(out)
+
+    async def _rest_call(self, **kwargs):
+        """ Call the PaLM API using the REST API.
+        """
+        
+        url = self.api_base
+        # Define the request headers
+        headers = copy.copy(self._rest_headers)
+
+        assert self.api_key is not None and self.project_id is not None, "You must provide a PaLM API key and project ID to use the PaLM LLM via rest calls. Either pass it in the constructor, set the GOOGLE_API_KEY and GOOGLE_PROJECT_ID environment variables, or create the files ~/.google_api_key and ~/.google_project_id with your credentials."
+        
+        stream = kwargs.pop("stream",False)
+        if stream:
+            url += ":serverStreamingPredict"
+        else:
+            url += ":predict"
+
+        headers['Authorization'] = f"Bearer {self.api_key}"
+
+        stop_sequences = kwargs.get("stop_sequences", [])
+        if isinstance(stop_sequences,str):
+            stop_sequences=[stop_sequences]
+        # Define the request data
+        if stream:
+            data = {
+                "inputs": [
+                    {
+                        "struct_val": {
+                            "prompt": {"string_val":kwargs["prompt"],}}
+                    },
+                ],
+                "parameters": {
+                    "struct_val":{
+                        "maxOutputTokens": {"int_val":kwargs.get("max_output_tokens", 0)},
+                        "temperature": {"float_val":float(kwargs.get("temperature", 0.0))},
+                        "topP": {"float_val":float(kwargs.get("top_p", 0.95))},
+                        "topK": {"int_val":kwargs.get("top_k", 40)},
+                    }
+                }
+            }
+        else:
+            
+            data = {
+                "instances": [
+                    {
+                        "prompt": kwargs["prompt"],
+                    },
+                ],
+                "parameters": {
+                    "maxOutputTokens": kwargs.get("max_output_tokens", 0),
+                    "temperature": kwargs.get("temperature", 0.0),
+                    "topP": kwargs.get("top_p", 0.95),
+                    "topK": kwargs.get("top_k", 40),
+                    "candidateCount": kwargs.get("candidate_count", 1),
+                    "stopSequences": stop_sequences,
+                }
+            }
+
+        #if stream and not self.chat_mode:
+        #    data["parameters"].pop("stop_sequences")
+
+        if self.chat_mode:
+            context, examples, messages = aggregate_messages(prompt_to_messages(kwargs["prompt"]))
+            if stream:
+                data["inputs"] = [{
+                    "structVal": {
+                        "messages": {
+                            "listVal": [{
+                                "structVal": {
+                                    "content": {"string_val": m["content"]},
+                                    "author": {"string_val": m["author"]},
+                                }}
+                                for m in messages]
+                        }
+                    }
+                }] 
+            else:
+                data["instances"] = [{
+                    "context": context,
+                    "messages": messages,
+                    "examples": examples,
+                }]
+                
+
+        # Send a POST request and get the response
+        # An exception for timeout is raised if the server has not issued a response for 10 seconds
+        try:
+            if len(list(string.Formatter().parse(url))) > 0:
+                url = url.format(project_id = self.project_id, model=self.model_name)
+            if stream:
+                session = aiohttp.ClientSession()
+                response = await session.post(url, json=data, headers=headers, timeout=60)
+                status = response.status
+            else:
+                response = requests.post(url, headers=headers, json=data, timeout=60)
+                status = response.status_code
+                text = response.text
+            if status != 200:
+                if stream:
+                    text = await response.text()
+                raise Exception("Response is not 200: " + text)
+            if stream:
+                response = self._rest_stream_handler(response, session)
+            else:
+                response = response.json()
+        except requests.Timeout:
+            raise Exception("Request timed out.")
+        except requests.ConnectionError:
+            raise Exception("Connection error occurred.")
+        
+        response = convert_to_guidance_names(response)
+        
+        return response
+        
+    async def _close_response_and_session(self, response, session):
+        await response.release()
+        await session.close()
+
+    async def _rest_stream_handler(self, response, session):
+        # async for line in response.iter_lines():
+        lines=[]
+        async for line in response.content:
+            text = line.decode('utf-8')
+            if text.startswith('  "outputs": [\n'):
+                if len(lines)>1:
+                    yield(json.loads("".join(lines[:-2])))
+                lines = ['{\n']
+            lines.append(text)
+        yield(json.loads("".join(lines[:-1])))
+        await self._close_response_and_session(response, session)
+                    
+    
+    def encode(self, string):
+        # note that is_fragment is not used used for this tokenizer
+        return self._tokenizer.encode(string, allowed_special=self.allowed_special_tokens)
+    
+    def decode(self, tokens):
+        return self._tokenizer.decode(tokens)
+    
+def merge_stream_chunks(first_chunk, second_chunk):
+    """ This merges two stream responses together.
+    """
+
+    out = copy.deepcopy(first_chunk)
+
+    # merge the choices
+    for i in range(len(out['choices'])):
+        out_choice = out['choices'][i]
+        second_choice = second_chunk['choices'][i]
+        out_choice['text'] += second_choice['text']
+        if 'index' in second_choice:
+            out_choice['index'] = second_choice['index']
+        if 'finish_reason' in second_choice:
+            out_choice['finish_reason'] = second_choice['finish_reason']
+        if out_choice.get('logprobs', None) is not None:
+            out_choice['logprobs']['token_logprobs'] += second_choice['logprobs']['token_logprobs']
+            out_choice['logprobs']['top_logprobs'] += second_choice['logprobs']['top_logprobs']
+            out_choice['logprobs']['text_offset'] = second_choice['logprobs']['text_offset']
+    
+    return out
+
+class RegexStopChecker():
+    def __init__(self, stop_pattern, decode, prefix_length):
+        if isinstance(stop_pattern, str):
+            self.stop_patterns = [regex.compile(stop_pattern)]
+        else:
+            self.stop_patterns = [regex.compile(pattern) for pattern in stop_pattern]
+        self.prefix_length = prefix_length
+        self.decode = decode
+        self.current_strings = None
+        self.current_length = 0
+
+    def __call__(self, input_ids, scores, **kwargs):
+
+        # extend our current strings
+        if self.current_strings is None:
+            self.current_strings = ["" for _ in range(len(input_ids))]
+        for i in range(len(self.current_strings)):
+            self.current_strings[i] += self.decode(input_ids[i][self.current_length:])
+        
+        # trim off the prefix string so we don't look for stop matches in the prompt
+        if self.current_length == 0:
+            for i in range(len(self.current_strings)):
+                self.current_strings[i] = self.current_strings[i][self.prefix_length:]
+        
+        self.current_length = len(input_ids[0])
+        
+        # check if all of the strings match a stop string (and hence we can stop the batch inference)
+        all_done = True
+        for i in range(len(self.current_strings)):
+            found = False
+            for s in self.stop_patterns:
+                if s.search(self.current_strings[i]):
+                    found = True
+            if not found:
+                all_done = False
+                break
+        
+        return all_done
+
+# Define a deque to store the timestamps of the calls
+class PALMSession(LLMSession):
+    async def __call__(self, prompt, stop=[], stop_regex=None, temperature=None, n=1, max_tokens=1000, logprobs=None,
+                       top_p=1.0, echo=False, logit_bias=None, token_healing=None, pattern=None, stream=None,
+                       cache_seed=0, caching=None, **completion_kwargs):
+        """ Generate a completion of the given prompt.
+        """
+
+        # we need to stream in order to support stop_regex
+        if stream is None:
+            stream = stop_regex is not None
+        
+        assert stop_regex is None or stream, "We can only support stop_regex for the PaLM API when stream=True!"
+        assert stop_regex is None or n == 1, "We don't yet support stop_regex combined with n > 1 with the PaLM API!"
+
+
+        assert token_healing is None or token_healing is False, "The PaLM API does not yet support token healing! Please either switch to an endpoint that does, or don't use the `token_healing` argument to `gen`."
+
+        # set defaults
+        if temperature is None:
+            temperature = self.llm.temperature
+
+        # get the arguments as dictionary for cache key generation
+        args = locals().copy()
+
+        assert not pattern, "The PaLM API does not support Guidance pattern controls! Please either switch to an endpoint that does, or don't use the `pattern` argument to `gen`."
+
+        # define the key for the cache
+        cache_params = self._cache_params(args)
+        llm_cache = self.llm.cache
+        key = llm_cache.create_key(self.llm.llm_name, **cache_params)
+        
+        # allow streaming to use non-streaming cache (the reverse is not true)
+        if key not in llm_cache and stream:
+            cache_params["stream"] = False
+            key1 = llm_cache.create_key(self.llm.llm_name, **cache_params)
+            if key1 in llm_cache:
+                key = key1
+
+        # check the cache
+        if key not in llm_cache or caching is False or (caching is not True and not self.llm.caching):
+
+            # ensure we don't exceed the rate limit
+            while self.llm.count_calls() > self.llm.max_calls_per_min:
+                await asyncio.sleep(1)
+
+            fail_count = 0
+            if stop is None:
+                stop=[]
+            while True:
+                try_again = False
+                try:
+                    self.llm.add_call()
+                    call_args = {
+                        "prompt": prompt,
+                        "max_output_tokens": max_tokens,
+                        "temperature": temperature,
+                        "top_p": top_p,
+                        "candidate_count": n,
+                        "stop_sequences": stop,
+                        "stream": stream,
+                        **completion_kwargs
+                    }
+                    
+                    out = await self.llm.caller(**call_args)
+
+                except ValueError:
+                    await asyncio.sleep(1)
+                    try_again = True
+                    fail_count += 1
+                
+                if not try_again:
+                    break
+
+                if fail_count > self.llm.max_retries:
+                    raise Exception(f"Too many (more than {self.llm.max_retries}) PaLM API errors in a row!")
+            
+            if stream:
+                return self.llm.stream_then_save(out, key, stop_regex, n)
+            else:
+                llm_cache[key] = out
+        
+        # wrap as a list if needed
+        if stream:
+            if isinstance(llm_cache[key], list):
+                return llm_cache[key]
+            return [llm_cache[key]]
+        
+        return llm_cache[key]

--- a/notebooks/api_examples/llms/PaLM.ipynb
+++ b/notebooks/api_examples/llms/PaLM.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `PaLM2` API examples\n",
+    "\n",
+    "This notebook contains examples of how to use the `PaLM` LLM.\n",
+    "\n",
+    "#### PaLM specific tools:\n",
+    "- `{{context}}`: alias for the system block\n",
+    "- `{{example}}`: example role to provide input-output demostration pairs\n",
+    "  - `{{input}}`: input user sentence in the demonstration pair\n",
+    "  - `{{output}}`: output assistant sentence in the demonstration pair\n",
+    "\n",
+    "As of now, 32k models can only be used in via rest calls."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic PaLM usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### library calls\n",
+    "\n",
+    "Authentication for library calls is handled automatically by the VertexAI SDK. If you have trouble autenticating visit the [official page](https://cloud.google.com/vertex-ai/docs/workbench/reference/authentication#client-libraries)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"guidance-stop-button-a33e221e-9f99-417c-8a32-c52585085586\" style=\"cursor: pointer; margin: 0px; display: none; float: right; padding: 3px; border-radius: 4px 4px 4px 4px; border: 0px solid rgba(127, 127, 127, 1); padding-left: 10px; padding-right: 10px; font-size: 13px; background-color: rgba(127, 127, 127, 0.25);\">Stop program</div><div id=\"guidance-content-a33e221e-9f99-417c-8a32-c52585085586\"><pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>The most liked food is: <span style='background-color: rgba(0, 165, 0, 0.25); opacity: 1.0; display: inline;' title='{{gen &#x27;flavor&#x27; max_tokens=10 stop=&quot;.&quot;}}'> Pizza</span></pre></div>\n",
+       "<script type=\"text/javascript\">(()=>{var t={296:(t,e,n)=>{var i=NaN,o=\"[object Symbol]\",r=/^\\s+|\\s+$/g,a=/^[-+]0x[0-9a-f]+$/i,s=/^0b[01]+$/i,c=/^0o[0-7]+$/i,d=parseInt,u=\"object\"==typeof n.g&&n.g&&n.g.Object===Object&&n.g,l=\"object\"==typeof self&&self&&self.Object===Object&&self,f=u||l||Function(\"return this\")(),h=Object.prototype.toString,p=Math.max,m=Math.min,g=function(){return f.Date.now()};function b(t){var e=typeof t;return!!t&&(\"object\"==e||\"function\"==e)}function y(t){if(\"number\"==typeof t)return t;if(function(t){return\"symbol\"==typeof t||function(t){return!!t&&\"object\"==typeof t}(t)&&h.call(t)==o}(t))return i;if(b(t)){var e=\"function\"==typeof t.valueOf?t.valueOf():t;t=b(e)?e+\"\":e}if(\"string\"!=typeof t)return 0===t?t:+t;t=t.replace(r,\"\");var n=s.test(t);return n||c.test(t)?d(t.slice(2),n?2:8):a.test(t)?i:+t}t.exports=function(t,e,n){var i,o,r,a,s,c,d=0,u=!1,l=!1,f=!0;if(\"function\"!=typeof t)throw new TypeError(\"Expected a function\");function h(e){var n=i,r=o;return i=o=void 0,d=e,a=t.apply(r,n)}function v(t){var n=t-c;return void 0===c||n>=e||n<0||l&&t-d>=r}function _(){var t=g();if(v(t))return w(t);s=setTimeout(_,function(t){var n=e-(t-c);return l?m(n,r-(t-d)):n}(t))}function w(t){return s=void 0,f&&i?h(t):(i=o=void 0,a)}function j(){var t=g(),n=v(t);if(i=arguments,o=this,c=t,n){if(void 0===s)return function(t){return d=t,s=setTimeout(_,e),u?h(t):a}(c);if(l)return s=setTimeout(_,e),h(c)}return void 0===s&&(s=setTimeout(_,e)),a}return e=y(e)||0,b(n)&&(u=!!n.leading,r=(l=\"maxWait\"in n)?p(y(n.maxWait)||0,e):r,f=\"trailing\"in n?!!n.trailing:f),j.cancel=function(){void 0!==s&&clearTimeout(s),d=0,i=c=o=s=void 0},j.flush=function(){return void 0===s?a:w(g())},j}},777:t=>{var e,n,i=Math.max,o=(e=function(t,e){return function(t,e,n){if(\"function\"!=typeof t)throw new TypeError(\"Expected a function\");return setTimeout((function(){t.apply(void 0,n)}),1)}(t,0,e)},n=i(void 0===n?e.length-1:n,0),function(){for(var t=arguments,o=-1,r=i(t.length-n,0),a=Array(r);++o<r;)a[o]=t[n+o];o=-1;for(var s=Array(n+1);++o<n;)s[o]=t[o];return s[n]=a,function(t,e,n){switch(n.length){case 0:return t.call(e);case 1:return t.call(e,n[0]);case 2:return t.call(e,n[0],n[1]);case 3:return t.call(e,n[0],n[1],n[2])}return t.apply(e,n)}(e,this,s)});t.exports=o}},e={};function n(i){var o=e[i];if(void 0!==o)return o.exports;var r=e[i]={exports:{}};return t[i](r,r.exports,n),r.exports}n.n=t=>{var e=t&&t.__esModule?()=>t.default:()=>t;return n.d(e,{a:e}),e},n.d=(t,e)=>{for(var i in e)n.o(e,i)&&!n.o(t,i)&&Object.defineProperty(t,i,{enumerable:!0,get:e[i]})},n.g=function(){if(\"object\"==typeof globalThis)return globalThis;try{return this||new Function(\"return this\")()}catch(t){if(\"object\"==typeof window)return window}}(),n.o=(t,e)=>Object.prototype.hasOwnProperty.call(t,e),(()=>{\"use strict\";const t=t=>{const e=new Set;do{for(const n of Reflect.ownKeys(t))e.add([t,n])}while((t=Reflect.getPrototypeOf(t))&&t!==Object.prototype);return e};function e(e,{include:n,exclude:i}={}){const o=t=>{const e=e=>\"string\"==typeof e?t===e:e.test(t);return n?n.some(e):!i||!i.some(e)};for(const[n,i]of t(e.constructor.prototype)){if(\"constructor\"===i||!o(i))continue;const t=Reflect.getOwnPropertyDescriptor(n,i);t&&\"function\"==typeof t.value&&(e[i]=e[i].bind(e))}return e}var i=n(777),o=n.n(i),r=n(296),a=n.n(r);class s{constructor(t,n){e(this),this.interfaceId=t,this.callbackMap={},this.data={},this.pendingData={},this.jcomm=new c(\"guidance_interface_target_\"+this.interfaceId,this.updateData,\"open\"),this.debouncedSendPendingData500=a()(this.sendPendingData,500),this.debouncedSendPendingData1000=a()(this.sendPendingData,1e3),n&&o()(n)}send(t,e){this.addPendingData(t,e),this.sendPendingData()}sendEvent(t){for(const e of Object.keys(t))this.addPendingData(e,t[e]);this.sendPendingData()}debouncedSendEvent500(t){for(const e of Object.keys(t))this.addPendingData(e,t[e]);this.debouncedSendPendingData500()}debouncedSend500(t,e){this.addPendingData(t,e),this.debouncedSendPendingData500()}debouncedSend1000(t,e){this.addPendingData(t,e),this.debouncedSendPendingData1000()}addPendingData(t,e){Array.isArray(t)||(t=[t]);for(const n in t)this.pendingData[t[n]]=e}updateData(t){t=JSON.parse(t.data);for(const e in t)this.data[e]=t[e];for(const e in t)e in this.callbackMap&&this.callbackMap[e](this.data[e])}subscribe(t,e){this.callbackMap[t]=e,o()((e=>this.callbackMap[t](this.data[t])))}sendPendingData(){this.jcomm.send_data(this.pendingData),this.pendingData={}}}class c{constructor(t,e,n=\"open\"){this._fire_callback=this._fire_callback.bind(this),this._register=this._register.bind(this),this.jcomm=void 0,this.callback=e,void 0!==window.Jupyter?\"register\"===n?Jupyter.notebook.kernel.comm_manager.register_target(t,this._register):(this.jcomm=Jupyter.notebook.kernel.comm_manager.new_comm(t),this.jcomm.on_msg(this._fire_callback)):void 0!==window._mgr&&(\"register\"===n?window._mgr.widgetManager.proxyKernel.registerCommTarget(t,this._register):(this.jcomm=window._mgr.widgetManager.proxyKernel.createComm(t),this.jcomm.open({},\"\"),this.jcomm.onMsg=this._fire_callback))}send_data(t){void 0!==this.jcomm?this.jcomm.send(t):console.error(\"Jupyter comm module not yet loaded! So we can't send the message.\")}_register(t,e){this.jcomm=t,this.jcomm.on_msg(this._fire_callback)}_fire_callback(t){this.callback(t.content.data)}}class d{constructor(t,n){e(this),this.id=t,this.comm=new s(t),this.comm.subscribe(\"append\",this.appendData),this.comm.subscribe(\"replace\",this.replaceData),this.comm.subscribe(\"event\",this.eventOccurred),this.element=document.getElementById(\"guidance-content-\"+t),this.stop_button=document.getElementById(\"guidance-stop-button-\"+t),this.stop_button.onclick=()=>this.comm.send(\"event\",\"stop\")}appendData(t){t&&(this.stop_button.style.display=\"inline-block\",this.element.innerHTML+=t)}replaceData(t){t&&(this.stop_button.style.display=\"inline-block\",this.element.innerHTML=t)}eventOccurred(t){\"complete\"===t&&(this.stop_button.style.display=\"none\")}}window._guidanceDisplay=function(t,e){return new d(t,e)}})()})();; window._guidanceDisplay(\"a33e221e-9f99-417c-8a32-c52585085586\");</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import guidance\n",
+    "\n",
+    "# this relies on the environment variable GOOGLE_APPLICATION_CREDENTIALS being set or any other google default credentials location\n",
+    "llm = guidance.llms.PaLM('text-bison')\n",
+    "\n",
+    "program = guidance(\"\"\"The most liked food is: {{gen 'flavor' max_tokens=10 stop=\".\"}}\"\"\", llm=llm)\n",
+    "program()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"guidance-stop-button-27de8b5e-b999-4214-9913-0821ceec8520\" style=\"cursor: pointer; margin: 0px; display: none; float: right; padding: 3px; border-radius: 4px 4px 4px 4px; border: 0px solid rgba(127, 127, 127, 1); padding-left: 10px; padding-right: 10px; font-size: 13px; background-color: rgba(127, 127, 127, 0.25);\">Stop program</div><div id=\"guidance-content-27de8b5e-b999-4214-9913-0821ceec8520\"><pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>example</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>input</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>Ferrari</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>output</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>red</div></div></div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>example</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>input</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>Mercedes</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>output</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>silver</div></div></div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>user</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>McClaren</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>assistant</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><span style='background-color: rgba(0, 165, 0, 0.25); opacity: 1.0; display: inline;' title='{{gen &#x27;answer&#x27; max_tokens=5}}'> papaya orange</span></div></div></pre></div>\n",
+       "<script type=\"text/javascript\">(()=>{var t={296:(t,e,n)=>{var i=NaN,o=\"[object Symbol]\",r=/^\\s+|\\s+$/g,a=/^[-+]0x[0-9a-f]+$/i,s=/^0b[01]+$/i,c=/^0o[0-7]+$/i,d=parseInt,u=\"object\"==typeof n.g&&n.g&&n.g.Object===Object&&n.g,l=\"object\"==typeof self&&self&&self.Object===Object&&self,f=u||l||Function(\"return this\")(),h=Object.prototype.toString,p=Math.max,m=Math.min,g=function(){return f.Date.now()};function b(t){var e=typeof t;return!!t&&(\"object\"==e||\"function\"==e)}function y(t){if(\"number\"==typeof t)return t;if(function(t){return\"symbol\"==typeof t||function(t){return!!t&&\"object\"==typeof t}(t)&&h.call(t)==o}(t))return i;if(b(t)){var e=\"function\"==typeof t.valueOf?t.valueOf():t;t=b(e)?e+\"\":e}if(\"string\"!=typeof t)return 0===t?t:+t;t=t.replace(r,\"\");var n=s.test(t);return n||c.test(t)?d(t.slice(2),n?2:8):a.test(t)?i:+t}t.exports=function(t,e,n){var i,o,r,a,s,c,d=0,u=!1,l=!1,f=!0;if(\"function\"!=typeof t)throw new TypeError(\"Expected a function\");function h(e){var n=i,r=o;return i=o=void 0,d=e,a=t.apply(r,n)}function v(t){var n=t-c;return void 0===c||n>=e||n<0||l&&t-d>=r}function _(){var t=g();if(v(t))return w(t);s=setTimeout(_,function(t){var n=e-(t-c);return l?m(n,r-(t-d)):n}(t))}function w(t){return s=void 0,f&&i?h(t):(i=o=void 0,a)}function j(){var t=g(),n=v(t);if(i=arguments,o=this,c=t,n){if(void 0===s)return function(t){return d=t,s=setTimeout(_,e),u?h(t):a}(c);if(l)return s=setTimeout(_,e),h(c)}return void 0===s&&(s=setTimeout(_,e)),a}return e=y(e)||0,b(n)&&(u=!!n.leading,r=(l=\"maxWait\"in n)?p(y(n.maxWait)||0,e):r,f=\"trailing\"in n?!!n.trailing:f),j.cancel=function(){void 0!==s&&clearTimeout(s),d=0,i=c=o=s=void 0},j.flush=function(){return void 0===s?a:w(g())},j}},777:t=>{var e,n,i=Math.max,o=(e=function(t,e){return function(t,e,n){if(\"function\"!=typeof t)throw new TypeError(\"Expected a function\");return setTimeout((function(){t.apply(void 0,n)}),1)}(t,0,e)},n=i(void 0===n?e.length-1:n,0),function(){for(var t=arguments,o=-1,r=i(t.length-n,0),a=Array(r);++o<r;)a[o]=t[n+o];o=-1;for(var s=Array(n+1);++o<n;)s[o]=t[o];return s[n]=a,function(t,e,n){switch(n.length){case 0:return t.call(e);case 1:return t.call(e,n[0]);case 2:return t.call(e,n[0],n[1]);case 3:return t.call(e,n[0],n[1],n[2])}return t.apply(e,n)}(e,this,s)});t.exports=o}},e={};function n(i){var o=e[i];if(void 0!==o)return o.exports;var r=e[i]={exports:{}};return t[i](r,r.exports,n),r.exports}n.n=t=>{var e=t&&t.__esModule?()=>t.default:()=>t;return n.d(e,{a:e}),e},n.d=(t,e)=>{for(var i in e)n.o(e,i)&&!n.o(t,i)&&Object.defineProperty(t,i,{enumerable:!0,get:e[i]})},n.g=function(){if(\"object\"==typeof globalThis)return globalThis;try{return this||new Function(\"return this\")()}catch(t){if(\"object\"==typeof window)return window}}(),n.o=(t,e)=>Object.prototype.hasOwnProperty.call(t,e),(()=>{\"use strict\";const t=t=>{const e=new Set;do{for(const n of Reflect.ownKeys(t))e.add([t,n])}while((t=Reflect.getPrototypeOf(t))&&t!==Object.prototype);return e};function e(e,{include:n,exclude:i}={}){const o=t=>{const e=e=>\"string\"==typeof e?t===e:e.test(t);return n?n.some(e):!i||!i.some(e)};for(const[n,i]of t(e.constructor.prototype)){if(\"constructor\"===i||!o(i))continue;const t=Reflect.getOwnPropertyDescriptor(n,i);t&&\"function\"==typeof t.value&&(e[i]=e[i].bind(e))}return e}var i=n(777),o=n.n(i),r=n(296),a=n.n(r);class s{constructor(t,n){e(this),this.interfaceId=t,this.callbackMap={},this.data={},this.pendingData={},this.jcomm=new c(\"guidance_interface_target_\"+this.interfaceId,this.updateData,\"open\"),this.debouncedSendPendingData500=a()(this.sendPendingData,500),this.debouncedSendPendingData1000=a()(this.sendPendingData,1e3),n&&o()(n)}send(t,e){this.addPendingData(t,e),this.sendPendingData()}sendEvent(t){for(const e of Object.keys(t))this.addPendingData(e,t[e]);this.sendPendingData()}debouncedSendEvent500(t){for(const e of Object.keys(t))this.addPendingData(e,t[e]);this.debouncedSendPendingData500()}debouncedSend500(t,e){this.addPendingData(t,e),this.debouncedSendPendingData500()}debouncedSend1000(t,e){this.addPendingData(t,e),this.debouncedSendPendingData1000()}addPendingData(t,e){Array.isArray(t)||(t=[t]);for(const n in t)this.pendingData[t[n]]=e}updateData(t){t=JSON.parse(t.data);for(const e in t)this.data[e]=t[e];for(const e in t)e in this.callbackMap&&this.callbackMap[e](this.data[e])}subscribe(t,e){this.callbackMap[t]=e,o()((e=>this.callbackMap[t](this.data[t])))}sendPendingData(){this.jcomm.send_data(this.pendingData),this.pendingData={}}}class c{constructor(t,e,n=\"open\"){this._fire_callback=this._fire_callback.bind(this),this._register=this._register.bind(this),this.jcomm=void 0,this.callback=e,void 0!==window.Jupyter?\"register\"===n?Jupyter.notebook.kernel.comm_manager.register_target(t,this._register):(this.jcomm=Jupyter.notebook.kernel.comm_manager.new_comm(t),this.jcomm.on_msg(this._fire_callback)):void 0!==window._mgr&&(\"register\"===n?window._mgr.widgetManager.proxyKernel.registerCommTarget(t,this._register):(this.jcomm=window._mgr.widgetManager.proxyKernel.createComm(t),this.jcomm.open({},\"\"),this.jcomm.onMsg=this._fire_callback))}send_data(t){void 0!==this.jcomm?this.jcomm.send(t):console.error(\"Jupyter comm module not yet loaded! So we can't send the message.\")}_register(t,e){this.jcomm=t,this.jcomm.on_msg(this._fire_callback)}_fire_callback(t){this.callback(t.content.data)}}class d{constructor(t,n){e(this),this.id=t,this.comm=new s(t),this.comm.subscribe(\"append\",this.appendData),this.comm.subscribe(\"replace\",this.replaceData),this.comm.subscribe(\"event\",this.eventOccurred),this.element=document.getElementById(\"guidance-content-\"+t),this.stop_button=document.getElementById(\"guidance-stop-button-\"+t),this.stop_button.onclick=()=>this.comm.send(\"event\",\"stop\")}appendData(t){t&&(this.stop_button.style.display=\"inline-block\",this.element.innerHTML+=t)}replaceData(t){t&&(this.stop_button.style.display=\"inline-block\",this.element.innerHTML=t)}eventOccurred(t){\"complete\"===t&&(this.stop_button.style.display=\"none\")}}window._guidanceDisplay=function(t,e){return new d(t,e)}})()})();; window._guidanceDisplay(\"27de8b5e-b999-4214-9913-0821ceec8520\");</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import guidance\n",
+    "\n",
+    "# this relies on the environment variable GOOGLE_APPLICATION_CREDENTIALS being set or any other google default credentials location\n",
+    "llm = guidance.llms.PaLM('chat-bison')\n",
+    "\n",
+    "chat = guidance('''\n",
+    "{{~#example~}}\n",
+    "    {{~#input~}}Ferrari{{~/input~}}\n",
+    "    {{~#output~}}red{{~/output~}}\n",
+    "{{~/example~}}\n",
+    "\n",
+    "{{~#example~}}\n",
+    "    {{~#input~}}Mercedes{{~/input~}}\n",
+    "    {{~#output~}}silver{{~/output~}}\n",
+    "{{~/example~}}\n",
+    "\n",
+    "{{~#user~}}\n",
+    "McClaren\n",
+    "{{~/user~}}\n",
+    "\n",
+    "{{~#assistant~}}\n",
+    "{{gen 'answer' max_tokens=5}}\n",
+    "{{~/assistant~}}\n",
+    "''', llm=llm)\n",
+    "chat()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### rest calls\n",
+    "\n",
+    "To autenticate to the rest services you need to provide the project id and your access token. If you want to use an endpoint different from the default one, you can specify it as a string requiring the format parameters `{project_id}` and `{model}` and it will be automatically formatted from the constructor arguments or environment variables."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height: 1px; opacity: 0.5; border: none; background: #cccccc;\">\n",
+    "<div style=\"text-align: center; opacity: 0.5\">Have an idea for more helpful examples? Pull requests that add to this documentation notebook are encouraged!</div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "adatest",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "diskcache",
         "gptcache",
         "openai>=0.27.8",
+        "google-cloud-aiplatform>=1.31.1",
         "pyparsing>=3.0.0",
         "pygtrie",
         "platformdirs",

--- a/tests/library/test_each.py
+++ b/tests/library/test_each.py
@@ -1,5 +1,6 @@
 import guidance
 from ..utils import get_llm
+import pytest
 
 def test_each():
     """ Test an each loop.
@@ -63,10 +64,11 @@ def test_each_parallel_with_gen():
     for food in executed_program["foods"]:
         assert food in ["Pizza", "Burger", "Salad"]
 
-def test_each_parallel_with_gen_openai():
-    """Test an each loop run in parallel with generations inside using OpenAI."""
+@pytest.mark.parametrize("llm", ["openai:text-curie-001","palm:text-bison"])
+def test_each_parallel_with_gen_nomock(llm):
+    """Test an each loop run in parallel with generations inside using OpenAI and PaLM."""
 
-    llm = get_llm("openai:text-curie-001")
+    llm = get_llm(llm)
 
     program = guidance("""Hello, {{name}}! Here are 5 names and their favorite food:
 {{#each names parallel=True hidden=True}}{{this}}: {{gen 'foods' list_append=True}}

--- a/tests/library/test_gen.py
+++ b/tests/library/test_gen.py
@@ -89,7 +89,7 @@ def test_custom_kwargs_transformers(llm):
 
     assert not executed_program["completion"].startswith(" Repeat this.")
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_stop(llm):
     """Test that the stop argument works as expected."""
     llm = get_llm(llm)
@@ -97,7 +97,7 @@ def test_stop(llm):
     out = program()
     assert str(out) == "Write \"repeat this. \" 10 times: repeat this. repeat this. repeat this. repeat this. repeat this. repeat this. repeat "
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_stop_regex(llm):
     """Test that the stop_regex argument works as expected."""
     llm = get_llm(llm)
@@ -105,20 +105,21 @@ def test_stop_regex(llm):
     out = program()
     assert str(out) == "Write \"repeat this. \" 10 times: repeat this. repeat this. repeat this. repeat this. repeat this. repeat this. repeat "
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_save_stop_text(llm):
     llm = get_llm(llm)
     out = guidance("""Repeat this ten times: "s38 kdjksid sk slk", "s38 kdjksid sk slk", "s38 kdjksid sk slk", "s38 kdjksid sk slk", "{{gen 'text' stop_regex="kdj.*slk" max_tokens=10 save_stop_text=True}}""", llm=llm)()
     assert out["text_stop_text"] == "kdjksid sk slk"
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_stop_regex_cut_short(llm):
     """Test that the stop_regex argument works as expected even when max_tokens cuts it short."""
     llm = get_llm(llm)
-    out = guidance("""Repeat this ten times: "s38 kdjksid", "s38 kdjksid", "s38 kdjksid", "s38 kdjksid", "{{gen 'text' stop_regex="s38 kdjksid" max_tokens=5 save_stop_text=True}}""", llm=llm)()
+    # bison blocks garbage prompts
+    out = guidance("""Repeat this ten times: "mary had a little lamb", "mary had a little lamb", "mary had a little lamb", "mary had a little lamb", "{{gen 'text' stop_regex="mary had a little lamb" max_tokens=3 save_stop_text=True}}""", llm=llm)()
     assert len(out["text"]) > 0 # make sure we got some output (it is not a stop string until it is a full match)
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_gen_stream(llm):
     """Test that streaming the generation works."""
 

--- a/tests/llms/test_palm.py
+++ b/tests/llms/test_palm.py
@@ -1,0 +1,179 @@
+import guidance
+from ..utils import get_llm
+import pytest
+
+def test_context_palm():
+    """
+    Test the context role opposed or combined with the system role
+    """
+    guidance.llm = get_llm("palm:chat-bison")
+
+    chat = guidance('''
+{{~#context~}}You are a helpful assistant{{~/context~}}
+{{~#user~}}Hi, how are you?{{~/user~}}
+{{~#assistant~}}Fine.{{~/assistant~}}
+''')
+    out = chat()
+    assert str(out)=="<|im_start|>context\nYou are a helpful assistant<|im_end|><|im_start|>user\nHi, how are you?<|im_end|><|im_start|>assistant\nFine.<|im_end|>"
+
+ 
+@pytest.mark.parametrize("rest_call",[True, False])
+def test_examples_palm(rest_call):
+    guidance.llm = get_llm("palm:chat-bison",rest_call=rest_call)
+    chat = guidance('''
+{{~#context~}}
+You always feel the same
+{{~/context~}}
+{{~#example~}}
+    {{~#input~}}
+Hi, how are you?
+    {{~/input~}}
+    {{~#output~}}
+{{feeling}}
+    {{~/output~}}
+{{~/example~}}
+{{~#user~}}
+Hi, how are you?
+{{~/user~}}
+{{~#assistant~}}
+{{gen 'answer' max_tokens=5 temperature=0}}
+{{~/assistant~}}
+''')
+    feeling = "I'm alright"
+    out=chat(feeling=feeling)
+    assert out["answer"].strip().startswith(feeling)
+
+    feeling = "I'm fine"
+    out=chat(feeling=feeling)
+    assert out["answer"].strip().startswith(feeling)
+
+def test_examples_palm_32k():
+    guidance.llm = get_llm("palm:chat-bison-32k",rest_call=True)
+    chat = guidance('''
+{{~#context~}}
+You always feel the same
+{{~/context~}}
+{{~#example~}}
+    {{~#input~}}
+Hi, how are you?
+    {{~/input~}}
+    {{~#output~}}
+{{feeling}}
+    {{~/output~}}
+{{~/example~}}
+{{~#user~}}
+Hi, how are you?
+{{~/user~}}
+{{~#assistant~}}
+{{gen 'answer' max_tokens=5 temperature=0}}
+{{~/assistant~}}
+''')
+    feeling = "I'm alright"
+    out=chat(feeling=feeling)
+    assert out["answer"].strip().startswith(feeling)
+
+    feeling = "I'm fine"
+    out=chat(feeling=feeling)
+    assert out["answer"].strip().startswith(feeling)
+
+def test_geneach_palm():
+    """ Test a geneach loop with ChatGPT.
+    """
+    guidance.llm = get_llm("palm:chat-bison")
+
+    chat_loop = guidance('''
+{{#system~}}
+You are a helpful assistant
+{{~/system}}
+
+{{~#geneach 'conversation' stop=False}}
+{{#user~}}
+This is great!
+{{~/user}}
+
+{{#assistant~}}
+{{gen 'this.response' temperature=0 max_tokens=3}}
+{{~/assistant}}
+{{#if @index > 0}}{{break}}{{/if}}
+{{~/geneach}}''')
+
+    out = chat_loop()
+    assert len(out["conversation"]) == 2
+
+def test_syntax_match():
+    """ Test a geneach loop with ChatGPT.
+    """
+    guidance.llm = get_llm("palm:chat-bison")
+
+    chat_loop = guidance('''
+{{~#system~}}
+You are a helpful assistant
+{{~/system~}}
+
+{{~#user~}}
+This is great!
+{{~/user~}}
+
+{{~#assistant~}}
+Indeed
+{{~/assistant~}}''')
+
+    out = chat_loop()
+    assert str(out) == '<|im_start|>system\nYou are a helpful assistant<|im_end|><|im_start|>user\nThis is great!<|im_end|><|im_start|>assistant\nIndeed<|im_end|>'
+
+def test_nostream():
+    guidance.llm = get_llm('palm:text-bison')
+    a = guidance('''What's your name? {{gen 'name' stream=False max_tokens=5}}''', stream=False)
+    a = a()
+    assert len(a['name']) > 0
+
+def test_rest_nostream():
+    guidance.llm = get_llm('palm:text-bison', rest_call=True)
+    a = guidance('''What's your name? {{gen 'name' stream=False max_tokens=5}}''', stream=False)
+    a = a()
+    assert len(a['name']) > 0
+
+def test_rest_stream():
+    import asyncio
+    loop = asyncio.new_event_loop()
+
+    async def f():
+        guidance.llm = get_llm('palm:text-bison', rest_call=True)
+        a = guidance('''What's your {{question}}? tell me the first chapter of the odissey {{gen 'name' stream=True max_tokens=50}}''')
+        a = await a(question="name")
+        assert len(a['name']) > 0
+    loop.run_until_complete(f())
+
+def test_rest_stream_chat():
+    import asyncio
+    loop = asyncio.new_event_loop()
+
+    async def f():
+        guidance.llm = get_llm('palm:chat-bison', rest_call=True)
+        chat = guidance('''
+{{~#user~}}
+tell me the first chapter of the {{book}}
+{{~/user~}}
+{{~#assistant~}}
+{{gen 'answer' max_tokens=50 temperature=0 stream=True}}
+{{~/assistant~}}
+''')
+        chat = await chat(book="odissey") 
+        print(chat)
+        assert len(chat['answer']) > 0
+    loop.run_until_complete(f())
+
+def test_rest_chat_nostream():
+    guidance.llm =get_llm("palm:chat-bison", rest_call=True)
+    prompt = guidance(
+'''{{~#system~}}
+You are a helpful assistant
+{{~/system~}}
+{{#user~}}
+{{conversation_question}}
+{{~/user}}
+{{#assistant~}}
+{{gen "answer" max_tokens=5 stream=False}}
+{{~/assistant}}''')
+    prompt = prompt(conversation_question='Whats is the meaning of life??')
+    assert len(prompt['answer']) > 0

--- a/tests/llms/test_transformers.py
+++ b/tests/llms/test_transformers.py
@@ -7,7 +7,6 @@ def test_basic(llm):
     llm = get_llm(llm)
     with llm.session() as s:
         out = s("this is a test", max_tokens=5)
-        print(out)
 
 def test_basic_object_init():
     import transformers
@@ -16,7 +15,6 @@ def test_basic_object_init():
     llm = guidance.llms.Transformers(model, tokenizer)
     with llm.session() as s:
         out = s("this is a test", max_tokens=5)
-        print(out)
 
 @pytest.mark.parametrize("llm", ["transformers:gpt2", "transformers:facebook/opt-350m"])
 def test_repeat(llm):
@@ -24,7 +22,6 @@ def test_repeat(llm):
     with llm.session() as s:
         out1 = s("this is a test", max_tokens=5)
         out2 = s("this is a test like another", max_tokens=5)
-        print(out2)
 
 @pytest.mark.parametrize("llm", ["transformers:gpt2", "transformers:facebook/opt-350m"])
 def test_select(llm):

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -2,14 +2,15 @@ import guidance
 import pytest
 from .utils import get_llm
 
-def test_chat_stream():
-    """ Test the behavior of `stream=True` for an openai chat endpoint.
+@pytest.mark.parametrize("model",["openai:gpt-3.5-turbo", "palm:chat-bison"])
+def test_chat_stream(model):
+    """ Test the behavior of `stream=True` for chat endpoints.
     """
 
     import asyncio
     loop = asyncio.new_event_loop()
 
-    guidance.llm = get_llm("openai:gpt-3.5-turbo")
+    guidance.llm = get_llm(model)
 
     async def f():
         chat = guidance("""<|im_start|>system
@@ -24,14 +25,15 @@ You are a helpful assistent.
         assert len(out["answer"]) > 0
     loop.run_until_complete(f())
 
-def test_chat_display():
-    """ Test the behavior of `stream=True` for an openai chat endpoint.
+@pytest.mark.parametrize("model",["openai:gpt-3.5-turbo", "palm:chat-bison"])
+def test_chat_display(model):
+    """ Test the behavior of `stream=True` for a chat endpoint.
     """
 
     import asyncio
     loop = asyncio.new_event_loop()
 
-    guidance.llm = get_llm("openai:gpt-3.5-turbo")
+    guidance.llm = get_llm(model)
 
     async def f():
         chat = guidance("""<|im_start|>system
@@ -46,10 +48,11 @@ You are a helpful assistent.
         assert len(out["answer"]) > 0
     loop.run_until_complete(f())
 
-def test_agents():
+@pytest.mark.parametrize("model",["openai:gpt-3.5-turbo", "palm:chat-bison"])
+def test_agents(model):
     """Test agents, calling prompt twice"""
 
-    guidance.llm = get_llm("openai:gpt-3.5-turbo")
+    guidance.llm = get_llm(model)
 
     prompt = guidance('''<|im_start|>system
 You are a helpful assistant.<|im_end|>
@@ -57,13 +60,13 @@ You are a helpful assistant.<|im_end|>
 <|im_start|>user
 {{set 'this.user_text' (await 'user_text')}}<|im_end|>
 <|im_start|>assistant
-{{gen 'this.ai_text' n=1 temperature=0 max_tokens=900}}<|im_end|>{{/geneach}}''', echo=True)
+{{gen 'this.ai_text' n=1 temperature=0 max_tokens=5}}<|im_end|>{{/geneach}}''', echo=True)
     prompt = prompt(user_text='Hi there')
     assert len(prompt['conversation']) == 2
     prompt = prompt(user_text='Please help')
     assert len(prompt['conversation']) == 3
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_stream_loop(llm):
     llm = get_llm(llm)
     program = guidance("""Generate a list of 5 company names:
@@ -78,7 +81,7 @@ def test_stream_loop(llm):
     assert len(partials[0]) < 5
     assert len(partials[-1]) == 5
 
-@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
+@pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001","palm:text-bison"])
 def test_stream_loop_async(llm):
     """ Test the behavior of `stream=True` for an openai chat endpoint.
     """
@@ -112,8 +115,8 @@ def test_logging_off():
     executed_program = program(flag=True)
     assert executed_program.log is False
 
-
-def test_async_mode_exceptions():
+@pytest.mark.parametrize("model",["openai:gpt-3.5-turbo", "palm:chat-bison"])
+def test_async_mode_exceptions(model):
     """
     Ensures that exceptions in async_mode=True don't hang the program and are
     re-raised back to the caller.
@@ -121,7 +124,7 @@ def test_async_mode_exceptions():
     import asyncio
     loop = asyncio.new_event_loop()
 
-    guidance.llm = get_llm("openai:gpt-3.5-turbo")
+    guidance.llm = get_llm(model)
 
     async def call_async():
         program = guidance("""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
 import guidance
 import pytest
+import vertexai.language_models as palm
 
 opanai_model_cache = {}
+palm_model_cache = {}
 
 def get_llm(model_name, caching=False, **kwargs):
     """ Get an LLM by name.
@@ -10,6 +12,27 @@ def get_llm(model_name, caching=False, **kwargs):
         return get_openai_llm(model_name[7:], caching, **kwargs)
     elif model_name.startswith("transformers:"):
         return get_transformers_llm(model_name[13:], caching, **kwargs)
+    elif model_name.startswith("palm:"):
+        return get_palm_llm(model_name[5:], caching, **kwargs)
+    
+def get_palm_llm(model_name, caching=False, **kwargs):
+    """ Get a Palm LLM with model reuse.
+    """
+    # we cache the models so lots of tests using the same model don't have to
+    # load it over and over again
+    key = model_name+"_"+str(caching)
+    if key not in palm_model_cache:
+        if not kwargs.get("rest_call",False):
+            try:
+                dummy_call = palm.ChatModel.from_pretrained("chat-bison")
+            except:
+                pytest.skip("Google credentials not found")
+        palm_model_cache[key] = guidance.llms.PaLM(model_name, caching=caching, **kwargs)
+    llm = palm_model_cache[key]
+    if llm.rest_call and (llm.api_key is None or llm.project_id is None):
+        pytest.skip("PaLM token/project_id not found")
+
+    return llm
 
 def get_openai_llm(model_name, caching=False, **kwargs):
     """ Get an OpenAI LLM with model reuse and smart test skipping.


### PR DESCRIPTION
Hi,

I added PaLM models to the available LLMs in guidance. A quick overview can be found in the dedicated notebook in the llm folder.

#### New features:
- "context" alias for the system role
- "example" role containing input and output blocks to provide demonstration examples, including notebook formatting of examples
- support for library (through VertexAI SDK) and rest calls to google's text genertion and chat models with or without streaming

#### Issues:
- the select tool requires tokenization of the prompt. However, to the best of my knowledge, there is not an equivalent to `tiktoken` providing google's models tokenizers. This could still be done by a billable rest call to their tokenization API, but I would like to get community feedback to decide whether to implement this feature or if there are other workarounds.

#### Tests:
- I tried to replicate all tests done on OpenAI models on PaLM, with the exception of the select tool.

Please let me know what you think!
