### PR TITLE
add new OpenAI client

### DIFF
--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -166,11 +166,11 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
                 #log("Stopping generation")
                 break
             # log.debug("resp", resp)
-            new_text = resp["choices"][0].get("text", "")
+            new_text = resp.choices[0].text or ""
             generated_value += new_text
             variable_stack["@raw_prefix"] += new_text
             if logprobs is not None:
-                logprobs_out.extend(resp["choices"][0]["logprobs"]["top_logprobs"])
+                logprobs_out.extend(resp.choices[0].logprobs["top_logprobs"])
             if list_append:
                 variable_stack[name][list_ind] = generated_value
                 if logprobs is not None:
@@ -184,7 +184,7 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
         if save_stop_text is not False:
             if save_stop_text is True:
                 save_stop_text = name+"_stop_text"
-            variable_stack[save_stop_text] = resp["choices"][0].get('stop_text', None)
+            variable_stack[save_stop_text] = resp.choices[0].get('stop_text', None)
         
         if hasattr(gen_obj, 'close'):
             gen_obj.close()
@@ -207,17 +207,17 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
         return
     else:
         assert not isinstance(gen_obj, list), "Streaming is only supported for n=1"
-        generated_values = [prefix+choice["text"]+suffix for choice in gen_obj["choices"]]
+        generated_values = [prefix+choice["text"]+suffix for choice in gen_obj.choices]
         if list_append:
             value_list = variable_stack.get(name, [])
             value_list.append(generated_values)
             if logprobs is not None:
                 logprobs_list = variable_stack.get(name+"_logprobs", [])
-                logprobs_list.append([choice["logprobs"]["top_logprobs"] for choice in gen_obj["choices"]])
+                logprobs_list.append([choice.logprobs["top_logprobs"] for choice in gen_obj.choices])
         elif name is not None:
             variable_stack[name] = generated_values
             if logprobs is not None:
-                variable_stack[name+"_logprobs"] = [choice["logprobs"]["top_logprobs"] for choice in gen_obj["choices"]]
+                variable_stack[name+"_logprobs"] = [choice.logprobs["top_logprobs"] for choice in gen_obj.choices]
 
         if not hidden:
             # TODO: we could enable the parsing to branch into multiple paths here, but for now we just complete the program with the first prefix

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "diskcache",
         "gptcache",
-        "openai>=0.27.8",
+        "openai>=1.0.0",
         "pyparsing>=3.0.0",
         "pygtrie",
         "platformdirs",


### PR DESCRIPTION
Fixes:
- Exchanges the deprecated global client for the new AsyncOpenAI. 
- The objects returned by the new clients are not directly subscriptable so the dot notation is implements. This probably has quite an impact on all other models, so advice on how to proceed is requested. 

Currently I have only tested this using a small example:
```

import guidance
# set Openai API key
api_key = "sk-"

model = guidance.llms.OpenAI("gpt-3.5-turbo", chat_mode=True, api_key=api_key, caching=False)
# vicuna = guidance.llms.transformers.Vicuna("your_path/vicuna_13B", device_map="auto")
example = guidance('''
{{#system~}}
You are a knowledgeable and efficient assistant.
{{~/system}}

{{#user~}}
Please analyze the following question:
{{query}}
Identify the exact topic and user intent in one sentence.
{{~/user}}

{{#assistant~}}
{{gen 'topic_intent' temperature=0 max_tokens=50}}
{{~/assistant}}
''', llm=model)

output = example(query="What is the capital of the Netherlands?")

print(output['topic_intent'])
```

Any additional examples on how to test streaming functionality is highly appreciated. 