### PR TITLE
Adding streaming support under guidance v0.1

### DIFF
--- a/guidance/__init__.py
+++ b/guidance/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 
 import functools
 import os

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -418,6 +418,7 @@ class Join(StatelessFunction):
     __slots__ = ("nullable", "values", "name", "hidden", "commit_point", "capture_name", "max_tokens")
 
     def __init__(self, values, name=None, max_tokens=100000000) -> None:
+        values = [string(v) if isinstance(v, (str, bytes)) else v for v in values] # wrap raw strings
         self.nullable = all(v.nullable for v in values)
         self.values = [v for v in values if not isinstance(v, Null)]
         self.name = name if name is not None else StatelessFunction._new_name()

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -447,7 +447,7 @@ class EarleyCommitParser:
                 # if we are at a capture group node then we save the matched bytes range
                 # note that we record this after calling our children so that we save the outermost version of self-recursive calls
                 cname = item.node.capture_name
-                if cname is not None and cname not in used_names:
+                if cname is not None and cname not in used_names and not item.node.hidden:
                     
                     # see if we are doing a list append
                     if cname.startswith("__LIST_APPEND:"):

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -1,3 +1,4 @@
+from sys import stderr
 import numpy as np
 from ordered_set import OrderedSet
 from ._grammar import Join, Select, Terminal, Null, Byte, ByteRange
@@ -378,14 +379,92 @@ class EarleyCommitParser:
     
     def parse_tree(self):
         reversed_state_sets = self._reversed_state_sets()
+        root_item = None
 
         # find the matching root state
         for item in reversed_state_sets[0]:
             if item.node == self.grammar and item.start == len(self.bytes) and item.pos == len(item.values): # note that ".start" mean end because items are reversed
                 root_item = item
+        if root_item is None:
+            return None
         self._compute_parse_tree(0, root_item, reversed_state_sets)
         return root_item
-    
+
+    def get_captures(self):
+        root_node = self.parse_tree()
+        data = {}
+        log_prob_data = {}
+        if root_node is not None:
+            # parse complete, so we can get the captures
+            self._record_captures_from_root(root_node, data, log_prob_data)
+            return data, log_prob_data
+        # compute on partially parsed tree
+        self._record_captures_partial(data, log_prob_data)
+        return data, log_prob_data
+
+    def _record_captures_partial(self, data, log_prob_data):
+        byte_data = self.bytes
+
+        for item in self.state_sets[self.state_set_pos]:
+            cname = item.node.capture_name
+            if cname is None:
+                continue
+            captured_value = byte_data[item.start:self.earliest_hidden_start()]
+            if captured_value.endswith(b'<'):
+                print("WARNING: Captured value ends with '<' which is a special character in the parser!", file=stderr)
+            data[cname] = captured_value
+            log_prob_data[cname] = item.log_prob
+
+    def _record_captures_from_root(self, initial_item, data, log_prob_data):
+        byte_data = self.bytes
+        stack = [(initial_item, 0)]
+        used_names = set() # track which capture names have been used so self-recursive children don't overwrite their parents
+        
+        while stack:
+            item, byte_pos = stack.pop()
+            # terminal nodes
+            if isinstance(item, Terminal):
+
+                # if we are at a capture group node then we save the matched terminal byte
+                if item.capture_name is not None:
+                    data[item.capture_name] = item.byte
+                    log_prob_data[item.capture_name] = 0
+            
+            # internal nodes
+            else:
+                start_byte_pos = byte_pos
+
+                # recurse for all our non-null children
+                for child in item.children:
+                    if child is not None:
+                        stack.append((child, byte_pos))
+                        # _record_captures(child, data, log_prob_data, byte_data, byte_pos)
+                        if isinstance(child, Terminal):
+                            byte_pos += len(child)
+                        else:
+                            byte_pos = child.start # note that "start" means "end" since this is a reversed state set
+
+                # if we are at a capture group node then we save the matched bytes range
+                # note that we record this after calling our children so that we save the outermost version of self-recursive calls
+                cname = item.node.capture_name
+                if cname is not None and cname not in used_names:
+                    
+                    # see if we are doing a list append
+                    if cname.startswith("__LIST_APPEND:"):
+                        cname = cname[14:] # trim off the list append tag
+                        if cname not in data or not isinstance(data[cname], list):
+                            data[cname] = []
+                            log_prob_data[cname] = []
+                        data[cname].append(byte_data[start_byte_pos:item.start])
+                        log_prob_data[cname].append(item.log_prob)
+                    
+                    # or just a regular assignment
+                    else:
+                        data[cname] = byte_data[start_byte_pos:item.start] # note that "start" means "end" since this is a reversed state set
+                        log_prob_data[cname] = item.log_prob
+
+                    used_names.add(cname)    
+
     def _compute_parse_tree(self, initial_pos, initial_item, reversed_state_sets):
         stack = [(initial_pos, initial_item)]
         

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -940,9 +940,7 @@ class Model:
                 #     self._cache_state["new_token_ids"].append(sampled_token_ind)
 
                 # capture the named groups from the parse tree
