### PR TITLE
Make Nulls Terminal

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -389,7 +389,7 @@ class ByteRange(Terminal):
         out.temperature = data.temperature
         return out
 
-class Null():
+class Null(Terminal):
     __slots__ = ("name", "hidden", "commit_point", "capture_name")
 
     nullable = True


### PR DESCRIPTION
Teeny-tiny little PR: make `Null` inherit from `Terminal`.

As far as I can tell, this is only really useful for preventing something rather silly from blowing up:
```python
@guidance
def null_grammar(lm):
  return lm
```

Why would you write this? Don't ask.

Currently, calling this will raise an `AttributeError: 'Null' object has no attribute 'values'` when `replace_grammar_node` does its thing.

An alternative fix would be to explicitly add `Null` to this `isinstance` check in `replace_grammar_node`:
```python
def replace_grammar_node(grammar, target, replacement):
  ...
    # We are done with this node if it's a terminal
    if isinstance(current, (Terminal, ModelVariable)):
            continue
```
But I think that this PR is a bit more elegant (unless anyone can think of a reason that `Null` wouldn't be `Terminal`).

All tests passing on my end :)