### PR TITLE
Add support for `prefixItems`, `minItems`, and `maxItems` for `JSON` array generation

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -127,14 +127,18 @@ def _gen_json_array(
         prefix_items_schema = []
 
     if len(prefix_items_schema) < min_items and item_schema is None:
-        raise ValueError(f"Not enough prefixItems ({len(prefix_items_schema)}) to satisfy minItems ({min_items})")
+        raise ValueError(
+            "No items schema provided, but prefixItems has too few elements "
+            f"({len(prefix_items_schema)}) to satisfy minItems ({min_items})"
+        )
 
     if max_items is not None and max_items < min_items:
-        raise ValueError(f"maxItems ({max_items}) can't be greater than minItems ({min_items})")
+        raise ValueError(f"maxItems ({max_items}) can't be less than minItems ({min_items})")
 
     required_items = []
     optional_items = []
 
+    # If max_items is None, we can add an infinite tail of items later
     n_to_add = max(len(prefix_items_schema), min_items) if max_items is None else max_items
     for i in range(n_to_add):
         if i < len(prefix_items_schema):

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -164,8 +164,9 @@ def _gen_json_array(
             lm += ',' + item
 
     if optional_items:
-        # This is a bit subtle and would not be required if not for prefixItems.
-        # This essentially produces (first optional(,second optional(,third (optional(,...)))))
+        # This is a bit subtle and would not be required if not for prefixItems -- the previous
+        # must be present before the next one may be added, meaning we have nested optionals:
+        # (first optional(,second optional(,third (optional(,...)))))
         first, *rest = optional_items
         tail = ''
         for item in reversed(rest):

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -117,6 +117,8 @@ def _gen_json_array(
     *,
     prefix_items_schema: Optional[Sequence[Mapping[str, Any]]],
     item_schema: Optional[Mapping[str, Any]],
+    min_items: Optional[int],
+    max_items: Optional[int],
     definitions: Mapping[str, Callable[[], GrammarFunction]],
 ):
     lm += "["
@@ -226,7 +228,9 @@ def _gen_json(
             return lm + _gen_json_array(
                 prefix_items_schema=json_schema.get("prefixItems"),
                 item_schema=json_schema.get("items"),
-                definitions=definitions
+                min_items=json_schema.get("minItems"),
+                max_items=json_schema.get("maxItems"),
+                definitions=definitions,
             )
         if target_type == "object":
             return lm + _gen_json_object(

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -373,14 +373,15 @@ class TestArrayWithLengthConstraints:
     @pytest.mark.parametrize(
         "min_items, max_items, target_obj",
         [
-            (0, 2, []),  # Empty array, within min and max bounds.
-            (0, 1, [42]),  # Array with one prefix item, within min and max bounds
-            (1, 2, [42, True]),  # Array with all prefix items, no extra items.
-            (0, 3, [42, True, "hello"]),  # Array with prefix items followed by item matching 'items' schema.
-            (3, 4, [42, True, "hello"]),  # Min and prefix items satisfied, one item matches 'items' schema.
-            (3, 4, [42, True, "hello", "world"]),  # Max items with prefix items and additional items.
-            (5, 5, [42, True, "hello", "world", "test"]),  # Array exactly meets minItems and maxItems.
-            (0, 10, [42, True] + ["extra"] * 8),  # Prefix items followed by a large number of items.
+            (0, 0, []), # None allowed, none provided
+            (0, 1, []), # Some prefixItems allowed, none provided
+            (0, 1, [42]), # Some prefixItems allowed, one provided
+            (1, 2, [42, True]),  # All prefix items, no extra items allowed or provided.
+            (1, 3, [42, True]),  # All prefix items, some extra items allowed but not provided.
+            (0, 3, [42, True, "hello"]),  # All prefix items and one extra item
+            (3, 4, [42, True, "hello"]),  # All prefix items and one extra item but more allowed
+            (5, 5, [42, True, "hello", "world", "test"]),  # Exactly meets minItems and maxItems.
+            (0, 10, [42, True] + ["extra"] * 8),  # Exactly meet large number of extra items
         ]
     )
     def test_good_with_prefix_and_items(self, min_items, max_items, target_obj):
@@ -396,8 +397,12 @@ class TestArrayWithLengthConstraints:
     @pytest.mark.parametrize(
         "min_items, max_items, target_obj",
         [
-            (1, 3, [42]),  # Single prefix item
-            (1, 3, [42, True]),  # All prefix items satisfied, no extra items
+            (0, 0, []), # None allowed, none provided
+            (0, 2, []), # Some allowed, none provided
+            (1, 2, [42, True]), # All prefix items, no extra allowed
+            (2, 2, [42, True]), # Exactly match min, max
+            (1, 3, [42]),  # Single prefix item, extra allowed
+            (1, 3, [42, True]), # All prefix items, extra allowed
         ]
     )
     def test_good_with_prefix(self, min_items, max_items, target_obj):
@@ -412,8 +417,11 @@ class TestArrayWithLengthConstraints:
     @pytest.mark.parametrize(
         "min_items, max_items, target_obj",
         [
-            (1, 2, ["hello"]),  # Single item array, matching 'items' schema.
-            (1, 2, ["hello", "world"]),  # Two items array, both matching 'items' schema.
+            (0, 0, []), # None allowed, none provided
+            (0, 2, []), # Some allowed, none provided
+            (1, 2, ["hello"]),  # Single item, more allowed
+            (1, 2, ["hello", "world"]),  # Meet max
+            (3, 3, ["hello", "world", "extra"]), # Exactly match min, max
             (0, 8, ["extra"]*8),  # Large number of items
         ]
     )

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -456,6 +456,7 @@ class TestArrayWithLengthConstraints:
             (1, 2, [42, "not_bool"], b'"'),  # Second item violates prefixItems type requirement
             (0, 1, [42, True], b","),  # Array exceeds maxItems with valid prefixItems types
             (1, 5, [42, True, "extra"], b","),  # Item beyond prefixItems with no "items" schema
+            (0, 0, [42], b"4"),  # maxItems set to 0, but array is not empty
         ]
     )
     def test_bad_with_prefix(self, min_items, max_items, bad_obj, failure_byte):
@@ -474,6 +475,7 @@ class TestArrayWithLengthConstraints:
             (1, 2, ["hello", "world", "extra"], b","),  # Too many items for maxItems
             (2, 3, ["hello"], b"]"),  # Not enough items
             (2, 3, ["hello", 42], b"4"),  # Badly typed second item
+            (0, 0, ["hello"], b'"'),  # maxItems set to 0, but array is not empty
         ]
     )
     def test_bad_with_items(self, min_items, max_items, bad_obj, failure_byte):


### PR DESCRIPTION
Resolves issue https://github.com/guidance-ai/guidance/issues/731.

I tried to be as comprehensive with tests as I could, but there are a LOT of cases to cover.

Tag @riedgar-ms 