### PR TITLE
Remove scipy dependency

### DIFF
--- a/guidance/models/_local.py
+++ b/guidance/models/_local.py
@@ -1,7 +1,7 @@
 import scipy.special
 import scipy.stats
 import numpy as np
-from .._utils import ByteTrie
+from .._utils import ByteTrie, log_softmax, softmax
 from ._model import Model
 from .._parser import EarleyCommitParser
 from .._grammar import Terminal
@@ -259,7 +259,7 @@ class Local(Model):
                 # if requested we compute the log probabilities so we can track the probabilities of each node
                 # TODO: we should lower this step to C++ with pybind11
                 if log_probs:
-                    _compute_log_probs(trie, scipy.special.log_softmax(logits, dim=-1))
+                    _compute_log_probs(trie, log_softmax(logits, axis=-1))
 
                 # get the sampling order
                 grammar_temp = parser.next_byte_temperature()
@@ -268,7 +268,7 @@ class Local(Model):
                     sampling_order = np.argsort(-logits) # we need numpy so the enumerate below does not get really slow...
                 else:
                     assert top_p == 1, "Still need to add support for top_p!"
-                    probs = scipy.special.softmax(logits / current_temp, axis=-1)
+                    probs = softmax(logits / current_temp, axis=-1)
                     probs += 1e-10 # ensure we have no zero probs that mess up numpy
                     probs /= np.sum(probs)
                     sampling_order = np.random.choice(len(probs), size=len(probs), p=probs, replace=False) # the 1e-10 is ensure we have no zero probs, which numpy does not like

--- a/guidance/models/_local.py
+++ b/guidance/models/_local.py
@@ -1,5 +1,3 @@
-import scipy.special
-import scipy.stats
 import numpy as np
 from .._utils import ByteTrie, log_softmax, softmax
 from ._model import Model

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         "msal",
         "requests",
         "numpy",
-        "scipy",
         "aiohttp",
         "ordered_set",
         "pyformlang"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,18 +24,14 @@ def atol() -> float:
     ],
 )
 class TestLogitsTransforms:
-    def test_log_softmax(
-        self, size_and_axis: Tuple[Tuple[int] | Tuple[int, int], int], atol: float
-    ):
+    def test_log_softmax(self, size_and_axis, atol: float):
         size, axis = size_and_axis
         logits: np.ndarray = -np.random.uniform(low=0, high=60, size=size)
         log_probs = _utils.log_softmax(logits, axis=axis)
         log_probs_correct = torch.tensor(logits).log_softmax(dim=axis).numpy()
         assert np.allclose(log_probs, log_probs_correct, atol=atol)
 
-    def test_softmax(
-        self, size_and_axis: Tuple[Tuple[int] | Tuple[int, int], int], atol: float
-    ):
+    def test_softmax(self, size_and_axis, atol: float):
         size, axis = size_and_axis
         logits: np.ndarray = -np.random.uniform(low=0, high=60, size=size)
         probs = _utils.softmax(logits, axis=axis)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,43 @@
+"""
+Unit tests guidance._utils
+"""
+from typing import Tuple
+
+import numpy as np
+import pytest
+import torch
+
+from guidance import _utils
+
+
+@pytest.fixture(scope="module")
+def atol() -> float:
+    return 1e-6
+
+
+@pytest.mark.parametrize(
+    "size_and_axis",
+    [
+        ((32_000,), -1),  # very next token logits
+        ((10, 32_000), -1),  # many token's next-token logits
+        ((4, 10, 32_000), -1),  # batch of texts
+    ],
+)
+class TestLogitsTransforms:
+    def test_log_softmax(
+        self, size_and_axis: Tuple[Tuple[int] | Tuple[int, int], int], atol: float
+    ):
+        size, axis = size_and_axis
+        logits: np.ndarray = -np.random.uniform(low=0, high=60, size=size)
+        log_probs = _utils.log_softmax(logits, axis=axis)
+        log_probs_correct = torch.tensor(logits).log_softmax(dim=axis).numpy()
+        assert np.allclose(log_probs, log_probs_correct, atol=atol)
+
+    def test_softmax(
+        self, size_and_axis: Tuple[Tuple[int] | Tuple[int, int], int], atol: float
+    ):
+        size, axis = size_and_axis
+        logits: np.ndarray = -np.random.uniform(low=0, high=60, size=size)
+        probs = _utils.softmax(logits, axis=axis)
+        probs_correct = torch.tensor(logits).softmax(dim=axis).numpy()
+        assert np.allclose(probs, probs_correct, atol=atol)


### PR DESCRIPTION
`scipy` is a slightly hefty dependency at 37.2 MB. It's only used for `softmax` and `log_softmax`, which can be implemented in numpy

The implementations are almost copy-pasted from [scipy](https://github.com/scipy/scipy/blob/v1.11.4/scipy/special/_logsumexp.py), so they are equally efficient:

```python
# ipython
import numpy as np
import scipy.special
from guidance._utils import log_softmax, softmax

size = (10, 32_000)
logits: np.ndarray = -np.random.uniform(low=0, high=60, size=size)

%timeit log_softmax(logits, axis=-1)
%timeit scipy.special.log_softmax(logits, axis=-1)

%timeit softmax(logits, axis=-1)
%timeit scipy.special.softmax(logits, axis=-1)

```