### PR TITLE
Use model config vocab size

### DIFF
--- a/guidance/endpoints/_transformers.py
+++ b/guidance/endpoints/_transformers.py
@@ -75,7 +75,7 @@ class Transformers(LLM):
         """ Build a map from token to index.
         """
         token_map = pygtrie.CharTrie()
-        for i in range(self.tokenizer.vocab_size):
+        for i in range(self.model.config.vocab_size):
             s = self.id_to_token(i)
             if s in token_map:
                 token_map[s].append(i) # handle duplicate token encodings... (GPT2 BPE has this oddly enough)

--- a/guidance/models/_remote.py
+++ b/guidance/models/_remote.py
@@ -55,7 +55,7 @@ class Remote(Local):
         # a transformer tokenizer was given that has a byte_decoder
         elif hasattr(tokenizer, "byte_decoder"):
             byte_tokens = []
-            for i in range(tokenizer.vocab_size):
+            for i in range(model.config.vocab_size):
                 byte_coded = bytes([tokenizer.byte_decoder[c] for c in tokenizer.convert_ids_to_tokens(i)])
                 byte_tokens.append(byte_coded)
             bos_token_id = tokenizer.bos_token_id
@@ -63,7 +63,7 @@ class Remote(Local):
         
         # a transformer tokenizer was given with byte_decoder
         elif hasattr(tokenizer, "convert_ids_to_tokens"):
-            byte_tokens = [bytes(tokenizer.convert_tokens_to_string(['a', tokenizer.convert_ids_to_tokens(i)])[1:], encoding="utf8") for i in range(tokenizer.vocab_size)]
+            byte_tokens = [bytes(tokenizer.convert_tokens_to_string(['a', tokenizer.convert_ids_to_tokens(i)])[1:], encoding="utf8") for i in range(model.config.vocab_size)]
             bos_token_id = tokenizer.bos_token_id
             eos_token_id = tokenizer.eos_token_id
 

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -42,11 +42,11 @@ class Transformers(Local):
         tkz = self._orig_tokenizer
         if hasattr(tkz, "byte_decoder"):
             byte_tokens = []
-            for i in range(tkz.vocab_size):
+            for i in range(model.config.vocab_size):
                 byte_coded = bytes([tkz.byte_decoder[c] for c in tkz.convert_ids_to_tokens(i)])
                 byte_tokens.append(byte_coded)
         else:
-            byte_tokens = [bytes(tkz.convert_tokens_to_string(['a', tkz.convert_ids_to_tokens(i)])[1:], encoding="utf8") for i in range(tkz.vocab_size)]
+            byte_tokens = [bytes(tkz.convert_tokens_to_string(['a', tkz.convert_ids_to_tokens(i)])[1:], encoding="utf8") for i in range(model.config.vocab_size)]
 
         # the superclass does most of the work once we have the tokens
         super().__init__(


### PR DESCRIPTION
The transformers tokenizer `vocab_size` property does not include added tokens. This PR uses the model config vocab size instead which should reflect the true vocab size. The alternative is to call `len` on the tokenizer.