### PR TITLE
WIP: fix: AzureOpenAI authentication to support API Key auth

### DIFF
--- a/guidance/models/_azure_openai.py
+++ b/guidance/models/_azure_openai.py
@@ -27,6 +27,7 @@ class AzureOpenAI(Remote):
         self,
         model: str,
         azure_endpoint: str,
+        azure_deployment: str,
         azure_ad_token_provider=None,
         api_key: str = None,
         tokenizer=None,
@@ -76,6 +77,7 @@ class AzureOpenAI(Remote):
                 azure_endpoint=azure_endpoint,
                 api_key=api_key,
                 azure_ad_token_provider=azure_ad_token_provider,
+                azure_deployment=azure_deployment,
                 tokenizer=tokenizer,
                 echo=echo,
                 caching=caching,
@@ -100,6 +102,7 @@ class AzureOpenAI(Remote):
             api_key=api_key,
             azure_ad_token_provider=azure_ad_token_provider,
             api_version=api_version,
+            azure_deployment=azure_deployment
         )
         self.model_name = model
         self.top_p = top_p


### PR DESCRIPTION
Based on the [notebook](https://github.com/guidance-ai/guidance/blob/main/notebooks/api_examples/models/AzureOpenAI.ipynb) and the [AzureOpenAI class code](https://github.com/guidance-ai/guidance/blob/f0c215728d1839781fd0b357fae5c82ffdbd6593/guidance/models/_azure_openai.py#L25), authentication with `API Key authentication` is not supported.

The `azure_deployment` field is required to differentiate between the `model` and its Azure deployment, which is crucial when multiple deployments of the same model exist, or when the deployment is not named after the model..


```python
from guidance import models, gen
import tiktoken

azureai_model = models.AzureOpenAI(
    model='gpt-3.5-turbo',
    azure_endpoint=azure_endpoint,
    azure_deployment='my_crazy_deployment_name',
    api_key=api_key,
)
```