### PR TITLE
[WIP?] Trying to fix Transformers tokenizer issues when models have extended vocabulary and/or special tokens

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -15,9 +15,10 @@ class TransformersTokenizer(Tokenizer):
             tokenizer = self._tokenizer(model)
 
         self._orig_tokenizer = tokenizer
+        special_tokens_map = {id:token for token, id in tokenizer.get_added_vocab().items()}
 
         # build out the set of byte_string tokens
-        byte_tokens = []
+        byte_tokens = [None] * len(tokenizer)
         if hasattr(tokenizer, "byte_decoder"):
             byte_decoder = tokenizer.byte_decoder
 
@@ -25,17 +26,20 @@ class TransformersTokenizer(Tokenizer):
                 byte_coded = bytes(
                     [byte_decoder[c] for c in tokenizer.convert_ids_to_tokens(i)]
                 )
-                byte_tokens.append(byte_coded)
+                byte_tokens[i] = byte_coded
 
         elif hasattr(tokenizer, "sp_model"):
             space_prefix = "▁".encode()
             for i in range(len(tokenizer)):
-                byte_coded = re.sub(
-                    rb"<0x(..)>",
-                    lambda x: bytes.fromhex(x[1].decode()),
-                    tokenizer.sp_model.id_to_piece(i).encode(),
-                )
-                byte_tokens.append(byte_coded.replace(space_prefix, b" "))
+                if i in special_tokens_map:
+                    byte_coded = special_tokens_map[i].encode()
+                else:
+                    byte_coded = re.sub(
+                        rb"<0x(..)>",
+                        lambda x: bytes.fromhex(x[1].decode()),
+                        tokenizer.sp_model.id_to_piece(i).encode(),
+                    )
+                byte_tokens[i] = byte_coded.replace(space_prefix, b" ")
 
         else:
             import transformers

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -71,7 +71,7 @@ class TransformersTokenizer(Tokenizer):
                 byte_coded = bytes(
                     [byte_decoder[c] for c in tokenizer.convert_ids_to_tokens(i)]
                 )
-                byte_tokens.append(byte_coded)
+                byte_tokens[i] = byte_coded
 
         # the superclass does most of the work once we have the tokens
         super().__init__(

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -15,7 +15,9 @@ class TransformersTokenizer(Tokenizer):
             tokenizer = self._tokenizer(model)
 
         self._orig_tokenizer = tokenizer
-        special_tokens_map = {id:token for token, id in tokenizer.get_added_vocab().items()}
+        special_tokens_map = {
+            id: token for token, id in tokenizer.get_added_vocab().items()
+        }
 
         # build out the set of byte_string tokens
         byte_tokens = [None] * len(tokenizer)


### PR DESCRIPTION
Looping over `len(tokenizer)` causes issues when we have to fallback to an underlying sentencepiece model, as the `tokenizer.sp_model` doesn't have context for the extended vocabulary.  I think this is part of the puzzle to solve some persistent issues like https://github.com/guidance-ai/guidance/issues/434?

This is probably broken right now, need to fix up

