### PR TITLE
Make `GrammarFunction.match` consume hidden commit points twice

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -164,15 +164,21 @@ class GrammarFunction(Function):
             byte_string = byte_string.encode()
         parser = _parser.EarleyCommitParser(self)
 
-        for i in range(len(byte_string)):
+        i = 0
+        while i < len(byte_string):
             try:
-                parser.consume_byte(byte_string[i:i+1])
+                commit_point = parser.consume_byte(byte_string[i:i+1])
             except _parser.ParserException:
                 if raise_exceptions:
                     raise
                 else:
                     return None
-        
+            if commit_point is not None and commit_point.node.hidden:
+                # Re-consume hidden nodes
+                i = commit_point.hidden_start
+                continue
+            i += 1
+
         if not allow_partial and not parser.matched():
             return None
         else:

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -164,10 +164,11 @@ class GrammarFunction(Function):
             byte_string = byte_string.encode()
         parser = _parser.EarleyCommitParser(self)
 
-        i = 0
-        while i < len(byte_string):
+        byte_pos = 0
+        parser_pos = 0
+        while byte_pos < len(byte_string):
             try:
-                commit_point = parser.consume_byte(byte_string[i:i+1])
+                commit_point = parser.consume_byte(byte_string[byte_pos:byte_pos+1])
             except _parser.ParserException:
                 if raise_exceptions:
                     raise
@@ -175,9 +176,11 @@ class GrammarFunction(Function):
                     return None
             if commit_point is not None and commit_point.node.hidden:
                 # Re-consume hidden nodes
-                i = commit_point.hidden_start
-                continue
-            i += 1
+                rewind = parser_pos - commit_point.hidden_start
+                byte_pos = byte_pos - rewind
+            else:
+                byte_pos += 1
+            parser_pos += 1
 
         if not allow_partial and not parser.matched():
             return None

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -165,7 +165,6 @@ class GrammarFunction(Function):
         parser = _parser.EarleyCommitParser(self)
 
         byte_pos = 0
-        parser_pos = 0
         while byte_pos < len(byte_string):
             try:
                 commit_point = parser.consume_byte(byte_string[byte_pos:byte_pos+1])
@@ -176,11 +175,10 @@ class GrammarFunction(Function):
                     return None
             if commit_point is not None and commit_point.node.hidden:
                 # Re-consume hidden nodes
-                rewind = parser_pos - commit_point.hidden_start
+                rewind = (parser.pos - 1) - commit_point.hidden_start
                 byte_pos = byte_pos - rewind
             else:
                 byte_pos += 1
-            parser_pos += 1
 
         if not allow_partial and not parser.matched():
             return None

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,6 +1,6 @@
 import pytest
 import guidance
-from guidance import models, select, gen, optional
+from guidance import models, select, gen, optional, one_or_more
 
 def test_select_reset_pos():
     model = models.Mock()
@@ -116,3 +116,10 @@ def test_gen_stop_repeat(prefix, suffix, stop):
     grammar = gen(stop=stop) + stop + suffix
     match = grammar.match(matchstr, allow_partial=True)
     assert match is None
+
+@pytest.mark.parametrize('stop',   ['@', '@@'])
+def test_multiple_gen_stops(stop):
+    grammar = one_or_more(gen(stop=stop) + stop)
+    matchstr = 'abc' + stop + '123' + stop + 'xyz' + stop
+    match = grammar.match(matchstr, allow_partial=True)
+    assert match is not None

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,3 +1,4 @@
+import pytest
 import guidance
 from guidance import models, select, gen, optional
 
@@ -86,3 +87,32 @@ class TestRecursion:
         grammar1()
         grammar2()
         grammar3()
+
+
+@pytest.mark.parametrize('prefix', ['', 'abc'])
+@pytest.mark.parametrize('suffix', ['', '123'])
+@pytest.mark.parametrize('stop',   ['@', '@@'])
+def test_gen_stop_excluded(prefix, suffix, stop):
+    matchstr = f"{prefix}{stop}{suffix}"
+    grammar = gen(stop=stop)
+    match = grammar.match(matchstr, allow_partial=True)
+    assert match is None
+
+@pytest.mark.parametrize('prefix', ['', 'abc'])
+@pytest.mark.parametrize('suffix', ['', '123'])
+@pytest.mark.parametrize('stop',   ['@', '@@'])
+def test_gen_stop_continues(prefix, suffix, stop):
+    matchstr = f"{prefix}{stop}{suffix}"
+    grammar = gen(stop=stop) + stop + suffix
+    match = grammar.match(matchstr, allow_partial=True)
+    assert match is not None
+    assert not match.partial
+
+@pytest.mark.parametrize('prefix', ['', 'abc'])
+@pytest.mark.parametrize('suffix', ['', '123'])
+@pytest.mark.parametrize('stop',   ['@', '@@'])
+def test_gen_stop_repeat(prefix, suffix, stop):
+    matchstr = f"{prefix}{stop}{stop}{suffix}"
+    grammar = gen(stop=stop) + stop + suffix
+    match = grammar.match(matchstr, allow_partial=True)
+    assert match is None


### PR DESCRIPTION
This fixes issue https://github.com/guidance-ai/guidance/issues/624 by having `GrammarFuntion.match` consume hidden commit points twice.

Namely, if `gen` has a `stop`, kwd, previous behavior allowed matches when the match string ended in the `stop` string. For the grammar to have possibly generated that match string, the `stop` string would have to be allowable by a part of the grammar _following_ the `gen` call, so we simply consume the bytes twice.