### PR TITLE
Separate out server tests

### DIFF
--- a/.github/workflows/server_tests.yml
+++ b/.github/workflows/server_tests.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Server tests
 
 on:
   push:
@@ -8,11 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit-tests:
-
+  server-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}
@@ -29,10 +28,7 @@ jobs:
           pip install pytest
           pip install -e .[test]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Run tests (except server)
+      - name: Run server tests
         run: |
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m "not server" ./tests/
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m server ./tests/
+

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  main-tests:
 
     strategy:
       matrix:
@@ -29,10 +29,35 @@ jobs:
           pip install pytest
           pip install -e .[test]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Test with pytest
+      - name: Run tests (except server)
         run: |
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m not server ./tests/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  server-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -e .[test]
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run server tests
+        run: |
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m server ./tests/
+

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,7 +31,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run tests (except server)
         run: |
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m not server ./tests/
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m "not server" ./tests/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,16 @@ requires = [
     "pybind11>=2.10.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "server: Potentially unreliable tests of the server functionality",
+]
+
+[tool.black]
+line-length = 88
+target_version = ['py38', 'py39', 'py310', 'py311']
+
+[tool.isort]
+profile = "black"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,8 @@ from guidance.library import json as gen_json
 
 from .utils import to_compact_json
 
+# Everything in here is a 'server' test
+# Mark is configured in pyproject.toml
 pytestmark = pytest.mark.server
 
 PROCESS_DELAY_SECS = 40

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,8 @@ from guidance.library import json as gen_json
 
 from .utils import to_compact_json
 
+pytestmark = pytest.mark.server
+
 PROCESS_DELAY_SECS = 40
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,10 @@ from .utils import to_compact_json
 # Mark is configured in pyproject.toml
 pytestmark = pytest.mark.server
 
+# We spin out a separate process, and it
+# has to start up and get ready to
+# respond to requests. Just waiting is
+# not ideal, but is the simplest option
 PROCESS_DELAY_SECS = 40
 
 


### PR DESCRIPTION
The tests in `test_server.py` seem to be a touch temperamental, often failing when the forked server process fails to start in time. In an effort to reduce the re-running of tests, add a `server` mark for these tests, and run in a separate runner job. Use a new workflow file so that everything doesn't get killed by the first failure.