### PR TITLE
[Test] Enable Azure AI notebook

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,6 +13,9 @@ on:
     # * is a special character in YAML so we quote this string
     # Run at 1030 UTC every day
     - cron:  '30 10 * * *'
+  # REMOVE BEFORE MERGE!
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -36,8 +39,6 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         env:
-          # Indicate that secrets should be available
-          EXPECT_SECRETS: 1
           # Configure endpoints
           AZUREAI_CHAT_ENDPOINT: ${{ secrets.AZUREAI_CHAT_ENDPOINT }}
           AZUREAI_CHAT_KEY: ${{ secrets.AZUREAI_CHAT_KEY }}
@@ -46,7 +47,7 @@ jobs:
           AZUREAI_COMPLETION_KEY: ${{ secrets.AZUREAI_COMPLETION_KEY }}
           AZUREAI_COMPLETION_MODEL: ${{ secrets.AZUREAI_COMPLETION_MODEL }}
         run: |
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing ./tests/models/test_azureai_openai.py
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing -m needs_credentials ./tests/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,9 +13,6 @@ on:
     # * is a special character in YAML so we quote this string
     # Run at 1030 UTC every day
     - cron:  '30 10 * * *'
-  # REMOVE BEFORE MERGE!
-  pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -28,12 +28,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install regular dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pytest
           pip install -e .[test]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Install dependencies for tests
+        run: |
+          pip install azure-identity
       - name: Test with pytest
         env:
           # Configure endpoints

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -34,9 +34,6 @@ jobs:
           pip install pytest
           pip install -e .[test]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Install dependencies for tests
-        run: |
-          pip install azure-identity
       - name: Test with pytest
         env:
           # Configure endpoints

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install regular dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pytest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
           pip install llama-cpp-python
       - name: Run tests (except server)
         run: |
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing --selected_model ${{ matrix.model }} -m "not server" ./tests/
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing --selected_model ${{ matrix.model }} -m "not server"  -m "not needs_credentials" ./tests/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/unit_tests_gpu.yml
+++ b/.github/workflows/unit_tests_gpu.yml
@@ -50,7 +50,7 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
       - name: Run tests (except server)
         run: |
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing --selected_model ${{ matrix.model }} -m "not server" ./tests/
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing --selected_model ${{ matrix.model }} -m "not server" -m "not needs_credentials" ./tests/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/notebooks/api_examples/models/AzureOpenAI.ipynb
+++ b/notebooks/api_examples/models/AzureOpenAI.ipynb
@@ -13,6 +13,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "6b887dab",
+   "metadata": {
+    "tags": [
+     "parameters",
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "call_delay_secs = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "61665201-12a8-4588-bb54-801a367c7535",
    "metadata": {},
@@ -107,6 +122,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da5ea477",
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "time.sleep(call_delay_secs)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "7fa274c5-01c6-46f9-a024-b8b44e16ce2c",
    "metadata": {},
@@ -190,6 +221,20 @@
     "    return lm\n",
     "                   \n",
     "azureai_model + experts(query='What is the meaning of life?')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5266819",
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "time.sleep(call_delay_secs)"
    ]
   }
  ],

