### PR TITLE
[Test] Expand testing of substring()

### DIFF
--- a/guidance/library/_substring.py
+++ b/guidance/library/_substring.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import guidance
 # from ._prefix_tree import prefix_tree
 from .._grammar import string, select
@@ -83,8 +85,8 @@ class SuffixAutomaton:
         self.last = cur
 
 @guidance(stateless=True, dedent=False)
-def substring(lm, s):
-    suffix_automaton = SuffixAutomaton(s)
+def substring(lm, target_string: str, name: Optional[str] = None):
+    suffix_automaton = SuffixAutomaton(target_string)
     node_cache = {}
     state_stack = [0]  # Start with the initial state index (0) on the stack
 
@@ -115,7 +117,7 @@ def substring(lm, s):
             node_cache[state_ind] = optional(select(options, skip_checks=True)) if len(options) > 1 else optional(options[0])
             state_stack.pop()
 
-    return lm + node_cache[0]
+    return lm + guidance.capture(node_cache[0], name=name)
 
 # @guidance(stateless=True, dedent=False)
 # def substring(s):

--- a/tests/library/test_substring.py
+++ b/tests/library/test_substring.py
@@ -1,8 +1,35 @@
-from guidance import gen, substring
+import pytest
+
+from guidance import gen, models, substring
 
 
 def test_substring_equal_unconstrained(selected_model):
     target_model = selected_model
     lm = target_model + "ae galera " + gen(max_tokens=10, name="test")
-    lm2 = target_model + "ae galera " + substring(lm["test"])
+    lm2 = target_model + "ae galera " + substring(lm["test"], name="capture")
+    assert lm2["capture"] in lm["test"]
     assert str(lm) == str(lm2)
+
+
+@pytest.mark.parametrize(
+    ("mock_string", "target_string", "expected_string"),
+    [
+        ("abc", "abc", "abc"),
+        ("ab", "abc", "ab"),
+        ("bc", "abc", "bc"),
+        ("a", "abc", "a"),
+        ("b", "abc", "b"),
+        ("c", "abc", "c"),
+        ("abc", "def", ""),  # This is a 'failure' case
+        (
+            "long string",
+            "This is long string, only take part of this long string",
+            "long string",
+        ),
+    ],
+)
+def test_mocked_substring(mock_string, target_string, expected_string):
+    m = models.Mock(f"<s>{mock_string}")
+
+    lm = m + substring(target_string, name="result")
+    assert lm["result"] == expected_string

--- a/tests/library/test_substring.py
+++ b/tests/library/test_substring.py
@@ -3,8 +3,8 @@ from guidance import gen, models, commit_point, Tool, select, capture, string, s
 from ..utils import get_model
 import re
 
-def test_substring_equal_unconstrained():
-    llama2 = get_model("llama_cpp:")
-    lm = llama2 + 'ae galera ' + gen(max_tokens=10, name='test')
-    lm2 = llama2 + 'ae galera ' + substring(lm['test'])
+def test_substring_equal_unconstrained(selected_model):
+    target_model = selected_model
+    lm = target_model + 'ae galera ' + gen(max_tokens=10, name='test')
+    lm2 = target_model + 'ae galera ' + substring(lm['test'])
     assert str(lm) == str(lm2)

--- a/tests/library/test_substring.py
+++ b/tests/library/test_substring.py
@@ -8,7 +8,6 @@ def test_substring_equal_unconstrained(selected_model):
     lm = target_model + "ae galera " + gen(max_tokens=10, name="test")
     lm2 = target_model + "ae galera " + substring(lm["test"], name="capture")
     assert lm2["capture"] in lm["test"]
-    assert str(lm) == str(lm2)
 
 
 @pytest.mark.parametrize(

--- a/tests/library/test_substring.py
+++ b/tests/library/test_substring.py
@@ -1,10 +1,8 @@
-import guidance
-from guidance import gen, models, commit_point, Tool, select, capture, string, substring
-from ..utils import get_model
-import re
+from guidance import gen, substring
+
 
 def test_substring_equal_unconstrained(selected_model):
     target_model = selected_model
-    lm = target_model + 'ae galera ' + gen(max_tokens=10, name='test')
-    lm2 = target_model + 'ae galera ' + substring(lm['test'])
+    lm = target_model + "ae galera " + gen(max_tokens=10, name="test")
+    lm2 = target_model + "ae galera " + substring(lm["test"])
     assert str(lm) == str(lm2)


### PR DESCRIPTION
The `substring()` function wasn't being tested in the builds. Make the following changes:

- Add a `name` argument to `substring()` so we can extract the parts we need
- Tweak the existing test, so that it is not skipped
- Add several tests using the `Mock` which should capture the various automaton states in `substring()`