### PR TITLE
JSON Schema and Pydantic Grammars

### DIFF
--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 from ._grammar import Byte, GrammarFunction, Join, Select, select
 from .library._char_range import char_range
@@ -110,9 +110,22 @@ def _get_definition(reference: str, definitions: Dict[str, any]) -> Dict[str, an
     return definitions[target_name]
 
 
+def _process_anyOf(
+    options: List[Dict[str, any]], definitions: Dict[str, any]
+) -> GrammarFunction:
+    all_opts = []
+    for opt in options:
+        all_opts.append(_process_node(opt, definitions))
+    return select(options=all_opts)
+
+
 def _process_node(
     node: Dict[str, any], definitions: Union[Dict[str, any], None]
 ) -> GrammarFunction:
+    ANYOF_STRING = "anyOf"
+    if ANYOF_STRING in node:
+        return _process_anyOf(node[ANYOF_STRING], definitions)
+
     REF_STRING = "$ref"
     if REF_STRING in node:
         node = _get_definition(node[REF_STRING], definitions)

--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -113,6 +113,10 @@ def _get_definition(reference: str, definitions: Dict[str, any]) -> Dict[str, an
 def _process_node(
     node: Dict[str, any], definitions: Union[Dict[str, any], None]
 ) -> GrammarFunction:
+    REF_STRING = "$ref"
+    if REF_STRING in node:
+        node = _get_definition(node[REF_STRING], definitions)
+
     if node["type"] == "null":
         # Not completely sure about this
         return Select(["null"])
@@ -132,7 +136,7 @@ def _process_node(
             if item_node["type"] == "object":
                 item_node["properties"] = node["items"]["properties"]
         else:
-            item_node = _get_definition(node["items"]["$ref"], definitions)
+            item_node = _get_definition(node["items"][REF_STRING], definitions)
         return _process_array(item_node, definitions)
     else:
         raise ValueError(f"Unsupported type in schema: {node['type']}")

--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -142,8 +142,7 @@ def _process_node(
         raise ValueError(f"Unsupported type in schema: {node['type']}")
 
 
-def json_schema_to_grammar(schema: str) -> GrammarFunction:
-    schema_obj = json.loads(schema)
+def _json_schema_obj_to_grammar(schema_obj: Dict[str, any]) -> GrammarFunction:
 
     _DEFS_KEY = "$defs"
 
@@ -153,3 +152,9 @@ def json_schema_to_grammar(schema: str) -> GrammarFunction:
         del schema_obj[_DEFS_KEY]
 
     return _process_node(schema_obj, definitions)
+
+
+def json_schema_to_grammar(schema: str) -> GrammarFunction:
+    schema_obj = json.loads(schema)
+
+    return _json_schema_obj_to_grammar(schema_obj)

--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -156,7 +156,6 @@ def _process_node(
 
 
 def _json_schema_obj_to_grammar(schema_obj: Dict[str, any]) -> GrammarFunction:
-
     _DEFS_KEY = "$defs"
 
     definitions = None

--- a/guidance/_pydantic_to_grammar.py
+++ b/guidance/_pydantic_to_grammar.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+import pydantic
+
+from ._grammar import GrammarFunction
+from ._json_schema_to_grammar import _json_schema_obj_to_grammar
+
+
+def pydantic_model_to_grammar(
+    model: Union[type, pydantic.BaseModel]
+) -> GrammarFunction:
+    # Rather than 'type' I think it should be pydantic._internal._model_construction.ModelMetaclass
+    json_schema = model.model_json_schema()
+
+    return _json_schema_obj_to_grammar(json_schema)

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -353,7 +353,7 @@ def test_simple_ref(target_obj):
     # First sanity check what we're setting up
     schema_obj = json.loads(schema)
     validate(instance=target_obj, schema=schema_obj)
-    
+
     grammar = json_schema_to_grammar(schema)
 
     target_string = to_compact_json(target_obj)

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -353,6 +353,11 @@ def test_simple_ref(target_obj):
     # First sanity check what we're setting up
     schema_obj = json.loads(schema)
     validate(instance=target_obj, schema=schema_obj)
+    
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(schema_obj)
+    check_string_with_grammar(target_string, grammar)
 
 
 def test_with_mock_model():

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -419,6 +419,30 @@ def test_nested_ref():
     check_string_with_grammar(target_string, grammar)
 
 
+@pytest.mark.parametrize("target_obj", [123, True])
+def test_anyOf_simple(target_obj):
+    schema = """{
+    "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "boolean"
+                }
+            ]
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+
 def test_with_mock_model():
     schema = """{
     "type": "object",

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -356,7 +356,7 @@ def test_simple_ref(target_obj):
     
     grammar = json_schema_to_grammar(schema)
 
-    target_string = to_compact_json(schema_obj)
+    target_string = to_compact_json(target_obj)
     check_string_with_grammar(target_string, grammar)
 
 

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -309,6 +309,52 @@ def test_null():
     check_string_with_grammar(target_string, grammar)
 
 
+@pytest.mark.parametrize(
+    "target_obj",
+    [
+        dict(all_cats=[]),
+        dict(all_cats=[dict(name="Kasha")]),
+        dict(all_cats=[dict(name="Dawon"), dict(name="Barong")]),
+    ],
+)
+def test_simple_ref(target_obj):
+    schema = """{
+  "$defs": {
+    "Cat": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Cat",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "all_cats": {
+      "items": {
+        "$ref": "#/$defs/Cat"
+      },
+      "title": "All Cats",
+      "type": "array"
+    }
+  },
+  "required": [
+    "all_cats"
+  ],
+  "title": "CatList",
+  "type": "object"
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+
 def test_with_mock_model():
     schema = """{
     "type": "object",

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -360,6 +360,65 @@ def test_simple_ref(target_obj):
     check_string_with_grammar(target_string, grammar)
 
 
+def test_nested_ref():
+    schema = """{
+  "$defs": {
+    "A": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "A",
+      "type": "object"
+    },
+    "B": {
+      "properties": {
+        "other_str": {
+          "title": "Other Str",
+          "type": "string"
+        },
+        "my_A": {
+          "$ref": "#/$defs/A"
+        }
+      },
+      "required": [
+        "other_str",
+        "my_A"
+      ],
+      "title": "B",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "my_B": {
+      "$ref": "#/$defs/B"
+    }
+  },
+  "required": [
+    "my_B"
+  ],
+  "title": "C",
+  "type": "object"
+}
+    """
+
+    target_obj = dict(my_B=dict(other_str="some string", my_A=dict(name="my name")))
+
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+
 def test_with_mock_model():
     schema = """{
     "type": "object",

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -436,7 +436,66 @@ def test_anyOf_simple(target_obj):
     schema_obj = json.loads(schema)
     validate(instance=target_obj, schema=schema_obj)
 
-    
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+
+@pytest.mark.parametrize(
+    "target_obj",
+    [
+        dict(my_val=dict(my_int=1)),
+        dict(my_val=dict(my_str="Some long string or other")),
+    ],
+)
+def test_anyOf_objects(target_obj):
+    schema = """{
+  "$defs": {
+    "A": {
+      "properties": {
+        "my_str": {
+          "default": "me",
+          "title": "My Str",
+          "type": "string"
+        }
+      },
+      "title": "A",
+      "type": "object"
+    },
+    "B": {
+      "properties": {
+        "my_int": {
+          "default": 1,
+          "title": "My Int",
+          "type": "integer"
+        }
+      },
+      "title": "B",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "my_val": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/A"
+        },
+        {
+          "$ref": "#/$defs/B"
+        }
+      ],
+      "title": "My Val"
+    }
+  },
+  "title": "C",
+  "type": "object"
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
     grammar = json_schema_to_grammar(schema)
 
     target_string = to_compact_json(target_obj)

--- a/tests/test_pydantic_to_grammar.py
+++ b/tests/test_pydantic_to_grammar.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import List, Union
 
 import pydantic
+import pytest
 
 from guidance._grammar import GrammarFunction
 from guidance._pydantic_to_grammar import pydantic_model_to_grammar
@@ -47,5 +48,23 @@ def test_nested_model():
         my_B: B = pydantic.Field(default_factory=B)
 
     my_obj = C(my_str="some other string!")
+    grammar = pydantic_model_to_grammar(my_obj)
+    check_object_with_grammar(my_obj, grammar)
+
+
+@pytest.mark.parametrize("has_A", [True, False])
+def test_model_with_optional(has_A):
+    class A(pydantic.BaseModel):
+        my_str: str = pydantic.Field(default="my_a_str")
+
+    class B(pydantic.BaseModel):
+        b_str: str = pydantic.Field(default="Some string")
+        my_A: Union[A, None] = pydantic.Field(default=None)
+
+    if has_A:
+        my_obj = B(my_A=A(my_str="a long string or two"))
+    else:
+        my_obj = B(b_str="A long b string")
+
     grammar = pydantic_model_to_grammar(my_obj)
     check_object_with_grammar(my_obj, grammar)

--- a/tests/test_pydantic_to_grammar.py
+++ b/tests/test_pydantic_to_grammar.py
@@ -1,14 +1,19 @@
+from typing import List
+
 import pydantic
 
 from guidance._grammar import GrammarFunction
 from guidance._pydantic_to_grammar import pydantic_model_to_grammar
 
 
-def check_object_with_grammar(target_object: pydantic.BaseModel, grammar: GrammarFunction):
+def check_object_with_grammar(
+    target_object: pydantic.BaseModel, grammar: GrammarFunction
+):
     print(f"Checking {target_object}")
     json_string = target_object.model_dump_json()
     matches = grammar.match(json_string.encode(), raise_exceptions=True)
     assert matches.partial == False
+
 
 def test_simple_model():
     class Simple(pydantic.BaseModel):
@@ -20,4 +25,27 @@ def test_simple_model():
     check_object_with_grammar(my_obj, grammar)
 
 
+def test_model_with_int_list():
+    class MyModel(pydantic.BaseModel):
+        my_list: List[int] = pydantic.Field(default_factory=list)
 
+    my_obj = MyModel(my_list=[1, 2, 3, 4])
+    grammar = pydantic_model_to_grammar(my_obj)
+    check_object_with_grammar(my_obj, grammar)
+
+
+def test_nested_model():
+    class A(pydantic.BaseModel):
+        my_str: str = pydantic.Field(default="my_a_str")
+
+    class B(pydantic.BaseModel):
+        my_str: str = pydantic.Field(default="my_b_str")
+        my_A: A = pydantic.Field(default_factory=A)
+
+    class C(pydantic.BaseModel):
+        my_str: str = pydantic.Field(default="my_c_str")
+        my_B: B = pydantic.Field(default_factory=B)
+
+    my_obj = C(my_str="some other string!")
+    grammar = pydantic_model_to_grammar(my_obj)
+    check_object_with_grammar(my_obj, grammar)

--- a/tests/test_pydantic_to_grammar.py
+++ b/tests/test_pydantic_to_grammar.py
@@ -1,0 +1,23 @@
+import pydantic
+
+from guidance._grammar import GrammarFunction
+from guidance._pydantic_to_grammar import pydantic_model_to_grammar
+
+
+def check_object_with_grammar(target_object: pydantic.BaseModel, grammar: GrammarFunction):
+    print(f"Checking {target_object}")
+    json_string = target_object.model_dump_json()
+    matches = grammar.match(json_string.encode(), raise_exceptions=True)
+    assert matches.partial == False
+
+def test_simple_model():
+    class Simple(pydantic.BaseModel):
+        my_string: str
+
+    my_obj = Simple(my_string="some string")
+
+    grammar = pydantic_model_to_grammar(my_obj)
+    check_object_with_grammar(my_obj, grammar)
+
+
+


### PR DESCRIPTION
Extend the existing support for converting JSON schema to grammars, and add use it to support conversion of Pydantic models to grammars:

- Add `$ref` and `$def` to the JSON schema support
- Add `anyOf` to the JSON schema support
- Use the `model_json_schema()` method from Pydantic to create a `pydantic_model_to_grammar()` function

There are 'happy path' tests of all of these features. I have also added some more negative tests of basic JSON schema