### PR TITLE
fix bug when resuming generation with OpenAI models

### DIFF
--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -257,6 +257,9 @@ class OpenAIChatEngine(OpenAIEngine):
                         assert (
                             role_name == "assistant"
                         ), "Bad chat format! Last role before gen needs to be assistant!"
+                        btext = prompt[pos:]
+                        pos = len(prompt)
+                        messages.append({"role": role_name, "content": btext.decode("utf8")})
                         break
                     btext = prompt[pos : pos + end_pos]
                     pos += end_pos + len(role_end)


### PR DESCRIPTION
I've come across what I think must be a bug when resuming generation with OpenAI models, i.e., letting a model complete a partial response. Without the fix in this pull request, the partial response is discarded, which is likely not the intended behaviour and can also lead to a raised Exception a little further down the line. With the fix, everything works fine for me, i.e., any partial response is included in the OpenAI API request and the model can successfully complete the partial response.