### PR TITLE
fix for issue #660 where the call to llama_batch_free is failing during process shutdown

### DIFF
--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -1,4 +1,5 @@
 import os
+import atexit
 from pathlib import Path
 from itertools import takewhile
 import operator
@@ -18,6 +19,13 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+shutdown_none = True
+def set_shutdown_flag():
+    global shutdown_none
+    # python can set anything to None at shutdown, so use None
+    shutdown_none = None 
+atexit.register(set_shutdown_flag)
+
 class _LlamaBatchContext:
     def __init__(self, n_batch, n_ctx):
         self._llama_batch_free = llama_cpp.llama_batch_free
@@ -26,12 +34,13 @@ class _LlamaBatchContext:
             raise Exception("call to llama_cpp.llama_batch_init returned NULL.")
 
     def __del__(self):
-        llama_batch_free = getattr(self, "_llama_batch_free", None)
-        batch = getattr(self, "batch", None)
-        if batch is not None and llama_batch_free is not None:
-            self._llama_batch_free = None
-            self.batch = None
-            llama_batch_free(batch)
+        if shutdown_none is not None:
+            llama_batch_free = getattr(self, "_llama_batch_free", None)
+            batch = getattr(self, "batch", None)
+            if batch is not None and llama_batch_free is not None:
+                self._llama_batch_free = None
+                self.batch = None
+                llama_batch_free(batch)
 
 class LlamaCppTokenizer(Tokenizer):
     def __init__(self, model_obj):


### PR DESCRIPTION
llama_batch_free is failing during python shutdown when the interpreter can set objects to None non-deterministically.  I believe Guidance is properly checking for None in the objects that can be accessed from Guidance, but llama-cpp-python is not, and the native library object in llama-cpp-python is being set to None before it can be called.  Since we're only dealing with memory deallocation here, and since the process is being killed anyway, we can solve this on the Guidance side by not calling llama_batch_free during process termination.