### PR TITLE
Together.ai Support

### DIFF
--- a/guidance/models/__init__.py
+++ b/guidance/models/__init__.py
@@ -14,3 +14,4 @@ from ._lite_llm import LiteLLM, LiteLLMChat, LiteLLMInstruct, LiteLLMCompletion
 from ._cohere import Cohere,CohereCompletion, CohereInstruct
 from ._anthropic import Anthropic, AnthropicChat
 from ._googleai import GoogleAI, GoogleAIChat
+from ._togetherai import TogetherAI, TogetherAIChat, TogetherAIInstruct, TogetherAICompletion

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -89,9 +89,13 @@ class GrammarlessEngine(Engine):
         self.max_repeated_calls = 10
         self.timeout = timeout
 
+        # If tokenizer is not already an instance of Tokenizer, then instantiate it as a GrammarlessTokenizer
+        if not isinstance(tokenizer, Tokenizer):
+            tokenizer = GrammarlessTokenizer(tokenizer)
+
         # build the 
         super().__init__(
-            tokenizer=GrammarlessTokenizer(tokenizer),
+            tokenizer=tokenizer,
             compute_log_probs=compute_log_probs
         )
 

--- a/guidance/models/_togetherai.py
+++ b/guidance/models/_togetherai.py
@@ -1,3 +1,4 @@
+import os
 from ._model import Chat, Instruct
 from ._openai import OpenAIChatEngine, OpenAI, OpenAIInstructEngine, OpenAICompletionEngine
 from .transformers._transformers import TransformersTokenizer
