### PR TITLE
fix: access exceptions at the top level

### DIFF
--- a/guidance/endpoints/_openai.py
+++ b/guidance/endpoints/_openai.py
@@ -702,28 +702,3 @@ class MSALOpenAI(OpenAI):
                 f.write(self._token_cache.serialize())
 
         return result["access_token"]
-
-
-
-
-openai.api_key
-openai.organization
-openai.api_type
-openai.api_version
-openai.api_base
-openai.api_key = self.api_key
-openai.organization = self.organization
-openai.api_type = self.api_type
-openai.api_version = self.api_version
-openai.api_base = self.api_base
-openai.api_key is not None, "You must provide an OpenAI API key to use the OpenAI LLM. Either pass it in the constructor, set the OPENAI_API_KEY environment variable, or create the file ~/.openai_api_key with your key in it."
-openai.ChatCompletion.acreate(**kwargs)
-openai.Completion.acreate(**kwargs)
-openai.api_key = prev_key
-openai.organization = prev_org
-openai.api_type = prev_type
-openai.api_version = prev_version
-openai.api_base = prev_base
-openai.RateLimitError, openai.ServiceUnavailableError):
-OpenAI.html")
-openai.token")

--- a/guidance/endpoints/_openai.py
+++ b/guidance/endpoints/_openai.py
@@ -600,7 +600,7 @@ class OpenAISession(LLMSession):
                         call_args["logit_bias"] = {str(k): v for k,v in logit_bias.items()} # convert keys to strings since that's the open ai api's format
                     out = await self.llm.caller(**call_args)
 
-                except (openai.error.RateLimitError, openai.error.ServiceUnavailableError):
+                except (openai.RateLimitError, openai.ServiceUnavailableError):
                     await asyncio.sleep(3)
                     try_again = True
                     fail_count += 1

--- a/guidance/endpoints/_openai.py
+++ b/guidance/endpoints/_openai.py
@@ -269,10 +269,10 @@ class OpenAI(LLM):
             del kwargs['echo']
             del kwargs['logprobs']
             # print(kwargs)
-            out = await openai.ChatCompletion.acreate(**kwargs)
+            out = await openai.chat.completions.acreate(**kwargs)
             out = add_text_to_chat_mode(out)
         else:
-            out = await openai.Completion.acreate(**kwargs)
+            out = await openai.completions.acreate(**kwargs)
         
         # restore the params of the openai library
         openai.api_key = prev_key
@@ -702,3 +702,28 @@ class MSALOpenAI(OpenAI):
                 f.write(self._token_cache.serialize())
 
         return result["access_token"]
+
+
+
+
+openai.api_key
+openai.organization
+openai.api_type
+openai.api_version
+openai.api_base
+openai.api_key = self.api_key
+openai.organization = self.organization
+openai.api_type = self.api_type
+openai.api_version = self.api_version
+openai.api_base = self.api_base
+openai.api_key is not None, "You must provide an OpenAI API key to use the OpenAI LLM. Either pass it in the constructor, set the OPENAI_API_KEY environment variable, or create the file ~/.openai_api_key with your key in it."
+openai.ChatCompletion.acreate(**kwargs)
+openai.Completion.acreate(**kwargs)
+openai.api_key = prev_key
+openai.organization = prev_org
+openai.api_type = prev_type
+openai.api_version = prev_version
+openai.api_base = prev_base
+openai.RateLimitError, openai.ServiceUnavailableError):
+OpenAI.html")
+openai.token")


### PR DESCRIPTION
Stemming from Issue: [#446](https://github.com/guidance-ai/guidance/issues/446)

Summary: 
The OpenAI python client changed a lot in the latest version, this applies some of the migration strategies from this [discussion](https://github.com/openai/openai-python/discussions/742). Fresh installations of Guidance, using the latest version of openai's python library, don't appear to work. This PR should unblock that, but it's not a 100% migration.
