### PR TITLE
reduce memory requirements (and probably improve speed) for llama.cpp tests

### DIFF
--- a/tests/models/test_llama_cpp.py
+++ b/tests/models/test_llama_cpp.py
@@ -47,27 +47,39 @@ def test_subtoken_forced():
     lm = llama2 + 'How much is 2 + 2? ' + gen(name='test', max_tokens=10, regex=r'\(')
     assert str(lm) == "How much is 2 + 2? ("
 
+def test_llama_cpp_almost_one_batch():
+    lm = get_model("llama_cpp:", n_batch=248)
+    long_str = lm.bos_token.decode("utf-8") * 247
+    lm += long_str + gen(max_tokens=10)
+    assert len(str(lm)) > len(long_str)
+
 def test_llama_cpp_exactly_one_batch():
-    lm = get_model("llama_cpp:", n_batch=9)
-    long_str = lm.bos_token.decode("utf-8") * 9
+    lm = get_model("llama_cpp:", n_batch=248)
+    long_str = lm.bos_token.decode("utf-8") * 248
+    lm += long_str + gen(max_tokens=10)
+    assert len(str(lm)) > len(long_str)
+
+def test_llama_cpp_more_than_one_batch():
+    lm = get_model("llama_cpp:", n_batch=248)
+    long_str = lm.bos_token.decode("utf-8") * 249
     lm += long_str + gen(max_tokens=10)
     assert len(str(lm)) > len(long_str)
 
 def test_llama_cpp_almost_two_batches():
-    lm = get_model("llama_cpp:", n_batch=8)
-    long_str = lm.bos_token.decode("utf-8") * 15
+    lm = get_model("llama_cpp:", n_batch=248)
+    long_str = lm.bos_token.decode("utf-8") * 495
     lm += long_str + gen(max_tokens=10)
     assert len(str(lm)) > len(long_str)
 
 def test_llama_cpp_two_batches():
-    lm = get_model("llama_cpp:", n_batch=7)
-    long_str = lm.bos_token.decode("utf-8") * 14
+    lm = get_model("llama_cpp:", n_batch=248)
+    long_str = lm.bos_token.decode("utf-8") * 496
     lm += long_str + gen(max_tokens=10)
     assert len(str(lm)) > len(long_str)
 
 def test_llama_cpp_more_than_two_batches():
-    lm = get_model("llama_cpp:", n_batch=6)
-    long_str = lm.bos_token.decode("utf-8") * 13
+    lm = get_model("llama_cpp:", n_batch=248)
+    long_str = lm.bos_token.decode("utf-8") * 497
     lm += long_str + gen(max_tokens=10)
     assert len(str(lm)) > len(long_str)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,6 +45,7 @@ def get_transformers_model(model_name, caching=False, **kwargs):
     return transformers_model_cache[key]
 
 llama_cpp_model_cache = {}
+llama_cpp_defaults = {'n_batch': 248}
 
 def get_llama_cpp_model(model_name, caching=False, **kwargs):
     """ Get a llama.cpp LLM with model reuse.
@@ -54,6 +55,11 @@ def get_llama_cpp_model(model_name, caching=False, **kwargs):
         model_name = os.environ.get("LLAMA_CPP_MODEL", "")
         if len(model_name.strip()) == 0:
             pytest.skip("No llama_cpp model found.")
+
+    kwargs = kwargs.copy()
+    for key, val in llama_cpp_defaults.items():
+        if key not in kwargs:
+            kwargs[key] = val
 
     # we cache the models so lots of tests using the same model don't have to
     # load it over and over again


### PR DESCRIPTION
reduce memory requirements (and probably improve speed) for llama.cpp tests by using a single cached model for all tests