### PR TITLE
Fix behavior of `_json_schema_to_grammar` for schemas with many properties

### DIFF
--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -66,11 +66,10 @@ def _process_object(schema_properties: Dict[str, any]) -> GrammarFunction:
                 Join([_QUOTE, name, _QUOTE]),
                 _COLON,
                 _process_node(nxt_node),
+                _COMMA if len(properties) + 1 < len(schema_properties) else "",
             ]
         )
         properties.append(nxt)
-        if len(properties) < len(schema_properties):
-            properties.append(_COMMA)
     return Join([_OPEN_BRACE, *properties, _CLOSE_BRACE])
 
 

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -102,6 +102,33 @@ def test_simple_object():
     check_string_with_grammar(target_string, grammar)
 
 
+def test_object_with_many_fields():
+    schema = """{
+        "type": "object",
+        "properties": {
+            "a" : {"type": "integer"},
+            "b" : {"type": "integer"},
+            "c" : {"type": "integer"},
+            "d" : {"type": "integer"},
+            "e" : {"type": "integer"},
+            "f" : {"type": "integer"},
+            "g" : {"type": "integer"},
+            "h" : {"type": "integer"}
+        }
+    }
+"""
+    target_obj = dict(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8)
+
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+
 def test_nested_object():
     schema = """{
         "type": "object",

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -101,8 +101,27 @@ def test_simple_object():
     target_string = to_compact_json(target_obj)
     check_string_with_grammar(target_string, grammar)
 
+def test_object_with_single_property():
+    schema = """{
+        "type": "object",
+        "properties": {
+            "a" : {"type": "integer"}
+        }
+    }
+"""
+    target_obj = dict(a=1)
 
-def test_object_with_many_fields():
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+
+def test_object_with_many_properties():
     schema = """{
         "type": "object",
         "properties": {


### PR DESCRIPTION
The conditional for adding commas to incomplete sets of properties in `_json_schema_to_grammar._process_object` was incorrect, leading to missing commas in the grammar when the number of properties was too high.

Added a test that fails on the current `main` branch.

@riedgar-ms please take a look when you can