### PR TITLE
fix: missing tokenizer choice in AzureOpenAI subclasses

### DIFF
--- a/guidance/models/_azure_openai.py
+++ b/guidance/models/_azure_openai.py
@@ -106,7 +106,7 @@ class AzureOpenAI(OpenAI):
 
         super().__init__(
             model=azure_endpoint,
-            tokenizer=tiktoken.encoding_for_model(model),
+            tokenizer=tokenizer or tiktoken.encoding_for_model(model),
             echo=echo,
             caching=caching,
             temperature=temperature,


### PR DESCRIPTION
Fixes a bug in `AzureOpenAI`. 
If an object is instanciated from a subclass of AzureOpenAI, then the tokenizer is always derived from the model name via tiktoken, even if a tokenizer is passed. 
This will typically fail, because Azure OpenAI deployments have individual model names.
This fixes this case.