### PR TITLE
Update _llama_cpp.py based on new contract of llama_get_logits

### DIFF
--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -198,7 +198,6 @@ class LlamaCppEngine(Engine):
 
         # get the logits
         logits = llama_cpp.llama_get_logits(self.model_obj.ctx)
-        logits = logits[(n_tokens - 1) * self._n_vocab : n_tokens * self._n_vocab]
         logits = np.ctypeslib.as_array(logits, shape=(self._n_vocab,)).copy()
 
         self._cached_logits = logits

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -198,6 +198,8 @@ class LlamaCppEngine(Engine):
 
         # get the logits
         logits = llama_cpp.llama_get_logits(self.model_obj.ctx)
+        if llama_cpp.__version__ < "0.2.58":
+            logits = logits[(n_tokens - 1) * self._n_vocab : n_tokens * self._n_vocab]
         logits = np.ctypeslib.as_array(logits, shape=(self._n_vocab,)).copy()
 
         self._cached_logits = logits


### PR DESCRIPTION
The new documentation for llama_get_logits is:

    // Token logits obtained from the last call to llama_decode()
    // The logits for which llama_batch.logits[i] != 0 are stored contiguously
    // in the order they have appeared in the batch.
    // Rows: number of tokens for which llama_batch.logits[i] != 0
    // Cols: n_vocab
    LLAMA_API float * llama_get_logits(struct llama_context * ctx);

Since we set llama_batch.logits[i] to true only for the last token, llama_get_logits already returns only the desired slice.