### PR TITLE
Drop unused `nest_asyncio`

### DIFF
--- a/guidance/__init__.py
+++ b/guidance/__init__.py
@@ -4,11 +4,10 @@ import functools
 import os
 import sys
 import types
-from contextlib import nullcontext
 
 import requests
 
-from . import _utils, models, selectors
+from . import models, selectors
 from ._grammar import (Placeholder, StatefulFunction, StatelessFunction,
                        Terminal, replace_grammar_node, string)
 from ._utils import (CaptureEvents, TextRange, chain, load,
@@ -26,15 +25,6 @@ class Guidance(types.ModuleType):
     def __call__(self, f=None, *, stateless=False, cache=None, dedent=True, model=models.Model):
         return _decorator(f, stateless=stateless, cache=cache, dedent=dedent, model=model)
 sys.modules[__name__].__class__ = Guidance
-
-# def optional_hidden(f, lm, hidden, kwargs):
-#     """This only enters a hidden context if the function does not manage the hidden parameter itself.
-#     """
-#     if 'hidden' in inspect.signature(f).parameters:
-#         kwargs['hidden'] = hidden
-#         return nullcontext()
-#     else:
-#         return Hidden(lm, hidden)
     
 _function_cache = {} # used to enable recursive grammar definitions
 _null_grammar = string('')

--- a/guidance/__init__.py
+++ b/guidance/__init__.py
@@ -1,21 +1,18 @@
 __version__ = "0.1.7"
 
-import nest_asyncio
-nest_asyncio.apply()
-import types
-import sys
-import os
-import requests
-from . import models
-import inspect
-
-from ._utils import load, chain, CaptureEvents, TextRange, strip_multiline_string_indents
-from . import _utils
-from . import selectors
-
-from ._grammar import StatelessFunction, StatefulFunction, string, Terminal, Placeholder, replace_grammar_node
 import functools
+import os
+import sys
+import types
 from contextlib import nullcontext
+
+import requests
+
+from . import _utils, models, selectors
+from ._grammar import (Placeholder, StatefulFunction, StatelessFunction,
+                       Terminal, replace_grammar_node, string)
+from ._utils import (CaptureEvents, TextRange, chain, load,
+                     strip_multiline_string_indents)
 
 curr_module = sys.modules[__name__]
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "openai>=1.0",
         "platformdirs",
         "tiktoken>=0.3",
-        "nest_asyncio",
         "msal",
         "requests",
         "numpy",


### PR DESCRIPTION
`nest_asyncio` is not used anymore so we can remove this dependency.