### PR TITLE
[Doc] Deal with notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,9 @@ autodoc_default_options = {
 autosummary_generate = True
 numpydoc_show_class_members = False
 
+# Don't try to execute the notebooks, they overwhelm RTD
+nbsphinx_execute = 'never'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Read The Docs appears to be trying to execute the notebooks as part of the build process. This is causing us to exceed the [RTD build resources](https://docs.readthedocs.io/en/stable/builds.html#build-resources). Since we check-in notebooks with executed cells, we don't need to do this.