### PR TITLE
[Build] Update for new CUDA Toolkit

### DIFF
--- a/.github/workflows/action_gpu_unit_tests.yml
+++ b/.github/workflows/action_gpu_unit_tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Ensure NVIDIA SDK available
         run: |
           sudo apt-get -y install cuda-toolkit
-          echo "/usr/local/cuda-12.4/bin" >> $GITHUB_PATH
+          echo "/usr/local/cuda-12.5/bin" >> $GITHUB_PATH
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,9 +42,8 @@ jobs:
           sudo apt-get -y upgrade
       - name: Ensure NVIDIA SDK available
         run: |
-          # We are having trouble with CUDA toolkit 12.5.....
-          sudo apt satisfy -y "cuda-toolkit (<=12.4)"
-          echo "/usr/local/cuda-12.4/bin" >> $GITHUB_PATH
+          sudo apt-get -y install cuda-toolkit
+          echo "/usr/local/cuda-12.5/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Ensure NVIDIA SDK available
         run: |
           # We are having trouble with CUDA toolkit 12.5.....
-          sudo apt satisfy -y "cuda-toolkit (<12.4)"
+          sudo apt satisfy -y "cuda-toolkit (<=12.4)"
           echo "/usr/local/cuda-12.4/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,7 +42,8 @@ jobs:
           sudo apt-get -y upgrade
       - name: Ensure NVIDIA SDK available
         run: |
-          sudo apt-get -y install cuda-toolkit
+          # We are having trouble with CUDA toolkit 12.5.....
+          sudo apt satisfy -y "cuda-toolkit (<12.4)"
           echo "/usr/local/cuda-12.4/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Ensure NVIDIA SDK available
         run: |
           sudo apt-get -y install cuda-toolkit
-          echo "/usr/local/cuda-12.4/bin" >> $GITHUB_PATH
+          echo "/usr/local/cuda-12.5/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
We have a new version of the CUDA Toolkit, so need to update the path we use. Without this, `cmake` wound up unable to find the toolkit when installing `llama-cpp-python`.