@@ -10,6 +11,14 @@ class TogetherAI(OpenAI):
         '''
 
         tokenizer = TransformersTokenizer(model=model, tokenizer=tokenizer, ignore_bos_token=True)
+
+        # Default base_url is the together.ai endpoint
+        if not "base_url" in kwargs:
+            kwargs["base_url"] = 'https://api.together.xyz'
+        # TogetherAI uses TOGETHERAI_API_KEY env value instead of OPENAI_API_KEY
+        # We pass explicitly to avoid OpenAI class complaining about a missing key
+        if api_key is None:
+            api_key = os.environ.get("TOGETHERAI_API_KEY", None)
 
         if engine_class is None:
             engine_map = {

--- a/guidance/models/_togetherai.py
+++ b/guidance/models/_togetherai.py
@@ -26,10 +26,10 @@ class TogetherAI(OpenAI):
 
         if engine_class is None:
             engine_map = {
-                TogetherAI: OpenAICompletionEngine,
                 TogetherAICompletion: OpenAICompletionEngine,
-                TogetherAIInstruct: OpenAIInstructEngine,
-                TogetherAIChat: OpenAIChatEngine
+                TogetherAIInstruct: TogetherAIInstructEngine,
+                TogetherAIChat: OpenAIChatEngine,
+                TogetherAI: OpenAICompletionEngine,
             }
             for k in engine_map:
                 if issubclass(self.__class__, k):

--- a/guidance/models/_togetherai.py
+++ b/guidance/models/_togetherai.py
@@ -19,6 +19,10 @@ class TogetherAI(OpenAI):
         # We pass explicitly to avoid OpenAI class complaining about a missing key
         if api_key is None:
             api_key = os.environ.get("TOGETHERAI_API_KEY", None)
+        if api_key is None:
+            raise Exception(
+                "The api_key client option must be set either by passing api_key to the client or by setting the TOGETHERAI_API_KEY environment variable"
+            )
 
         if engine_class is None:
             engine_map = {

--- a/guidance/models/_togetherai.py
+++ b/guidance/models/_togetherai.py
@@ -13,6 +13,7 @@ class TogetherAI(OpenAI):
 
         if engine_class is None:
             engine_map = {
+                TogetherAI: OpenAICompletionEngine,
                 TogetherAICompletion: OpenAICompletionEngine,
                 TogetherAIInstruct: OpenAIInstructEngine,
                 TogetherAIChat: OpenAIChatEngine

--- a/guidance/models/_togetherai.py
+++ b/guidance/models/_togetherai.py
@@ -1,6 +1,6 @@
 import os
 from ._model import Chat, Instruct
-from ._openai import OpenAIChatEngine, OpenAI, OpenAIInstructEngine, OpenAICompletionEngine
+from ._openai import OpenAIChatEngine, OpenAI, OpenAIInstructEngine, OpenAICompletionEngine, OpenAIEngine
 from .transformers._transformers import TransformersTokenizer
 
 
@@ -45,7 +45,63 @@ class TogetherAICompletion(TogetherAI):
 
 
 class TogetherAIInstruct(TogetherAI, Instruct):
-    pass
+    """
+    Utilizes transformers chat templates to apply a user role to the prompt
+    """
+    def __init__(self, model, tokenizer=None, echo=True, api_key=None, max_streaming_tokens=1000, timeout=0.5, compute_log_probs=False, engine_class=None, **kwargs):
+        self.dummy_prompt = "$GUIDANCE_DUMMY_INPUT$"
+        super().__init__(
+            model, tokenizer, echo, api_key, max_streaming_tokens, timeout, compute_log_probs, engine_class, **kwargs
+        )
+
+    def get_template_prompt(self):
+        dummy_messages = [
+            {
+                "role": "user",
+                "content": self.dummy_prompt,
+            }
+        ]
+        template_prompt = self.engine.tokenizer._orig_tokenizer.apply_chat_template(dummy_messages, tokenize=False)
+        return template_prompt
+
+
+    def get_role_start(self, name):
+        template_prompt = self.get_template_prompt()
+        start = template_prompt[:template_prompt.index(self.dummy_prompt)]
+        return start
+    
+    def get_role_end(self, name):
+        if name == "instruction":
+            template_prompt = self.get_template_prompt()
+            end = template_prompt[template_prompt.index(self.dummy_prompt) + len(self.dummy_prompt):]
+            return end
+        else:
+            raise Exception(f"The TogetherAIInstruct model does not know about the {name} role type!")
+
+
+class TogetherAIInstructEngine(OpenAIEngine):
+    def _generator(self, prompt, temperature):
+        self._reset_shared_data(prompt, temperature)
+
+        try:
+            generator = self.client.completions.create(
+                model=self.model_name,
+                prompt=prompt.decode("utf8"), 
+                max_tokens=self.max_streaming_tokens, 
+                n=1, 
+                top_p=1.0, # TODO: this should be controllable like temp (from the grammar)
+                temperature=temperature, 
+                stream=True
+            )
+        except Exception as e: # TODO: add retry logic
+            raise e
+
+        for part in generator:
+            if len(part.choices) > 0:
+                chunk = part.choices[0].text or ""
+            else:
+                chunk = ""
+            yield chunk.encode("utf8")
 
 
 class TogetherAIChat(TogetherAI, Chat):

--- a/guidance/models/_togetherai.py
+++ b/guidance/models/_togetherai.py
@@ -1,0 +1,38 @@
+from ._model import Chat, Instruct
+from ._openai import OpenAIChatEngine, OpenAI, OpenAIInstructEngine, OpenAICompletionEngine
+from .transformers._transformers import TransformersTokenizer
+
+
+class TogetherAI(OpenAI):
+    def __init__(self, model, tokenizer=None, echo=True, api_key=None, max_streaming_tokens=1000, timeout=0.5, compute_log_probs=False, engine_class=None, **kwargs):
+        '''
+        Build a new TogetherAI model object that represents a model in a given state.
+        '''
+
+        tokenizer = TransformersTokenizer(model=model, tokenizer=tokenizer, ignore_bos_token=True)
+
+        if engine_class is None:
+            engine_map = {
+                TogetherAICompletion: OpenAICompletionEngine,
+                TogetherAIInstruct: OpenAIInstructEngine,
+                TogetherAIChat: OpenAIChatEngine
+            }
+            for k in engine_map:
+                if issubclass(self.__class__, k):
+                    engine_class = engine_map[k]
+                    break
+
+        super().__init__(
+            model, tokenizer, echo, api_key, max_streaming_tokens, timeout, compute_log_probs, engine_class, **kwargs
+        )
+
+class TogetherAICompletion(TogetherAI):
+    pass
+
+
+class TogetherAIInstruct(TogetherAI, Instruct):
+    pass
+
+
+class TogetherAIChat(TogetherAI, Chat):
+    pass

--- a/notebooks/api_examples/models/TogetherAI.ipynb
+++ b/notebooks/api_examples/models/TogetherAI.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `TogetherAI` API examples\n",
+    "\n",
+    "This notebook contains examples of how to use the `TogetherAI` LLM, utilizing models hosted by [together.ai](https://together.ai)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Completion usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>The most famous piece of japanese literature in a JSON format is:\n",
+       "{\n",
+       "    &quot;title_english&quot;:<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>  </span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>&quot;</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>The</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> Tal</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>e</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> of</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> Gen</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>ji</span>&quot;,\n",
+       "    &quot;title_japanese&quot;:<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> &quot;</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>源</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>氏</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>物</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>語</span>&quot;,\n",
+       "    &quot;author&quot;:<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> &quot;</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>Mu</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>ras</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>aki</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> Sh</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>iki</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>bu</span>&quot;,\n",
+       "    &quot;year&quot;:<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> </span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>1</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>0</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>0</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>8</span>\n",
+       "}\n",
+       "</pre>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from guidance import models, gen\n",
+    "\n",
+    "# This relies on the environment variable TOGETHERAI_API_KEY being set\n",
+    "mixtral = models.TogetherAI('mistralai/Mixtral-8x7B-Instruct-v0.1')\n",
+    "\n",
+    "lm = mixtral\n",
+    "\n",
+    "stop_tokens = [\",\", \"}\", \"\\n\"]\n",
+    "temperature = 0.0\n",
+    "\n",
+    "lm += f\"\"\"The most famous piece of japanese literature in a JSON format is:\n",
+    "{{\n",
+    "    \"title_english\": {gen(name='title_english', temperature=temperature, max_tokens=50, stop=stop_tokens)},\n",
+    "    \"title_japanese\": {gen(name='title_japanese', temperature=temperature, max_tokens=50, stop=stop_tokens)},\n",
+    "    \"author\": {gen(name='author', temperature=temperature, max_tokens=50, stop=stop_tokens)},\n",
+    "    \"year\": {gen(name='year', temperature=temperature, max_tokens=50, stop=stop_tokens)}\n",
+    "}}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instruct usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>instruction</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>What is ice cream refered to as in Italy?</div></div><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>Gel</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>ato</span></pre>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from guidance import instruction\n",
+    "\n",
+    "# This relies on the environment variable TOGETHERAI_API_KEY being set\n",
+    "gemma = models.TogetherAIInstruct('google/gemma-7b-it')\n",
+    "\n",
+    "lm = gemma\n",
+    "with instruction():\n",
+    "    lm += \"What is ice cream refered to as in Italy?\"\n",
+    "lm += gen('flavor', max_tokens=50, stop='\\n')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chat usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>system</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>You only speak in ALL CAPS for the entirety of your response.</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>user</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>What is the captial of Trinidad &amp; Tobago?</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>assistant</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>PORT</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> OF</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> SP</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>AIN</span></div></div></pre>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from guidance import system, user, assistant\n",
+    "\n",
+    "# This relies on the environment variable TOGETHERAI_API_KEY being set\n",
+    "hermes = models.TogetherAIChat('NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO')\n",
+    "\n",
+    "lm = hermes\n",
+    "\n",
+    "with system():\n",
+    "    lm += \"You only speak in ALL CAPS for the entirety of your response.\"\n",
+    "\n",
+    "with user():\n",
+    "    lm += \"What is the captial of Trinidad & Tobago?\"\n",
+    "\n",
+    "with assistant():\n",
+    "    lm += gen('answer', max_tokens=50, temperature=0.0, stop=\".\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height: 1px; opacity: 0.5; border: none; background: #cccccc;\">\n",
+    "<div style=\"text-align: center; opacity: 0.5\">Have an idea for more helpful examples? Pull requests that add to this documentation notebook are encouraged!</div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "adatest",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/api_examples/models/TogetherAI.ipynb
+++ b/notebooks/api_examples/models/TogetherAI.ipynb
@@ -46,7 +46,7 @@
     "from guidance import models, gen\n",
     "\n",
     "# This relies on the environment variable TOGETHERAI_API_KEY being set\n",
-    "mixtral = models.TogetherAI('mistralai/Mixtral-8x7B-Instruct-v0.1')\n",
+    "mixtral = models.TogetherAI('mistralai/Mixtral-8x7B-v0.1')\n",
     "\n",
     "lm = mixtral\n",
     "\n",

--- a/tests/models/test_togetherai.py
+++ b/tests/models/test_togetherai.py
@@ -1,0 +1,69 @@
+import pytest
+import guidance
+from guidance import gen, select, user, system, assistant
+
+def test_togetherai_basic():
+    try:
+        lm = guidance.models.TogetherAI("mistralai/Mistral-7B-v0.1")
+    except:
+        pytest.skip("Skipping TogetherAI test because we can't load the model!")
+    lm += "Count to 20: 1,2,3,4,"
+    stop = '\n'
+    lm += f"""{gen(max_tokens=1, stop=stop, name="text")}"""
+    assert str(lm)[-1] == "5"
+
+
+def test_togetherai_select():
+    try:
+        lm = guidance.models.TogetherAI("mistralai/Mistral-7B-v0.1")
+    except:
+        pytest.skip("Skipping TogetherAI test because we can't load the model!")
+    nums = ["1", "11", "111", "1111", "11111", "111111", "1111111"]
+    lm += "Pick a number: "
+    lm += select(nums, name='number')
+    assert str(lm["number"]) in nums
+
+
+def test_togetherai_chat():
+    try:
+        lm = guidance.models.TogetherAIChat("teknium/OpenHermes-2-Mistral-7B")
+    except:
+        pytest.skip("Skipping TogetherAI test because we can't load the model!")
+    with system():
+        lm += "You are a math wiz."
+
+    with user():
+        lm += "What is 1 + 1?"
+
+    with assistant():
+        lm += gen(max_tokens=10, name="text")
+        lm += "Pick a number: "
+
+    assert len(lm["text"]) > 0
+
+
+def test_togetherai_chat_without_roles():
+    try:
+        lm = guidance.models.TogetherAIChat("teknium/OpenHermes-2-Mistral-7B")
+    except:
+        pytest.skip("Skipping TogetherAI test because we can't load the model!")
+    with pytest.raises(ValueError) as error_info:
+        lm += "You are a math wiz. What is 1+1?" + gen(max_tokens=10, name="text")
+
+
+def test_togetherai_chat_loop():
+    try:
+        model = guidance.models.TogetherAIChat("teknium/OpenHermes-2-Mistral-7B", echo=False)
+    except:
+        pytest.skip("Skipping TogetherAI test because we can't load the model!")
+
+    with system():
+        lm = model + "You will just return whatever number I give you"
+    
+    for i in range(2):
+        with user():
+            lm += f'The number is: {i}'
+        
+        with assistant():
+            lm += gen(name='answer', max_tokens=10)
+    assert len(lm["answer"]) > 0


### PR DESCRIPTION
This PR adds a new `TogetherAI` model, implementing:
`TogetherAICompletion`, `TogetherAIChat`, `TogetherAIInstruct`

In support of [together.ai models](https://docs.together.ai/docs/inference-models).

Together has two library implementations: One is the [together](https://docs.together.ai/docs/inference-python) library, but it also supports the [openai](https://docs.together.ai/docs/openai-api-compatibility) library.
This PR uses the `openai` implementation.

Because of this, we can largely re-use the existing `OpenAI` classes, with some adjustments:

- To support the wide range of open source models, we use `transformers` tokenizers instead of `tiktoken`
  - `GrammarlessEngine` now accepts `Tokenizer` instances as well instead of forcing the use of `GrammarlessTokenizer`, allowing us to create and use `TransformersTokenizer` instances instead
  - `TransformersTokenizer` can now download the tokenizer for a HF model by itself, while `TransformersEngine` now only downloads the model and leaves tokenizer initialization to the tokenizer instance
  - `TransformersTokenizer` also gains an `ignore_bos_token` param, which was necessary to avoid extra tokens inserted into the prompt that are not required for API requests
- `base_url` is set to `'https://api.together.xyz'`
- Instead of `OPENAI_API_KEY`, we use `TOGETHERAI_API_KEY`


For `TogetherAIInstruct`, i am simply utilizing the chat template with a single `user` role message, since together.ai will be parsing that in the model-appropriate instruct/chat format behind the scenes. 
Initially, i was using [HF chat templates](https://huggingface.co/docs/transformers/main/chat_templating) for the instruction role, however midway through testing the completions endpoint stopped working for models within their [chat category](https://docs.together.ai/docs/inference-models#chat-models), which is why i reverted to above.


I also added a `TogetherAI.ipynb` example notebook.