### PR TITLE
Removed side effect on the stop argument from _gen

### DIFF
--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -106,7 +106,7 @@ def gen(lm, name=None, *, max_tokens=1000, list_append=False, regex=None,
         if isinstance(stop, str):
             stop = [stop]
         if regex is None:
-            stop.append(select([eos_token(), active_role_end()]))
+            stop = stop + [select([eos_token(), active_role_end()])]
 
         if stop_regex is None:
             stop_regex = []

--- a/tests/library/test_gen.py
+++ b/tests/library/test_gen.py
@@ -18,6 +18,20 @@ def test_stop_char():
     lm += "Count to 10: 1, 2, 3, 4, 5, 6, 7, " + gen('text', stop=",")
     assert lm["text"] == "8"
 
+def test_stop_list_side_effect():
+    '''Tests a bug where a stop list has an item appended to it in place instead of being updated non-destructively. The bug only occurs whe regex is also None'''
+    stop_list = ['\nStep', '\n\n', '\nAnswer'];
+    stop_list_length = len(stop_list);
+    lm = get_model("transformers:gpt2")
+    lm + '''Question: Josh decides to try flipping a house.  He buys a house for $80,000 and then puts in $50,000 in repairs.  This increased the value of the house by 150%.  How much profit did he make?
+Let's think step by step, and then write the answer:
+Step 1''' + gen('steps', list_append=True, stop=['\nStep', '\n\n', '\nAnswer'], temperature=0.7, max_tokens=20) + '\n'
+    assert stop_list_length == len(stop_list)
+    i = 2
+    lm + f'Step {i}:' + gen('steps', list_append=True, stop=['\nStep', '\n\n', '\nAnswer'], temperature=0.7, max_tokens=20) + '\n'
+    assert stop_list_length == len(stop_list)
+    
+
 def test_save_stop():
     lm = models.Mock(b"<s>Count to 10: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10")
     lm += "Count to 10: 1, 2, 3, 4, 5, 6, 7, " + gen('text', stop=",", save_stop_text='stop_text')


### PR DESCRIPTION
Calling append on `stop` can cause issues if the same list is used in multiple situations in the same parent context. Using a non-destructive method to update the stop list also makes invoking gen over rpyc possible.


