### PR TITLE
Add extensible tests to transformers

### DIFF
--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -27,12 +27,16 @@ def test_recursion_error():
     )
 
 
-TRANSFORMER_MODELS = ["gpt2", "microsoft/phi-2"]
+TRANSFORMER_MODELS = {
+    "gpt2": {},
+    "microsoft/phi-2": {"trust_remote_code": True},
+    "HuggingFaceTB/cosmo-1b": {},
+}
 
 
-@pytest.mark.parametrize("model_name", TRANSFORMER_MODELS)
-def test_transformer_smoke_gen(model_name):
-    my_model = get_model(f"transformers:{model_name}", trust_remote_code=True)
+@pytest.mark.parametrize(["model_name", "model_kwargs"], TRANSFORMER_MODELS.items())
+def test_transformer_smoke_gen(model_name, model_kwargs):
+    my_model = get_model(f"transformers:{model_name}", **model_kwargs)
 
     prompt = "How many sides has a triangle?"
     lm = my_model + prompt + gen(name="answer", max_tokens=2)

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -1,18 +1,45 @@
-import guidance
-from guidance import gen, capture
+from textwrap import dedent
+
+import pytest
+
+from guidance import gen, select
+
 from ..utils import get_model
+
 
 def test_gpt2():
     gpt2 = get_model("transformers:gpt2")
     lm = gpt2 + "this is a test" + gen("test", max_tokens=10)
     assert len(str(lm)) > len("this is a test")
 
+
 def test_recursion_error():
-    '''This checks for an infinite recursion error resulting from a terminal node at the root of a grammar.'''
+    """This checks for an infinite recursion error resulting from a terminal node at the root of a grammar."""
     gpt2 = get_model("transformers:gpt2")
 
     # define a guidance program that adapts a proverb
-    lm = gpt2 + f"""Tweak this proverb to apply to model instructions instead.
+    lm = (
+        gpt2
+        + f"""Tweak this proverb to apply to model instructions instead.
     {gen('verse', max_tokens=2)}
     """
-    assert len(str(lm)) > len("Tweak this proverb to apply to model instructions instead.\n\n")
+    )
+    assert len(str(lm)) > len(
+        "Tweak this proverb to apply to model instructions instead.\n\n"
+    )
+
+
+@pytest.mark.parametrize("model_name", ["gpt2", "microsoft/phi-2"])
+def test_transformer_smoke(model_name):
+    my_model = get_model(f"transformers:{model_name}", trust_remote_code=True)
+
+    prompt = dedent(
+        """How many sides has a triangle?
+
+p) 4
+t) 3
+w) 10
+"""
+    )
+    lm = my_model + prompt + select(["p", "t", "w"], name="answer")
+    assert lm["answer"] in ["p", "t", "w"]

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 import pytest
 
 from guidance import gen, select
@@ -36,7 +34,7 @@ TRANSFORMER_MODELS = ["gpt2", "microsoft/phi-2"]
 def test_transformer_smoke_gen(model_name):
     my_model = get_model(f"transformers:{model_name}", trust_remote_code=True)
 
-    prompt = dedent(f"""How many sides has a triangle?""")
+    prompt = "How many sides has a triangle?"
     lm = my_model + prompt + gen(name="answer", max_tokens=2)
     assert len(lm["answer"]) > 0, f"Output: {lm['answer']}"
     # Inexact, but at least make sure not too much was produced
@@ -47,13 +45,10 @@ def test_transformer_smoke_gen(model_name):
 def test_transformer_smoke_select(model_name):
     my_model = get_model(f"transformers:{model_name}", trust_remote_code=True)
 
-    prompt = dedent(
-        """How many sides has a triangle?
+    prompt = """How many sides has a triangle?
 
 p) 4
 t) 3
-w) 10
-"""
-    )
+w) 10"""
     lm = my_model + prompt + select(["p", "t", "w"], name="answer")
     assert lm["answer"] in ["p", "t", "w"]

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -29,8 +29,22 @@ def test_recursion_error():
     )
 
 
-@pytest.mark.parametrize("model_name", ["gpt2", "microsoft/phi-2"])
-def test_transformer_smoke(model_name):
+TRANSFORMER_MODELS = ["gpt2", "microsoft/phi-2"]
+
+
+@pytest.mark.parametrize("model_name", TRANSFORMER_MODELS)
+def test_transformer_smoke_gen(model_name):
+    my_model = get_model(f"transformers:{model_name}", trust_remote_code=True)
+
+    prompt = dedent(f"""How many sides has a triangle?""")
+    lm = my_model + prompt + gen(name="answer", max_tokens=2)
+    assert len(lm["answer"]) > 0, f"Output: {lm['answer']}"
+    # Inexact, but at least make sure not too much was produced
+    assert len(lm["answer"]) < 8, f"Output: {lm['answer']}"
+
+
+@pytest.mark.parametrize("model_name", TRANSFORMER_MODELS)
+def test_transformer_smoke_select(model_name):
     my_model = get_model(f"transformers:{model_name}", trust_remote_code=True)
 
     prompt = dedent(

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -30,7 +30,6 @@ def test_recursion_error():
 TRANSFORMER_MODELS = {
     "gpt2": {},
     "microsoft/phi-2": {"trust_remote_code": True},
-    "HuggingFaceTB/cosmo-1b": {},
 }
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,7 @@ def get_openai_model(model_name, caching=False, **kwargs):
 transformers_model_cache = {}
 
 def get_transformers_model(model_name, caching=False, **kwargs):
-    """ Get an OpenAI LLM with model reuse.
+    """Get model from Hugging Face
     """
 
     # we cache the models so lots of tests using the same model don't have to


### PR DESCRIPTION
Add basic smoke tests to `transformers` which are parameterised with the name of a Hugging Face model. This is to prevent things like #609 reoccurring. 