### PR TITLE
Offer one suite of workflows on any pr, and another just on approval.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Protect the github workflows by assigning code owners to the .github folder.
+/.github/ @riedgar-ms @paulbkoch @Harsha-Nori

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -6,8 +6,8 @@ name: CI Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  pull_request_review:
+    types: [submitted, edited]
   schedule:
     # * is a special character in YAML so we quote this string
     # Run at 1030 UTC every day
@@ -15,12 +15,11 @@ on:
 
 jobs:
   build:
-
     runs-on: gpu-runner
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
           # - "transformers_mistral_7b" See Issue 713
           - "hfllama7b"
           - "hfllama_mistral_7b"
-
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests_gpu.yml
+++ b/.github/workflows/unit_tests_gpu.yml
@@ -1,11 +1,9 @@
 name: Unit tests GPU
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  pull_request_review:
+    types: [submitted, edited]
 
 jobs:
   unit-tests:
@@ -15,7 +13,7 @@ jobs:
         os: [gpu-runner]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         model: ["gpt2gpu", "phi2gpu", "hfllama_7b_gpu"]
-
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests_minimal.yml
+++ b/.github/workflows/unit_tests_minimal.yml
@@ -1,8 +1,10 @@
-name: Unit tests
+name: Unit Tests Minimal
 
 on:
-  pull_request_review:
-    types: [submitted, edited]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -10,14 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.12"]
         model:
           - "gpt2cpu"
-          - "phi2cpu"
-          # - "transformers_mistral_7b" See Issue 713
-          - "hfllama7b"
-          - "hfllama_mistral_7b"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests_minimal.yml
+++ b/.github/workflows/unit_tests_minimal.yml
@@ -13,9 +13,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         model:
           - "gpt2cpu"
+          - "phi2cpu"
+          # - "transformers_mistral_7b" See Issue 713
+          - "hfllama7b"
+          - "hfllama_mistral_7b"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Upon merging this, be sure to enable "Dismiss stale approvals when new commits are pushed". This will allow you to re-approve prs, triggering re-run of workflows, if there is a new commit.