### PR TITLE
Fix GPU usage by removing `device` from `Transformers` class wrapper to use the device/device_map directly exposed by HF Transformers in kwargs

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -13,7 +13,7 @@ from .._model import Model, Chat
 
 
 class Transformers(Model):
-    def __init__(self, model=None, tokenizer=None, echo=True, caching=True, temperature=0.0, compute_log_probs=False, device=None, **kwargs):
+    def __init__(self, model=None, tokenizer=None, echo=True, caching=True, temperature=0.0, compute_log_probs=False, **kwargs):
         '''Build a new Transformers model object that represents a model in a given state.'''
 
         # fill in default model value
@@ -34,8 +34,6 @@ class Transformers(Model):
         # self.current_time = time.time()
         # self.call_history = collections.deque()
         self.temperature = temperature
-        if device is not None: # set the device if requested
-            self.model_obj = self.model_obj.to(device)
         self.device = self.model_obj.device # otherwise note the current device
 
         # build out the set of byte_string tokens


### PR DESCRIPTION
# The issue

Using the `device` parameter already provided by the `Transformers` wrapper doesn't work as intended. It first loads the model (by default on CPU) and then pushes the model to the `device` later. This is inefficient and hasn't been working at all on my end.

Example code snippet for the above:
```Python
from guidance import models

# This is confusing since the user can think this is given directly to the wrapped HF transformers class
gpt = models.Transformers('gpt2', device='cuda') 
```

# The fix

Removing the `device` parameter altogether fixes this and removes the confusion of having a `device` parameter that isn't actually directly being used by HF Transformers but only by the wrapper itself.

Also, it doesn't affect anything else since there is a `self.device = self.model_obj.device` that gets the device from the model directly. Also, the tests seem to pass.

It is now only necessary to use `device_map` from HF Transformers directly through `kwargs` and the model is loaded correctly.

Example code snippet for the above:
```Python
from guidance import models

gpt = models.Transformers('gpt2', device_map='auto') # `auto` or any other device map
```