--- a/notebooks/api_examples/models/AzureOpenAI.ipynb
+++ b/notebooks/api_examples/models/AzureOpenAI.ipynb
@@ -20,7 +20,8 @@
    "source": [
     "import os\n",
     "\n",
-    "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
+    "# Uncomment if using DefaultAzureCredential below\n",
+    "# from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
     "\n",
     "# This is the name of the model deployed, such as 'gpt-4' or 'gpt-3.5-turbo\n",
     "model = os.getenv(\"AZUREAI_CHAT_MODEL\", \"Please set the model\")\n",
@@ -32,10 +33,10 @@
     "api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
     "\n",
     "# Alternatively, we can use Entra authentication\n",
-    "token_provider = get_bearer_token_provider(\n",
-    "     DefaultAzureCredential(),\n",
-    "     \"https://cognitiveservices.azure.com/.default\"\n",
-    ")"
+    "# token_provider = get_bearer_token_provider(\n",
+    "#     DefaultAzureCredential(),\n",
+    "#     \"https://cognitiveservices.azure.com/.default\"\n",
+    "#)"
    ]
   },
   {
@@ -59,9 +60,9 @@
     "    model=model,\n",
     "    azure_endpoint=azure_endpoint,\n",
     "    # For authentication, use either\n",
-    "    #api_key=api_key\n",
+    "    api_key=api_key\n",
     "    # or\n",
-    "    azure_ad_token_provider=token_provider\n",
+    "    # azure_ad_token_provider=token_provider\n",
     ")"
    ]
   },

