### PR TITLE
replace catches of the ImportError exception with the more specific ModuleNotFoundError exception

### DIFF
--- a/guidance/models/_anthropic.py
+++ b/guidance/models/_anthropic.py
@@ -8,7 +8,7 @@ class AnthropicEngine(GrammarlessEngine):
     def __init__(self, model, tokenizer, api_key, timeout, max_streaming_tokens, compute_log_probs, **kwargs):        
         try:
             from anthropic import Anthropic
-        except ImportError:
+        except ModuleNotFoundError:
             raise Exception("Please install the anthropic package version >= 0.7 using `pip install anthropic -U` in order to use guidance.models.Anthropic!")
         
         # if we are called directly (as opposed to through super()) then we convert ourselves to a more specific subclass if possible

--- a/guidance/models/_azure_openai.py
+++ b/guidance/models/_azure_openai.py
@@ -9,11 +9,9 @@ from ._openai import (
 )
 
 try:
-    # TODO: can we eliminate the torch requirement for llama.cpp by using numpy in the caller instead?
     import openai as openai_package
-
     is_openai = True
-except ImportError:
+except ModuleNotFoundError:
     is_openai = False
 
 

--- a/guidance/models/_cohere.py
+++ b/guidance/models/_cohere.py
@@ -5,7 +5,7 @@ class Cohere(LiteLLM):
         '''Build a new Anthropic model object that represents a model in a given state.'''
         try:
             import tokenizers
-        except ImportError:
+        except ModuleNotFoundError:
             raise Exception("Please install the HuggingFace tokenizers package using `pip install tokenizers -U` in order to use guidance.models.Cohere!")
 
         # get the tokenizer

--- a/guidance/models/_googleai.py
+++ b/guidance/models/_googleai.py
@@ -10,7 +10,7 @@ class GoogleAIEngine(GrammarlessEngine):
     def __init__(self, model, tokenizer, api_key, max_streaming_tokens, timeout, compute_log_probs, **kwargs):
         try:
             import google.generativeai as genai
-        except ImportError:
+        except ModuleNotFoundError:
             raise Exception("Please install the Google AI Studio(makersuite.google.com) package using `pip install google-generativeai google-ai-generativelanguage` in order to use guidance.models.GoogleAI!")
 
         assert not compute_log_probs, "We don't support compute_log_probs=True yet for GoogleAIEngine!"

--- a/guidance/models/_lite_llm.py
+++ b/guidance/models/_lite_llm.py
@@ -7,7 +7,7 @@ class LiteLLMEngine(GrammarlessEngine):
     def __init__(self, model, tokenizer, timeout, compute_log_probs, max_streaming_tokens, **kwargs):
         try:
             import litellm
-        except ImportError:
+        except ModuleNotFoundError:
             raise Exception("Please install the litellm package version >= 1.7 using `pip install litellm -U` in order to use guidance.models.LiteLLM!")
         
         self.litellm = litellm

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1,12 +1,12 @@
 try:
     from IPython.display import clear_output, display, HTML
-except ImportError:
+except ModuleNotFoundError:
     clear_output = lambda wait=True: None
     display = lambda arg: None
     HTML = lambda arg: None
 try:
     import torch
-except ImportError:
+except ModuleNotFoundError:
     torch = None
 import html
 import re

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -19,7 +19,7 @@ from ._grammarless import GrammarlessEngine, Grammarless
 try:
     import openai as openai_package
     is_openai = True
-except ImportError:
+except ModuleNotFoundError:
     is_openai = False
 
 chat_model_pattern = r'^(ft:)?(gpt-3\.5-turbo|gpt-4)(?:(?!-instruct$)(-\w+)+)?(:[\w-]+(?:[:\w-]+)*)?(::\w+)?$'

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -13,7 +13,7 @@ from ..._utils import normalize_notebook_stdout_stderr
 try:
     import llama_cpp
     is_llama_cpp = True
-except ImportError:
+except ModuleNotFoundError:
     is_llama_cpp = False
 
 logger = logging.getLogger(__name__)

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -2,7 +2,7 @@ import os
 
 try:
     import torch
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 from .._model import Tokenizer, Engine, Model, Chat

--- a/guidance/models/vertexai/_Codey.py
+++ b/guidance/models/vertexai/_Codey.py
@@ -5,7 +5,7 @@ from ._vertexai import VertexAICompletion, VertexAIInstruct, VertexAIChat
 try:
     from vertexai.language_models import CodeGenerationModel, CodeChatModel
     is_vertexai = True
-except ImportError:
+except ModuleNotFoundError:
     is_vertexai = False
 
 class CodeyCompletion(VertexAICompletion):

--- a/guidance/models/vertexai/_Gemini.py
+++ b/guidance/models/vertexai/_Gemini.py
@@ -29,7 +29,7 @@ try:
     # print(get_chat_response("What are all the colors in a rainbow?"))
     # print(get_chat_response("Why does it appear when it rains?"))
     is_vertexai = True
-except ImportError:
+except ModuleNotFoundError:
     is_vertexai = False
 
 # class GeminiCompletion(VertexAICompletion):

--- a/guidance/models/vertexai/_PaLM2.py
+++ b/guidance/models/vertexai/_PaLM2.py
@@ -14,7 +14,7 @@ from ._vertexai import VertexAICompletion, VertexAIInstruct, VertexAIChat
 try:
     from vertexai.language_models import TextGenerationModel, ChatModel, InputOutputTextPair
     is_vertexai = True
-except ImportError:
+except ModuleNotFoundError:
     is_vertexai = False
 
 class PaLM2Completion(VertexAICompletion):

--- a/guidance/models/vertexai/_vertexai.py
+++ b/guidance/models/vertexai/_vertexai.py
@@ -5,7 +5,7 @@ from .._grammarless import GrammarlessEngine, Grammarless
 try:
     import vertexai
     is_vertexai = True
-except ImportError:
+except ModuleNotFoundError:
     is_vertexai = False
 
 class VertexAIEngine(GrammarlessEngine):


### PR DESCRIPTION
This should partly address https://github.com/guidance-ai/guidance/issues/690 where it appears the import of llama-cpp is generating an ImportError exception that is not due to the module not being installed.  This more specific exception will only catch the specific case of the Module not being installed and will leave other exceptions to propagate to the user with more descriptive errors.