### PR TITLE
[Test] MacOS Issue with Server tests

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,7 @@ from guidance.library import json as gen_json
 
 from .utils import to_compact_json
 
-PROCESS_DELAY_SECS = 30
+PROCESS_DELAY_SECS = 40
 
 
 def server_process(*, mock_string: Union[str, List[str]] = ""):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,7 @@ from guidance.library import json as gen_json
 
 from .utils import to_compact_json
 
-PROCESS_DELAY_SECS = 20
+PROCESS_DELAY_SECS = 30
 
 
 def server_process(*, mock_string: Union[str, List[str]] = ""):


### PR DESCRIPTION
It appears that the MacOS hosts are running into trouble with the server tests. Try increasing the startup delay, to see if that helps. The [MacOS hosts are slightly lower spec](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) than the Windows and Linux ones.