### PR TITLE
Propagate errors in ModelStream

### DIFF
--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1207,8 +1207,11 @@ class ModelStream:
 
             # Define the target function for the thread
             def target():
-                self._inner_run(self.model)
-                events.put(None) # mark that we are done
+                try:
+                    self._inner_run(self.model)
+                    events.put(None) # mark that we are done
+                except BaseException as ex:
+                    events.put(ex)
 
             # Start the thread
             thread = threading.Thread(target=target)
@@ -1221,6 +1224,8 @@ class ModelStream:
                     event = events.get(timeout=self.timeout)
                     if event is None:
                         break
+                    elif isinstance(event, BaseException):
+                        raise event
                     yield event
                 except queue.Empty:
                     # Check if the thread is still alive

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,3 +1,5 @@
+import pytest
+
 import guidance
 from guidance import select, models, gen, zero_or_more, byte_range
 from ..utils import get_model
@@ -45,3 +47,20 @@ def test_token_healing():
     gpt2 = get_model("transformers:gpt2")
     lm = gpt2 + ("This is a story of 10 or 5 or " + zero_or_more(byte_range(b'0', b'9')))
     assert len(lm) > len("This is a story of 10 or 5 or ")
+
+def test_stream():
+    lm = get_model("transformers:gpt2").stream()
+    lm += select(["item1", "item2"])
+    *_, last_lm = lm
+    assert str(last_lm) in ["item1", "item2"]
+
+def test_stream_propagate_errors():
+    lm = get_model("transformers:gpt2").stream()
+
+    @guidance
+    def my_function(lm):
+        raise Exception()
+    
+    lm += my_function()
+    with pytest.raises(Exception):
+        list(lm)


### PR DESCRIPTION
This change propagates exceptions that are raised in grammar functions in ModelStreams up to the place where the ModelStream is being iterated. Prior to this change, exceptions were just swallowed in ModelStreams since the grammar functions are processed in a different thread. This works by re-using the existing event queue to store the exception, and then raising any instance of BaseException that comes off the queue during iteration.

This is kind of similar to how concurrent.futures works: https://github.com/python/cpython/blob/94d1a7b853cf115e52e07e14576d3dd75ecd4a8c/Lib/concurrent/futures/thread.py#L53-L64