### PR TITLE
Support null captures (Fix #826)

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -649,12 +649,13 @@ class EarleyCommitParser(Parser):
                     return True
 
         # if we didn't find a child set and this is nullable we can skip this child (since it may not exist if nulled)
+        # we skip it by adding a fake EarlyItem with zero length (this makes zero length named captures still work)
         if value.nullable:
             if self._compute_children(
                 state_set_pos, item, reversed_state_sets, values_pos + 1
             ):
                 item.children[values_pos] = (
-                    None  # this child was skipped since it was nullable
+                    EarleyItem(value, tuple(), 0, state_set_pos, 0, state_set_pos)  # this child has zero length since it was nullable
                 )
                 return True
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -22,6 +22,13 @@ def test_select_longer():
     assert lm["text"] == "nice man."
 
 
+def test_select_empty():
+    """This tests to ensure that we save empty capture groups."""
+    lm = models.Mock(b"<s>This is a test")
+    lm += "This is a" + select(name="text", options=["", "nope"])
+    assert lm["text"] == ""
+
+
 def test_grammar_plus_fstring():
     @guidance(stateless=True, dedent=False)
     def test(lm):


### PR DESCRIPTION
This fixes an issue where selecting or generating empty strings does not get recorded as a named capture (as noted in #826).