-                parse_tree = parser.parse_tree()
-                _record_captures(parse_tree, captured_data, captured_log_prob_data, parser.bytes)
-                
+                captured_data, captured_log_prob_data = parser.get_captures()
                 # we have no valid log prob data if we didn't compute it
                 yield new_bytes[hidden_count:], is_generated, new_bytes_prob, captured_data, captured_log_prob_data, token_count - last_token_count
                 last_token_count = token_count
@@ -953,7 +951,9 @@ class Model:
                 # yeild the snippet of text created by the next token
                 out = new_bytes[hidden_count:]
                 if len(out) > 0:
-                    yield out, is_generated, new_bytes_prob, {}, {}, token_count - last_token_count # note that we don't capture groups until a complete parse right now...
+                    # capture the named groups from the (partial) parse tree, 
+                    captured_data, captured_log_prob_data = parser.get_captures()
+                    yield out, is_generated, new_bytes_prob, captured_data, captured_log_prob_data, token_count - last_token_count # note that we don't capture groups until a complete parse right now...
                     last_token_count = token_count
                     hidden_count = 0
                     token_count += 1 # note we only update this for tokens that emit non-hidden content

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -971,10 +971,10 @@ class Model:
                 # yeild the snippet of text created by the next token
                 out = new_bytes[hidden_count:]
                 if len(out) > 0:
-                    # capture the named groups from the (partial) parse tree, 
-                    new_captured_data, new_captured_log_prob_data = parser.get_captures()
-                    captured_data.update(new_captured_data)
-                    captured_log_prob_data.update(new_captured_log_prob_data)
+                    # capture the named groups from the (partial) parse tree, # TODO: disabled for now until we handle list_append correctly
+                    # new_captured_data, new_captured_log_prob_data = parser.get_captures()
+                    # captured_data.update(new_captured_data)
+                    # captured_log_prob_data.update(new_captured_log_prob_data)
                     yield out, is_generated, new_bytes_prob, captured_data, captured_log_prob_data, token_count - last_token_count # note that we don't capture groups until a complete parse right now...
                     last_token_count = token_count
                     hidden_count = 0

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1035,55 +1035,6 @@ def throttle_refresh():
 class ConstraintException(Exception):
     pass
 
-def _record_captures(initial_item, data, log_prob_data, byte_data):
-    stack = [(initial_item, 0)]
-    used_names = set() # track which capture names have been used so self-recursive children don't overwrite their parents
-    
-    while stack:
-        item, byte_pos = stack.pop()
-        # terminal nodes
-        if isinstance(item, Terminal):
-
-            # if we are at a capture group node then we save the matched terminal byte
-            if item.capture_name is not None:
-                data[item.capture_name] = item.byte
-                log_prob_data[item.capture_name] = 0
-        
-        # internal nodes
-        else:
-            start_byte_pos = byte_pos
-
-            # recurse for all our non-null children
-            for child in item.children:
-                if child is not None:
-                    stack.append((child, byte_pos))
-                    # _record_captures(child, data, log_prob_data, byte_data, byte_pos)
-                    if isinstance(child, Terminal):
-                        byte_pos += len(child)
-                    else:
-                        byte_pos = child.start # note that "start" means "end" since this is a reversed state set
-
-            # if we are at a capture group node then we save the matched bytes range
-            # note that we record this after calling our children so that we save the outermost version of self-recursive calls
-            cname = item.node.capture_name
-            if cname is not None and cname not in used_names and not item.node.hidden:
-                
-                # see if we are doing a list append
-                if cname.startswith("__LIST_APPEND:"):
-                    cname = cname[14:] # trim off the list append tag
-                    if cname not in data or not isinstance(data[cname], list):
-                        data[cname] = []
-                        log_prob_data[cname] = []
-                    data[cname].append(byte_data[start_byte_pos:item.start])
-                    log_prob_data[cname].append(item.log_prob)
-                
-                # or just a regular assignment
-                else:
-                    data[cname] = byte_data[start_byte_pos:item.start] # note that "start" means "end" since this is a reversed state set
-                    log_prob_data[cname] = item.log_prob
-
-                used_names.add(cname)    
-
 # def _compute_probs(trie, probs, found):
 #     '''Computes the log probabilities for each internal trie node.'''
 #     if trie.value is not None:

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -957,7 +957,10 @@ class Model:
                 #     self._cache_state["new_token_ids"].append(sampled_token_ind)
 
                 # capture the named groups from the parse tree
