### PR TITLE
Improve HF tokenization hack to cover multiple special tokens

### DIFF
--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -615,13 +615,20 @@ class Engine:
                 token_byte_positions.append(pos)
 
             # ugly hack to deal with sentence peice craziness of space hiding after special tokens TODO: figure out how to make this more robust
-            if token_byte_positions[-1] > last_pos:
+            if (
+                hasattr(self.tokenizer, "_orig_tokenizer")
+                and hasattr(self.tokenizer._orig_tokenizer, "all_special_tokens")
+                and token_byte_positions[-1] > last_pos
+            ):
+                special_tokens = [
+                    bytes(s, encoding="utf8")
+                    for s in self.tokenizer._orig_tokenizer.all_special_tokens
+                ]
                 spaces_hidden = 0
                 for i in range(0, len(token_byte_positions)):
                     token_byte_positions[i] -= spaces_hidden
                     if (
-                        self.tokenizer.tokens[token_ids[i]]
-                        in [b"<s>", b"</s>", b"<unk>"]
+                        self.tokenizer.tokens[token_ids[i]] in special_tokens
                         and len(token_ids) > i + 1
                         and self.tokenizer.tokens[token_ids[i + 1]][0:1] == b" "
                     ):

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -617,11 +617,12 @@ class Engine:
             # ugly hack to deal with sentence peice craziness of space hiding after special tokens TODO: figure out how to make this more robust
             if token_byte_positions[-1] > last_pos:
                 spaces_hidden = 0
-                for i in range(0, len(token_byte_positions) - 1):
+                for i in range(0, len(token_byte_positions)):
                     token_byte_positions[i] -= spaces_hidden
                     if (
                         self.tokenizer.tokens[token_ids[i]]
                         in [b"<s>", b"</s>", b"<unk>"]
+                        and len(token_ids) > i + 1
                         and self.tokenizer.tokens[token_ids[i + 1]][0:1] == b" "
                     ):
                         spaces_hidden += 1

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -97,11 +97,9 @@ class TransformersEngine(Engine):
         first_decode = b''.join([self.tokenizer.tokens[id] for id in token_ids]).decode("utf8")
 
         # HACK: work around a bug in the HuggingFace tokenizer (that will just add extra spaces during an encode-decode cycle)
-        first_decode = (
-            first_decode.replace("<s> ", "<s>")
-            .replace("</s> ", "</s>")
-            .replace("<unk> ", "<unk>")
-        )
+        if hasattr(self.tokenizer._orig_tokenizer, "all_special_tokens"):
+            for special_token in self.tokenizer._orig_tokenizer.all_special_tokens:
+                first_decode = first_decode.replace(f"{special_token} ", special_token)
 
         new_ids = self.tokenizer._orig_tokenizer(first_decode, add_special_tokens=False)["input_ids"]
 


### PR DESCRIPTION
Like some others (#620, #609, #581, #556, #555, #494, #479) I have been running into issues with an assertion failure when my prompt contains special tokens. Particularly, it seems like the existing workaround doesn't account for multiple special tokens being present in the prompt, but this is necessary for example if you want to use the chat template provided with models such as `HuggingFaceH4/zephyr-7b-beta`, which contains special tokens as part of the template.

I don't fully understand the nature of the workaround or why it is necessary, but after some experimentation, the changes here made it work for my use case. I am posting them here in case it helps anyone experiencing the same issue and also in hopes of creating a discussion that might lead to a more robust solution. Perhaps @slundberg, who I believe implemented the original workaround, can chime in and let me know if I am on the right track with this change.

Thanks, Shawn