### PR TITLE
Add save_finish_reason gen argument

### DIFF
--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -7,7 +7,7 @@ from .._utils import escape_template_block, AsyncIter
 
 log = logging.getLogger(__name__)
 
-async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_tokens=500, n=1, stream=None,
+async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, save_finish_reason=False, max_tokens=500, n=1, stream=None,
               temperature=0.0, top_p=1.0, logprobs=None, pattern=None, hidden=False, list_append=False,
               save_prompt=False, token_healing=None, function_call="none", _parser_context=None, **llm_kwargs):
     ''' Use the LLM to generate a completion.
@@ -26,6 +26,10 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
         If set to a string, the exact stop text used will be saved in a variable with the given name. If set to
         True, the stop text will be saved in a variable named `name+"_stop_text"`. If set to False,
         the stop text will not be saved.
+    save_finish_reason : str or bool
+        If set to a string, the exact finish_reason text used will be saved in a variable with the given name. If set to
+        True, the finish_reason text will be saved in a variable named `name+"_finish_reason"`. If set to False,
+        the finish_reason text will not be saved.
     max_tokens : int
         The maximum number of tokens to generate in this completion.
     n : int
@@ -185,6 +189,12 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
             if save_stop_text is True:
                 save_stop_text = name+"_stop_text"
             variable_stack[save_stop_text] = resp["choices"][0].get('stop_text', None)
+
+        # save the finish_reason if requested
+        if save_finish_reason is not False:
+            if save_finish_reason is True:
+                save_finish_reason = name+"_finish_reason"
+            variable_stack[save_finish_reason] = resp["choices"][0].get('finish_reason', None)
         
         if hasattr(gen_obj, 'close'):
             gen_obj.close()

--- a/tests/library/test_gen.py
+++ b/tests/library/test_gen.py
@@ -111,6 +111,33 @@ def test_save_stop_text(llm):
     out = guidance("""Repeat this ten times: "s38 kdjksid sk slk", "s38 kdjksid sk slk", "s38 kdjksid sk slk", "s38 kdjksid sk slk", "{{gen 'text' stop_regex="kdj.*slk" max_tokens=10 save_stop_text=True}}""", llm=llm)()
     assert out["text_stop_text"] == "kdjksid sk slk"
 
+@pytest.mark.parametrize("llm", ["openai:gpt-35-turbo"])
+def test_save_finish_reason(llm):
+    program = guidance("""
+{{#user~}}
+Repeat this 3 times: "abc"
+{{~/user}}
+
+{{#assistant~}}
+{{gen 'name' temperature=0 max_tokens=1 save_finish_reason=True}}.
+{{~/assistant}}
+""", llm=get_llm(llm, api_type="azure", api_version="2023-05-15", chat_mode="True"))
+
+    prompt = program()
+    assert prompt['name_finish_reason'] == "length"
+
+    program = guidance("""
+{{#user~}}
+Repeat this 3 times: "def"
+{{~/user}}
+
+{{#assistant~}}
+{{gen 'name' temperature=0 max_tokens=100 save_finish_reason=True}}.
+{{~/assistant}}
+""", llm=get_llm(llm, api_type="azure", api_version="2023-05-15", chat_mode="True"))
+    prompt = program()
+    assert prompt['name_finish_reason'] == "stop"
+
 @pytest.mark.parametrize("llm", ["transformers:gpt2", "openai:text-curie-001"])
 def test_stop_regex_cut_short(llm):
     """Test that the stop_regex argument works as expected even when max_tokens cuts it short."""


### PR DESCRIPTION
At the moment, there is no easy way to identify the [finish_reason](https://platform.openai.com/docs/guides/gpt/chat-completions-api) when using ChatGPT call.
This adds the `save_finish_reason` argument to the `gen` template function which gives clients access to `finish_reason` in the calling code.
