### PR TITLE
fix: variable_stack[list_name] may be an object instead of list

### DIFF
--- a/guidance/library/_geneach.py
+++ b/guidance/library/_geneach.py
@@ -203,7 +203,10 @@ async def geneach(list_name, stop=None, max_iterations=100, min_iterations=0, nu
                     next_item = d
 
                 # update the list variable (we do this each time we get a new item so that streaming works)
-                variable_stack[list_name] = variable_stack.get(list_name, []) + [next_item]
+                if isinstance(variable_stack.get(list_name, []), list):
+                    variable_stack[list_name] = variable_stack.get(list_name, []) + [next_item]
+                else:
+                    variable_stack[list_name] = [variable_stack.get(list_name, [])] + [next_item]
 
                 # recreate the output string with format markers added
                 item_out = re.sub(


### PR DESCRIPTION
Using the geneach example in the README may encounter a bug, that is, variable_stack[list_name] may not be a list but an object, then, it can't add to a list, which will cause the error in _geneach.py:129