### PR TITLE
Update _llama_cpp.py to use new bindings

### DIFF
--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class _LlamaBatchContext:
     def __init__(self, n_batch, n_ctx):
         self._llama_batch_free = llama_cpp.llama_batch_free
-        self.batch = llama_cpp.llama_batch_init(n_tokens=n_batch, embd=0, n_seq_max=n_ctx)
+        self.batch = llama_cpp.llama_batch_init(n_batch, 0, n_ctx)
         if self.batch is None:
             raise Exception("call to llama_cpp.llama_batch_init returned NULL.")
 
@@ -38,6 +38,8 @@ class LlamaCppTokenizer(Tokenizer):
         self._model_obj = model_obj
 
         tokenizer = llama_cpp.LlamaTokenizer(model_obj)
+        if not hasattr(tokenizer, 'llama'):
+            tokenizer.llama = tokenizer._model
 
         # get the bytes strings for all the tokens
         tokens = []


### PR DESCRIPTION
The newest version of llama_cpp bindings breaks a few lines of code due to changed variable names and function signatures. I've attempted to make a fix that will be backwards compatible for people using the older version of the llama_cpp library while also working with the new one.

This PR will fix issue https://github.com/guidance-ai/guidance/issues/659