### PR TITLE
Allow _gen() can switch AI Model rather than default LLM

### DIFF
--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -7,9 +7,18 @@ from .._utils import escape_template_block, AsyncIter
 
 log = logging.getLogger(__name__)
 
+def load_alt_model(model_name):
+    from guidance import llms
+    if model_name.startswith("gpt-"):
+        return llms.OpenAI(model_name, caching=False).session(asynchronous=True)
+        llms.OpenAI.cache.clear()
+    else:
+        return llms.Transformers(model_name, device='cpu', caching=False).session(asynchronous=True)
+        llms.Transformers.cache.clear()
+
 async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_tokens=500, n=1, stream=None,
               temperature=0.0, top_p=1.0, logprobs=None, pattern=None, hidden=False, list_append=False,
-              save_prompt=False, token_healing=None, function_call="none", _parser_context=None, **llm_kwargs):
+              save_prompt=False, token_healing=None, function_call="none", llm_alt_model=None, _parser_context=None, **llm_kwargs):
     ''' Use the LLM to generate a completion.
 
     Parameters
@@ -135,6 +144,13 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
         logprobs = parser.program.logprobs
 
     assert parser.llm_session is not None, "You must set an LLM for the program to use (use the `llm=` parameter) before you can use the `gen` command."
+
+    # Replace LLM Session with Alternated LLM Model Session
+    if llm_alt_model is not None:
+        if isinstance(llm_alt_model, str):
+            parser.llm_session = load_alt_model(llm_alt_model)
+        else:
+            parser.llm_session = llm_alt_model
 
     # call the LLM
     gen_obj = await parser.llm_session(


### PR DESCRIPTION
Usage:
Method 1:
use directly model_name in param llm_alt_model
example with OpenAI model:
```
{{gen 'bot_reply' temperature=0.7 llm_alt_model="gpt-3.5-turbo"}}
```
example with Huggingface Transformer model:
```
{{gen 'bot_reply' temperature=0.7 llm_alt_model="daryl149/llama-2-7b-chat-hf"}}
```
Method 2:
use through custom model loader
1. add a method to load custom model
```
def load_alt_model_custom(model):

    if model == "gpt-3.5":
        return guidance.llms.OpenAI("gpt-3.5-turbo", caching=False).session(asynchronous=True)
        guidance.llms.OpenAI.cache.clear()
    elif model == "gpt-3.5-16k":
        return guidance.llms.OpenAI("gpt-3.5-turbo-16k-0613", caching=False).session(asynchronous=True)
        guidance.llms.OpenAI.cache.clear()
    elif model == "gpt-4":
        return guidance.llms.OpenAI("gpt-4", caching=False).session(asynchronous=True)
        guidance.llms.OpenAI.cache.clear()
    elif model == "llama-7b":
        return guidance.llms.Transformers("Trelis/Llama-2-7b-chat-hf-function-calling-v2", device='cpu', caching=False).session(asynchronous=True)
        guidance.llms.Transformers.cache.clear()
    elif model == "llama-7b-function":
        return guidance.llms.Transformers("Trelis/Llama-2-7b-chat-hf-function-calling-v2", device='cpu', caching=False).session(asynchronous=True)
        guidance.llms.Transformers.cache.clear()
    else:
        return guidance.llms.OpenAI("gpt-3.5-turbo-16k-0613", caching=False).session(asynchronous=True)
        guidance.llms.OpenAI.cache.clear()
```
2. change guidance program define, add method below as guidance program variable
```
output = program(load_alt_model_custom=load_alt_model_custom, silent=True, stream=False)
```
3. change {{ gen }} function to call load_alt_model_custom
```
{{gen 'bot_reply' temperature=0.7 llm_alt_model=load_alt_model_custom("llama-7b")}}
```