### PR TITLE
Add guard for running build from setup.py, redirecting users to pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
             "Please use 'pip' to build and install this package, like so:\n"
             "  pip install . (for the current directory)\n"
             "  pip install -e . (for an editable install)\n"
-            "  pip wheel . (to build a wheel)"
+            "  pip wheel . --no-deps (to build a wheel)"
         )
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,17 @@
+import sys
+
+# Check if 'setup.py' is run directly with 'build'
+# TODO: Consider generalizing this check further?
+if __name__ == "__main__":
+    if len(sys.argv) >= 2 and sys.argv[1] == 'build':
+        raise SystemExit(
+            "Error: Direct invocation of 'setup.py build' is not recommended."
+            "Please use 'pip' to build and install this package, like so:\n"
+            "  pip install . (for the current directory)\n"
+            "  pip install -e . (for an editable install)\n"
+            "  pip wheel . (to build a wheel)"
+        )
+    
 import os
 import re
 import codecs

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 # Check if 'setup.py' is run directly with 'build'
 # TODO: Consider generalizing this check further?
 if __name__ == "__main__":
-    if len(sys.argv) >= 2 and sys.argv[1] == 'build':
+    if len(sys.argv) >= 2 and sys.argv[1] == "build":
         raise SystemExit(
             "Error: Direct invocation of 'setup.py build' is not recommended."
             "Please use 'pip' to build and install this package, like so:\n"
@@ -11,7 +11,7 @@ if __name__ == "__main__":
             "  pip install -e . (for an editable install)\n"
             "  pip wheel . (to build a wheel)"
         )
-    
+
 import os
 import re
 import codecs


### PR DESCRIPTION
Resolves https://github.com/guidance-ai/guidance/issues/801 . I thought we could use lazy imports and `setup_requires` to get `python setup.py build`, but I kept running into challenges with guaranteeing an install of `PyBind11` and `setuptools_rust` ahead of executing the code. 

Pointing users to `pip` based systems is more robust, especially since we already have a `pyproject.toml` file. 