### PR TITLE
[Test] Increase notebook verbosity

### DIFF
--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -83,6 +83,7 @@ jobs:
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
             -m "notebooks" \
+            -vv \
             ./tests/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Our notebook tests are less totally reliable. Try increasing the verbosity of `pytest` in an effort to understand what's going on.