### PR TITLE
[Test] Don't fail fast on CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -18,6 +18,7 @@ jobs:
 
     runs-on: gpu-runner
     strategy:
+      fail-fast: false # Don't cancel all on first failure
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 


### PR DESCRIPTION
Our CI tests are a little flaky, so don't use `fail-fast`. The chances are that some will succeed, so it's best to let the others continue.