### PR TITLE
[Test] Add Mistral to test matrix

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "mistraltransformers"]
+        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "transformers_mistral_7b", "hfllama_mistral_7b"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "transformers_mistral_7b", "hfllama_mistral_7b"]
+        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "hfllama_mistral_7b"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "transformers_mistral_7b", "hfllama_mistral_7b"]
+        model:
+          - "gpt2cpu"
+          - "phi2cpu"
+          - "hfllama7b"
+          - "hfllama_mistral_7b"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        model: ["gpt2cpu", "phi2cpu", "hfllama7b"]
+        model: ["gpt2cpu", "phi2cpu", "hfllama7b". "mistraltransformers"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "hfllama_mistral_7b"]
+        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "transformers_mistral_7b", "hfllama_mistral_7b"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        model: ["gpt2cpu", "phi2cpu", "hfllama7b". "mistraltransformers"]
+        model: ["gpt2cpu", "phi2cpu", "hfllama7b", "mistraltransformers"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,6 +17,7 @@ jobs:
         model:
           - "gpt2cpu"
           - "phi2cpu"
+          # - "transformers_mistral_7b" See Issue 713
           - "hfllama7b"
           - "hfllama_mistral_7b"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,9 @@ AVAILABLE_MODELS = {
         name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
         kwargs={"verbose": True},
     ),
+    "mistraltransformers": dict(
+        name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()
+    ),
     "gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
     "phi2gpu": dict(
         name="transformers:microsoft/phi-2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,12 @@ AVAILABLE_MODELS = {
         name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
         kwargs={"verbose": True},
     ),
-    "mistraltransformers": dict(
+    "transformers_mistral_7b": dict(
         name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()
+    ),
+    "hfllama_mistral_7b": dict(
+        name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
+        kwargs={"verbose": True},
     ),
     "gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
     "phi2gpu": dict(

--- a/tests/library/test_gen.py
+++ b/tests/library/test_gen.py
@@ -30,7 +30,7 @@ Step 1''' + gen('steps', list_append=True, stop=['\nStep', '\n\n', '\nAnswer'], 
     i = 2
     lm + f'Step {i}:' + gen('steps', list_append=True, stop=['\nStep', '\n\n', '\nAnswer'], temperature=0.7, max_tokens=20) + '\n'
     assert stop_list_length == len(stop_list)
-    
+
 
 def test_save_stop():
     lm = models.Mock(b"<s>Count to 10: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10")
@@ -160,7 +160,11 @@ def test_various_regexes(selected_model: models.Model, prompt: str, pattern: str
     assert re.match(pattern, lm2["test"], re.DOTALL) is not None
 
 def test_long_prompt(selected_model, selected_model_name):
-    if selected_model_name == "hfllama7b":
+    if selected_model_name in [
+        "hfllama7b",
+        "hfllama_mistral_7b",
+        "transformers_mistral_7b",
+    ]:
         pytest.xfail("Insufficient context window in model")
     lm = selected_model
     prompt = '''Question: Legoland has 5 kangaroos for each koala. If Legoland has 180 kangaroos, how many koalas and kangaroos are there altogether?

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -29,7 +29,7 @@ def test_recursion_error():
 
 TRANSFORMER_MODELS = {
     "gpt2": {},
-    "microsoft/phi-2": {"trust_remote_code": True},
+    # "microsoft/phi-2": {"trust_remote_code": True},
 }
 
 


### PR DESCRIPTION
Since our notebooks feature Mistral, add an example to our test matrix. The Mistral model itself is loaded via llama-cpp. However:

- Due to #713, have to skip loading Mistral via `transformers`
- To avoid running out of disk space on the GitHub runner machines, we have to narrow the testing in `test_transformers.py`