-                captured_data, captured_log_prob_data = parser.get_captures()
+                new_captured_data, new_captured_log_prob_data = parser.get_captures()
+                captured_data.update(new_captured_data)
+                captured_log_prob_data.update(new_captured_log_prob_data)
+
                 # we have no valid log prob data if we didn't compute it
                 yield new_bytes[hidden_count:], is_generated, new_bytes_prob, captured_data, captured_log_prob_data, token_count - last_token_count
                 last_token_count = token_count
@@ -969,7 +972,9 @@ class Model:
                 out = new_bytes[hidden_count:]
                 if len(out) > 0:
                     # capture the named groups from the (partial) parse tree, 
-                    captured_data, captured_log_prob_data = parser.get_captures()
+                    new_captured_data, new_captured_log_prob_data = parser.get_captures()
+                    captured_data.update(new_captured_data)
+                    captured_log_prob_data.update(new_captured_log_prob_data)
                     yield out, is_generated, new_bytes_prob, captured_data, captured_log_prob_data, token_count - last_token_count # note that we don't capture groups until a complete parse right now...
                     last_token_count = token_count
                     hidden_count = 0

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -299,10 +299,12 @@ class Model:
             
             # run stateless functions (grammar nodes)
             elif isinstance(value, StatelessFunction):
+                value._event_parent = lm
                 out = lm._run_stateless(value)
             
             # run stateful functions
             else:
+                value._event_parent = lm
                 out = value(lm)
                 if out is None:
                     raise Exception(f"A guidance function did not return a model object! Did you forget to return the new lm at the end of your function?")

--- a/notebooks/tutorials/intro_to_guidance.ipynb
+++ b/notebooks/tutorials/intro_to_guidance.ipynb
@@ -582,6 +582,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Streaming\n",
+    "\n",
+    "Often you want to get the results of a generation as it is happening so you update an interface. You can do this programmatically using the `.stream()` method of model objects. This creates a `ModelStream` that you can use to accumulate updates. These updates don't get executed until you interate over then `ModelStream` object. When you iterate over the object you get lots of partially completed model objects as the guidance program is executed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for part in llama2.stream() + qa_bot(query):\n",
+    "    part # do something with the partially executed lm"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
Streaming updates of variables is crucial for my application yet not supported after the v0.1 update. I found the key is about capturing over the syntax tree and have implemented that in a very naive manner. As the result, we can use `CaptureEvents` to receives the latest `Model` reference every time a token is generated. 

Here is how I use it in my application. Basically, I consume the `event_queue` of a model running in a separate thread and turn it into an iterator. 

```python
LMFunc = Callable[[Model], Model]

def get_vars_recursively(lm: Model) -> Dict[str, str]:
    vars = lm._variables
    if not lm._event_parent:
        return vars
    return {**get_vars_recursively(lm._event_parent), **vars}

def iter_guidance_vars(
    lm: Model, lm_func: LMFunc, timeout_secs=5
) -> Generator[Dict[str, str], None, None]:
    with CaptureEvents(lm) as events:
        worker_thread = threading.Thread(target=lambda: lm_func(lm))
        worker_thread.start()
        first_come_timeout = time.time() + timeout_secs
        while time.time() < first_come_timeout:
            if not events.empty():
                break
        while True:
            if not worker_thread.is_alive():
                for lm_res in events.queue:
                    yield get_vars_recursively(lm_res)
                return
            if not events.empty():
                yield get_vars_recursively(events.get())
```

I am not sure whether it breaks any other in other aspects. Look forward to your feedbacks and suggestions for any improvements or concerns regarding potential impacts.