### PR TITLE
[Feature] Improved JSON Schema support

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -247,6 +247,13 @@ def _gen_json(
             anyof_list=json_schema[ANYOF_STRING], definitions=definitions
         )
 
+    ALLOF_STRING = "allOf"
+    if ALLOF_STRING in json_schema:
+        allof_list = json_schema[ALLOF_STRING]
+        if len(allof_list) != 1:
+            raise ValueError("Only support allOf with exactly one item")
+        return lm + _gen_json(allof_list[0], definitions)
+
     REF_STRING = "$ref"
     if REF_STRING in json_schema:
         return lm + _get_definition(

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -807,6 +807,44 @@ class TestAllOf:
         # The actual check
         _generate_and_check(my_int, schema_obj)
 
+    def test_allOf_ref(self):
+        schema = """{
+            "definitions": {
+                "Cat": {
+                    "properties": {
+                        "name": {
+                            "title": "Name",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "title": "Cat",
+                    "type": "object"
+                }
+            },
+            "type": "object",
+            "properties": {
+                "my_cat": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Cat"
+                        }
+                    ]
+                }
+            }
+        }
+        """
+
+        target_obj = dict(my_cat=dict(name="Sampson"))
+        # First sanity check what we're setting up
+        schema_obj = json.loads(schema)
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        _generate_and_check(target_obj, schema_obj)
+
 
 class TestEnum:
     simple_schema = """{

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -845,6 +845,26 @@ class TestAllOf:
         # The actual check
         _generate_and_check(target_obj, schema_obj)
 
+    def test_allOf_bad_schema(self):
+        schema = """{
+        "allOf" : [{ "type": "integer" }, { "type": "number" }]
+        }
+        """
+        # First sanity check what we're setting up
+        schema_obj = json.loads(schema)
+
+        TARGET_VALUE = 20
+        validate(instance=TARGET_VALUE, schema=schema_obj)
+
+        prepared_string = f"<s>{_to_compact_json(TARGET_VALUE)}"
+        lm = models.Mock(prepared_string.encode())
+
+        # Run with the mock model
+        CAPTURE_KEY = "my_capture"
+        with pytest.raises(ValueError) as ve:
+            lm += gen_json(name=CAPTURE_KEY, schema=schema_obj)
+        assert ve.value.args[0] == "Only support allOf with exactly one item"
+
 
 class TestEnum:
     simple_schema = """{

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -606,6 +606,55 @@ class TestWithReferences:
         # The actual check
         _generate_and_check(target_obj, schema_obj)
 
+    @pytest.mark.parametrize(
+        "target_obj",
+        [
+            dict(all_cats=[]),
+            dict(all_cats=[dict(name="Kasha")]),
+            dict(all_cats=[dict(name="Dawon"), dict(name="Barong")]),
+        ],
+    )
+    def test_simple_ref_alt(self, target_obj):
+        # Uses 'definitions' rather than '$defs'
+        schema = """{
+        "definitions": {
+            "Cat": {
+            "properties": {
+                "name": {
+                "title": "Name",
+                "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "title": "Cat",
+            "type": "object"
+            }
+        },
+        "properties": {
+            "all_cats": {
+            "items": {
+                "$ref": "#/definitions/Cat"
+            },
+            "title": "All Cats",
+            "type": "array"
+            }
+        },
+        "required": [
+            "all_cats"
+        ],
+        "title": "CatList",
+        "type": "object"
+        }"""
+
+        # First sanity check what we're setting up
+        schema_obj = json.loads(schema)
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        _generate_and_check(target_obj, schema_obj)
+
     def test_nested_ref(self):
         schema = """{
         "$defs": {

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -790,6 +790,24 @@ class TestAnyOf:
         _generate_and_check(target_obj, schema_obj)
 
 
+class TestAllOf:
+    @pytest.mark.parametrize(
+        "my_int",
+        [0, 1, 100, 9876543210, 99, 737, 858, -1, -10, -20],
+    )
+    def test_allOf_integer(self, my_int):
+        schema = """{
+        "allOf" : [{ "type": "integer" }]
+        }
+        """
+        # First sanity check what we're setting up
+        schema_obj = json.loads(schema)
+        validate(instance=my_int, schema=schema_obj)
+
+        # The actual check
+        _generate_and_check(my_int, schema_obj)
+
+
 class TestEnum:
     simple_schema = """{
         "enum": [1,"2",false]


### PR DESCRIPTION
Add some extra support for JSON schema, to work better with the `langchain` examples:

- Allow definitions to be given in a `definitions` key, as well ad `$defs`
- Allow for single-entry `allOf` blocks