### PR TITLE
Support multiple additions to ModelStream

### DIFF
--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1188,8 +1188,11 @@ class ModelStream:
 
     def __add__(self, grammar):
         '''Extend this delayed chain of execution with another grammar append.'''
-        return ModelStream(self.model, grammar)
-    
+        if self.grammar is None:
+            return ModelStream(self.model, grammar)
+        else:
+            return ModelStream(self.model, self.grammar + grammar)
+
     def _inner_run(self, model):
         '''This runs the model stream without iterating, and is only using internally by __iter__.'''
         if isinstance(self.grammar, ModelStream):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -45,3 +45,11 @@ def test_token_healing():
     gpt2 = get_model("transformers:gpt2")
     lm = gpt2 + ("This is a story of 10 or 5 or " + zero_or_more(byte_range(b'0', b'9')))
     assert len(lm) > len("This is a story of 10 or 5 or ")
+
+def test_stream_add_multiple():
+    '''Test to make sure multiple additions to a ModelStream are all respected'''
+    lm = get_model("transformers:gpt2").stream()
+    lm += select(["item1", "item2"])
+    lm += ''
+    *_, last_lm = lm
+    assert str(last_lm) in ["item1", "item2"]


### PR DESCRIPTION
Currently when using the streaming feature, multiple successive additions to the ModelStream object will overwrite each other. This change adds the grammars together instead to preserve each addition.

For example, consider the following code:

```python
import guidance
import guidance.models
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig


def main():
    model_id = "HuggingFaceH4/zephyr-7b-beta"
    quantization_config = BitsAndBytesConfig(
        load_in_4bit=True,
        bnb_4bit_compute_dtype=torch.bfloat16,
        bnb_4bit_use_double_quant=True,
    )
    tokenizer = AutoTokenizer.from_pretrained(model_id)
    model = AutoModelForCausalLM.from_pretrained(
        model_id, quantization_config=quantization_config
    )

    prompt = "Who was the first president of the United States? It was "

    print("Without streaming, but with multiple additions:")
    lm1 = guidance.models.Transformers(model=model, tokenizer=tokenizer)
    lm1 += prompt
    lm1 += guidance.gen(max_tokens=3)
    print(str(lm1))

    print("\nWith streaming and single addition:")
    lm2 = guidance.models.Transformers(model=model, tokenizer=tokenizer).stream()
    lm2 += prompt + guidance.gen(max_tokens=3)
    *_, last_lm2 = lm2
    print(str(last_lm2))

    print("\nWith streaming and multiple additions:")
    lm3 = guidance.models.Transformers(model=model, tokenizer=tokenizer).stream()
    lm3 += prompt
    lm3 += guidance.gen(max_tokens=3)
    *_, last_lm3 = lm3
    print(str(last_lm3))


if __name__ == "__main__":
    main()
```

Prior to this change, only the first two generations will give sensical output whereas the third will output garbage.