### PR TITLE
Add completion and instruct engines for GoogleAI

### DIFF
--- a/guidance/models/_googleai.py
+++ b/guidance/models/_googleai.py
@@ -116,7 +116,7 @@ class GoogleAICompletionEngine(GoogleAIEngine):
             kwargs["generation_config"] = generation_config
 
             generator = self.model_obj.generate_content(
-                contents=prompt,
+                contents=self._data.decode("utf8"),
                 stream=True,
                 **kwargs,
             )

--- a/tests/models/test_googleai.py
+++ b/tests/models/test_googleai.py
@@ -17,6 +17,17 @@ def test_googleai_basic():
     lm += f"""{gen(max_tokens=1, suffix=nl)}aaaaaa"""
     assert str(lm)[-5:] == "aaaaa"
 
+def test_googleai_instruct():
+    try:
+        lm = models.GoogleAIInstruct("gemini-pro")
+    except:
+        pytest.skip("Skipping GoogleAI test because we can't load the model!")
+    
+    with instruction():
+        lm += "this is a test about"
+    lm += gen("test", max_tokens=100)
+    assert len(lm["test"]) > 0
+
 def test_gemini_pro():
     from guidance import assistant, gen, models, system, user
 

--- a/tests/models/test_googleai.py
+++ b/tests/models/test_googleai.py
@@ -4,6 +4,18 @@ from guidance import gen, instruction, models, select
 
 from ..utils import get_model
 
+def test_googleai_basic():
+    try:
+        lm = models.GoogleAICompletion("gemini-pro")
+    except:
+        pytest.skip("Skipping GoogleAI test because we can't load the model!")
+    
+    lm += "Count to 20: 1,2,3,4,"
+    nl = "\n"
+    lm += f"""\
+5,6,7"""
+    lm += f"""{gen(max_tokens=1, suffix=nl)}aaaaaa"""
+    assert str(lm)[-5:] == "aaaaa"
 
 def test_gemini_pro():
     from guidance import assistant, gen, models, system, user


### PR DESCRIPTION
I propose merging these commits that add in the missing completion and instruct engines for GoogleAI. With these inclusions, Gemini can be more fully supported.

The one hitch with this implementation is that Google AI Studio uses the same model name for different modalities like completion vs instruct vs chat, so it's not possible to determine which to use in the generalized class definition based on the model name alone as it is with other LLM services.

Unless maintainer has a better idea, I have decided to handle this situation by implementing with GoogleAIChat by default (as it was before), allowing for users specify different modalities by constructing GoogleAICompletion or GoogleAIInstruction  directly.