### PR TITLE
[Build] Quick fix for break

### DIFF
--- a/.github/workflows/action_gpu_unit_tests.yml
+++ b/.github/workflows/action_gpu_unit_tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pip install accelerate
           pip uninstall -y llama-cpp-python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/action_plain_unit_tests.yml
+++ b/.github/workflows/action_plain_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install sentencepiece
           pip uninstall -y llama-cpp-python
-          pip install "llama-cpp-python!=0.2.58"
+          pip install "llama-cpp-python!=0.2.58,!=0.2.76"
       - name: Run tests (except server)
         shell: bash
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"


### PR DESCRIPTION
It appears that the latest version of `llama-cpp-python` has broken our build. This is most likely due to something in the tokeniser, but pending a deeper investigation, exclude the latest release from the build.