### PR TITLE
Fix models like phi-3 which have a mismatched tokenizer definition and model output tensor size

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -262,7 +262,9 @@ class TransformersEngine(Engine):
             self._past_key_values = model_out.past_key_values
             cache_token_ids.extend(new_token_ids)
             # Need to add special truncating logic here for weird models that have a different output size than tokenizer vocab
-            self._cached_logits = model_out.logits[0, -1, :len(self.tokenizer.tokens)].cpu().numpy()
+            self._cached_logits = (
+                model_out.logits[0, -1, : len(self.tokenizer.tokens)].cpu().numpy()
+            )
 
         return self._cached_logits
 

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -261,7 +261,8 @@ class TransformersEngine(Engine):
             # save the results
             self._past_key_values = model_out.past_key_values
             cache_token_ids.extend(new_token_ids)
-            self._cached_logits = model_out.logits[0, -1, :].cpu().numpy()
+            # Need to add special truncating logic here for weird models that have a different output size than tokenizer vocab
+            self._cached_logits = model_out.logits[0, -1, :len(self.tokenizer.tokens)].cpu().numpy()
 
         return self._cached_logits
 


### PR DESCRIPTION
The Phi-3 Mini models (e.g. https://huggingface.co/microsoft/Phi-3-mini-4k-instruct) have a total tokenizer vocab size of 32011 (base 32000 plus 11 special tokens), but the model outputs logit vectors of size 32064 (for CUDA performance reasons maybe?). 

I _think_ models that use this trick will always have the "padded" model output at the end, which makes this PR a very clean and simple change to guarantee tokenizer <> model output consistency. This fix will NOT work if the padded outputs are either in the beginning or interspersed throughout the token vector, but I haven't seen a model do that yet. If models do start doing that, we'll need to make significantly heavier changes across the guidance codebase, as we currently heavily rely on the len(tokenizer) to be usable for iteration.