### PR TITLE
[Deploy] Updating deployment workflow

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -20,15 +20,17 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install cibuildwheel
       # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.14.0
+        run: pipx install cibuildwheel==2.17.0
       - id: set-matrix
         run: |
           MATRIX=$(
             {
               cibuildwheel --print-build-identifiers --platform linux --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --archs x86_64,arm64 \
+              && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "macos-12"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --archs arm64 \
+              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
               # && cibuildwheel --print-build-identifiers --platform windows \
               # | jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install cibuildwheel
       # Nb. keep cibuildwheel version pin consistent with job below
         run: pipx install cibuildwheel==2.17.0
@@ -72,7 +72,7 @@ jobs:
         with:
           only: ${{ matrix.only }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: bdist_files
@@ -106,7 +106,7 @@ jobs:
           python -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist_files
           path: dist/*.tar.gz

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           MATRIX=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux \
+              cibuildwheel --print-build-identifiers --platform linux --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos \
               | jq -nRc '{"only": inputs, "os": "macos-12"}' \
-              # && cibuildwheel --print-build-identifiers --platform windows \
+              # && cibuildwheel --print-build-identifiers --platform windows  --archs x86_64 \
               # | jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -68,7 +68,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.14.0
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           only: ${{ matrix.only }}
 

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -27,10 +27,10 @@ jobs:
             {
               cibuildwheel --print-build-identifiers --platform linux --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos \
+              && cibuildwheel --print-build-identifiers --platform macos --archs x86_64,arm64 \
               | jq -nRc '{"only": inputs, "os": "macos-12"}' \
-              && cibuildwheel --print-build-identifiers --platform windows \
-              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
+              # && cibuildwheel --print-build-identifiers --platform windows \
+              # | jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -111,26 +111,26 @@ jobs:
           name: sdist_files
           path: dist/*.tar.gz
 
-  # publish_wheels:
-  #   permissions:
-  #     id-token: write
-  #   name: Publish wheels on pypi
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   if: startsWith(github.ref, 'refs/tags')
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: bdist_files
-  #         path: dist
+  publish_wheels:
+    permissions:
+      id-token: write
+    name: Publish wheels on pypi
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: bdist_files
+          path: dist
 
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: sdist_files
-  #         path: dist
+    - uses: actions/download-artifact@v3
+        with:
+          name: sdist_files
+        path: dist
 
-  #     - name: Publish package to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+    #- name: Publish package to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         shell: bash
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v4

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -28,7 +28,7 @@ jobs:
               cibuildwheel --print-build-identifiers --platform linux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos \
-              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              | jq -nRc '{"only": inputs, "os": "macos-12"}' \
               # && cibuildwheel --print-build-identifiers --platform windows \
               # | jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -124,10 +124,10 @@ jobs:
           name: bdist_files
           path: dist
 
-    - uses: actions/download-artifact@v3
-        with:
-          name: sdist_files
-        path: dist
+      - uses: actions/download-artifact@v3
+          with:
+            name: sdist_files
+          path: dist
 
     #- name: Publish package to PyPI
     #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: bdist_files_${{ matrix.include }}
+          name: bdist_files_${{ matrix.os }}_${{ strategy.job-index }}
 
   build_sdist:
     name: Build source distribution
@@ -119,12 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     # if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: bdist_files
+          pattern: bdist_files_*
+          merge-multiple: true
           path: dist
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdist_files
           path: dist

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -130,6 +130,9 @@ jobs:
           name: sdist_files
           path: dist
 
+      - run: ls -R
+        name: View downloaded artifacts
+
     #- name: Publish package to PyPI
     #   uses: pypa/gh-action-pypi-publish@release/v1
     #   with:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -125,8 +125,8 @@ jobs:
           path: dist
 
       - uses: actions/download-artifact@v3
-          with:
-            name: sdist_files
+        with:
+          name: sdist_files
           path: dist
 
     #- name: Publish package to PyPI

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -31,8 +31,8 @@ jobs:
               | jq -nRc '{"only": inputs, "os": "macos-12"}' \
               && cibuildwheel --print-build-identifiers --platform macos --archs arm64 \
               | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
-              # && cibuildwheel --print-build-identifiers --platform windows \
-              # | jq -nRc '{"only": inputs, "os": "windows-latest"}'
+              && cibuildwheel --print-build-identifiers --platform windows --archs auto64 \
+              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -29,8 +29,8 @@ jobs:
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos \
               | jq -nRc '{"only": inputs, "os": "macos-12"}' \
-              # && cibuildwheel --print-build-identifiers --platform windows  --archs x86_64 \
-              # | jq -nRc '{"only": inputs, "os": "windows-latest"}'
+              && cibuildwheel --print-build-identifiers --platform windows \
+              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           only: ${{ matrix.only }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
           name: bdist_files

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -72,10 +72,10 @@ jobs:
         with:
           only: ${{ matrix.only }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: bdist_files
+          name: bdist_files_${{ matrix.include }}
 
   build_sdist:
     name: Build source distribution
@@ -117,7 +117,7 @@ jobs:
     name: Publish wheels on pypi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
+    # if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -117,7 +117,6 @@ jobs:
     name: Publish wheels on pypi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -130,16 +129,14 @@ jobs:
           name: sdist_files
           path: dist
 
-      - run: ls -R
-        name: View downloaded artifacts
-      
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*
           name: collected_dist_files
 
-    #- name: Publish package to PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: startsWith(github.ref, 'refs/tags')
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
@@ -132,6 +132,11 @@ jobs:
 
       - run: ls -R
         name: View downloaded artifacts
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./dist/*
+          name: collected_dist_files
 
     #- name: Publish package to PyPI
     #   uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Working in the build mines:

- Drop 32-bit support; it seems unlikely that many models will load on such machines
- Update all actions
- Create a single combined artifact
- Re-enable publishing, conditional on a tag