--- a/notebooks/api_examples/models/AzureOpenAI.ipynb
+++ b/notebooks/api_examples/models/AzureOpenAI.ipynb
@@ -18,7 +18,7 @@
    "metadata": {
     "tags": [
      "parameters",
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -127,7 +127,7 @@
    "id": "da5ea477",
    "metadata": {
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -229,7 +229,7 @@
    "id": "d5266819",
    "metadata": {
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ build-backend = "setuptools.build_meta"
 addopts = "--strict-markers"
 markers = [
     "server: Potentially unreliable tests of the server functionality",
+    "needs_credentials: Test which needs access to credentials to work",
 ]
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,10 +71,11 @@ def selected_model(selected_model_info: str) -> models.Model:
 def rate_limiter() -> int:
     """Limit test execution rate
 
-    This fixture introduces a random delay of up
-    to 10 seconds. It can be used as a crude rate
-    limiter for tests which call external APIs
+    Any test using this fixture will have a
+    random delay inserted before the test runs.
+    It can be used as a crude rate limiter for
+    tests which call external APIs
     """
-    delay_secs = random.randint(5, 20)
+    delay_secs = random.randint(10, 30)
     time.sleep(delay_secs)
     return delay_secs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,10 +42,12 @@ def pytest_addoption(parser):
 def selected_model_name(pytestconfig) -> str:
     return pytestconfig.getoption("selected_model")
 
+
 @pytest.fixture(scope="session")
 def selected_model_info(selected_model_name: str):
     model_info = AVAILABLE_MODELS[selected_model_name]
     return model_info
+
 
 @pytest.fixture(scope="session")
 def selected_model(selected_model_info: str) -> models.Model:
@@ -64,8 +66,9 @@ def selected_model(selected_model_info: str) -> models.Model:
     model = get_model(selected_model_info["name"], **(selected_model_info["kwargs"]))
     return model
 
+
 @pytest.fixture(scope="function")
 def rate_limiter() -> int:
-    delay_secs = random.randint(1,10)
+    delay_secs = random.randint(1, 10)
     time.sleep(delay_secs)
     return delay_secs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,12 @@ def selected_model(selected_model_info: str) -> models.Model:
 
 @pytest.fixture(scope="function")
 def rate_limiter() -> int:
+    """Limit test execution rate
+
+    This fixture introduces a random delay of up
+    to 10 seconds. It can be used as a crude rate
+    limiter for tests which call external APIs
+    """
     delay_secs = random.randint(1, 10)
     time.sleep(delay_secs)
     return delay_secs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import random
+import time
+
 import pytest
 
 from guidance import models
@@ -60,3 +63,9 @@ def selected_model(selected_model_info: str) -> models.Model:
     """
     model = get_model(selected_model_info["name"], **(selected_model_info["kwargs"]))
     return model
+
+@pytest.fixture(scope="function")
+def rate_limiter() -> int:
+    delay_secs = random.randint(1,10)
+    time.sleep(delay_secs)
+    return delay_secs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,6 @@ def rate_limiter() -> int:
     to 10 seconds. It can be used as a crude rate
     limiter for tests which call external APIs
     """
-    delay_secs = random.randint(1, 10)
+    delay_secs = random.randint(5, 20)
     time.sleep(delay_secs)
     return delay_secs

--- a/tests/models/test_azureai_openai.py
+++ b/tests/models/test_azureai_openai.py
@@ -9,6 +9,7 @@ from guidance import models, gen, system, user, assistant
 # Mark is configured in pyproject.toml
 pytestmark = pytest.mark.needs_credentials
 
+
 def _env_or_fail(var_name: str) -> str:
     env_value = os.getenv(var_name, None)
 

--- a/tests/models/test_azureai_openai.py
+++ b/tests/models/test_azureai_openai.py
@@ -17,7 +17,7 @@ def _env_or_fail(var_name: str) -> str:
     return env_value
 
 
-def test_azureai_openai_chat_smoke():
+def test_azureai_openai_chat_smoke(rate_limiter):
     azureai_endpoint = _env_or_fail("AZUREAI_CHAT_ENDPOINT")
     azureai_key = _env_or_fail("AZUREAI_CHAT_KEY")
     model = _env_or_fail("AZUREAI_CHAT_MODEL")
@@ -41,7 +41,7 @@ def test_azureai_openai_chat_smoke():
     assert len(lm["text"]) > 0
 
 
-def test_azureai_openai_completion_smoke():
+def test_azureai_openai_completion_smoke(rate_limiter):
     azureai_endpoint = _env_or_fail("AZUREAI_COMPLETION_ENDPOINT")
     azureai_key = _env_or_fail("AZUREAI_COMPLETION_KEY")
     model = _env_or_fail("AZUREAI_COMPLETION_MODEL")
@@ -56,7 +56,7 @@ def test_azureai_openai_completion_smoke():
     assert len(result["text"]) > 0
 
 
-def test_azureai_openai_chat_loop():
+def test_azureai_openai_chat_loop(rate_limiter):
     azureai_endpoint = _env_or_fail("AZUREAI_CHAT_ENDPOINT")
     azureai_key = _env_or_fail("AZUREAI_CHAT_KEY")
     model = _env_or_fail("AZUREAI_CHAT_MODEL")

--- a/tests/models/test_azureai_openai.py
+++ b/tests/models/test_azureai_openai.py
@@ -5,21 +5,22 @@ import pytest
 from guidance import models, gen, system, user, assistant
 
 
-def _env_or_skip(var_name: str) -> str:
+# Everything in here needs credentials to work
+# Mark is configured in pyproject.toml
+pytestmark = pytest.mark.needs_credentials
+
+def _env_or_fail(var_name: str) -> str:
     env_value = os.getenv(var_name, None)
 
-    if not env_value:
-        if os.getenv("EXPECT_SECRETS", None):
-            raise ValueError(f"Env '{var_name}' not found")
-        else:
-            pytest.skip(f"Did not find required environment variable: {var_name}")
+    assert env_value is not None, f"Env '{var_name}' not found"
+
     return env_value
 
 
 def test_azureai_openai_chat_smoke():
-    azureai_endpoint = _env_or_skip("AZUREAI_CHAT_ENDPOINT")
-    azureai_key = _env_or_skip("AZUREAI_CHAT_KEY")
-    model = _env_or_skip("AZUREAI_CHAT_MODEL")
+    azureai_endpoint = _env_or_fail("AZUREAI_CHAT_ENDPOINT")
+    azureai_key = _env_or_fail("AZUREAI_CHAT_KEY")
+    model = _env_or_fail("AZUREAI_CHAT_MODEL")
 
     lm = models.AzureOpenAI(
         model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
@@ -41,9 +42,9 @@ def test_azureai_openai_chat_smoke():
 
 
 def test_azureai_openai_completion_smoke():
-    azureai_endpoint = _env_or_skip("AZUREAI_COMPLETION_ENDPOINT")
-    azureai_key = _env_or_skip("AZUREAI_COMPLETION_KEY")
-    model = _env_or_skip("AZUREAI_COMPLETION_MODEL")
+    azureai_endpoint = _env_or_fail("AZUREAI_COMPLETION_ENDPOINT")
+    azureai_key = _env_or_fail("AZUREAI_COMPLETION_KEY")
+    model = _env_or_fail("AZUREAI_COMPLETION_MODEL")
 
     lm = models.AzureOpenAI(
         model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
@@ -56,9 +57,9 @@ def test_azureai_openai_completion_smoke():
 
 
 def test_azureai_openai_chat_loop():
-    azureai_endpoint = _env_or_skip("AZUREAI_CHAT_ENDPOINT")
-    azureai_key = _env_or_skip("AZUREAI_CHAT_KEY")
-    model = _env_or_skip("AZUREAI_CHAT_MODEL")
+    azureai_endpoint = _env_or_fail("AZUREAI_CHAT_ENDPOINT")
+    azureai_key = _env_or_fail("AZUREAI_CHAT_KEY")
+    model = _env_or_fail("AZUREAI_CHAT_MODEL")
 
     lm = models.AzureOpenAI(
         model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -29,7 +29,7 @@ class TestTutorials:
 class TestModels:
     BASE_MODEL_PATH = BASE_NB_PATH / "api_examples" / "models"
 
-    @pytest.mark("needs_credentials")
+    @pytest.mark.needs_credentials
     def test_azure_openai(self, rate_limiter):
         nb_path = TestModels.BASE_MODEL_PATH / "AzureOpenAI.ipynb"
         run_notebook(nb_path)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,17 +1,21 @@
 import pathlib
 
+from typing import Any, Dict, Optional
+
 import papermill as pm
 import pytest
 
 BASE_NB_PATH = pathlib.Path("./notebooks").absolute()
 
 
-def run_notebook(notebook_path: pathlib.Path):
+def run_notebook(notebook_path: pathlib.Path, params: Optional[Dict[str, Any]] = None):
     output_nb = notebook_path.stem + ".papermill_out" + notebook_path.suffix
     output_path = TestTutorials.BASE_TUTORIAL_PATH / output_nb
 
     # Just make sure nothing throws an exception
-    pm.execute_notebook(input_path=notebook_path, output_path=output_path)
+    pm.execute_notebook(
+        input_path=notebook_path, output_path=output_path, parameters=params
+    )
 
 
 class TestTutorials:
@@ -32,4 +36,4 @@ class TestModels:
     @pytest.mark.needs_credentials
     def test_azure_openai(self, rate_limiter):
         nb_path = TestModels.BASE_MODEL_PATH / "AzureOpenAI.ipynb"
-        run_notebook(nb_path)
+        run_notebook(nb_path, params=dict(call_delay_secs=rate_limiter))

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import papermill as pm
+import pytest
 
 BASE_NB_PATH = pathlib.Path("./notebooks").absolute()
 
@@ -22,4 +23,13 @@ class TestTutorials:
 
     def test_token_healing(self):
         nb_path = TestTutorials.BASE_TUTORIAL_PATH / "token_healing.ipynb"
+        run_notebook(nb_path)
+
+
+class TestModels:
+    BASE_MODEL_PATH = BASE_NB_PATH / "api_examples" / "models"
+
+    @pytest.mark("needs_credentials")
+    def test_azure_openai(self, rate_limiter):
+        nb_path = TestModels.BASE_MODEL_PATH / "AzureOpenAI.ipynb"
         run_notebook(nb_path)


### PR DESCRIPTION
Start running the Azure AI notebook in tests. This is causing a rethink of some of the testing infrastructure, to add a new `needs_credentials` tag for selecting tests which require API keys and the like.

A fixture for rate limiting is also required, since otherwise we overwhelm our endpoints.