### PR TITLE
Exclude tests packages from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email="scott@scottlundberg.com",
     description="A guidance language for controlling large language models.",
     long_description="Guidance enables you to control modern language models more effectively and efficiently than traditional prompting or chaining. Guidance programs allow you to interleave generation, prompting, and logical control into a single continuous flow matching how the language model actually processes the text.",
-    packages=find_packages(exclude=["notebooks", "client"]),
+    packages=find_packages(exclude=["notebooks", "client", "tests", "tests.*"]),
     package_data={"guidance": ["resources/*"]},
     ext_modules=[Pybind11Extension("guidance.cpp", ["guidance/_cpp/main.cpp", "guidance/_cpp/byte_trie.cpp"])],
     cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
Fixes #618 

This change adds `tests` and `tests.*` to the `exclude` parameter of `find_packages`. Previously, installing guidance would also create an unexpected `tests` subdirectory in the user's `site-packages` directory, which can cause issues if the user has their own package also named `tests`.

I validated this change with the following:

```bash
python3 -m venv .venv
source .venv/bin/activate
pip install .[test]
```

and verified that `.venv/lib/python3.10/site-packages` did not contain a `tests` subdirectory. Furthermore, I verified that running `pytest` still works as expected after the change