### PR TITLE
[Build] Better fix for break

### DIFF
--- a/.github/workflows/action_gpu_unit_tests.yml
+++ b/.github/workflows/action_gpu_unit_tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pip install accelerate
           pip uninstall -y llama-cpp-python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/action_gpu_unit_tests.yml
+++ b/.github/workflows/action_gpu_unit_tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pip install accelerate
           pip uninstall -y llama-cpp-python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/action_plain_unit_tests.yml
+++ b/.github/workflows/action_plain_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install sentencepiece
           pip uninstall -y llama-cpp-python
-          pip install "llama-cpp-python!=0.2.58,!=0.2.76"
+          pip install "llama-cpp-python!=0.2.58"
       - name: Run tests (except server)
         shell: bash
         run: |

--- a/.github/workflows/action_plain_unit_tests.yml
+++ b/.github/workflows/action_plain_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install sentencepiece
           pip uninstall -y llama-cpp-python
-          pip install "llama-cpp-python!=0.2.58"
+          pip install "llama-cpp-python!=0.2.58,!=0.2.76"
       - name: Run tests (except server)
         shell: bash
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.76"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -4,8 +4,10 @@ import html
 import logging
 import queue
 import re
+import textwrap
 import threading
 import time
+import warnings
 
 
 from pprint import pprint
@@ -72,6 +74,7 @@ class Tokenizer:
     This class should be subclassed by specific implementations and then used as the
     tokenizer in the corresponding Engine subclass.
     """
+
     # TODO: We should probably have encode and decode methods on here...
     def __init__(self, tokens, chat_template, bos_token_id=None, eos_token_id=None):
 
@@ -91,7 +94,6 @@ class Tokenizer:
         assert isinstance(
             self.tokens[0], bytes
         ), "The tokens need to be provided as bytes!"
-
 
         # This method supports None, a huggingface style jinja2_template_str, or a ChatTemplate subclass
         # Defaults to ChatML if nothing is found
@@ -211,9 +213,13 @@ class Engine:
 
         self.metrics = GuidanceEngineMetrics()
 
-    def get_chat_template(self): # TODO [HN]: Add more logic here...should we instantiate class here? do we even need to?
-        return self.tokenizer.chat_template() # Instantiate the class before returning to client for now
-    
+    def get_chat_template(
+        self,
+    ):  # TODO [HN]: Add more logic here...should we instantiate class here? do we even need to?
+        return (
+            self.tokenizer.chat_template()
+        )  # Instantiate the class before returning to client for now
+
     def reset_metrics(self):
         self.metrics = GuidanceEngineMetrics()
 
@@ -309,9 +315,13 @@ class Engine:
             if self.compute_log_probs:
                 if torch_is_imported:
                     # note we don't adjust for temp since we consider that a sampling step, not part of the probs
-                    probs = torch.nn.functional.softmax(torch.tensor(logits), dim=-1).cpu().numpy()
+                    probs = (
+                        torch.nn.functional.softmax(torch.tensor(logits), dim=-1)
+                        .cpu()
+                        .numpy()
+                    )
                 else:
-                     # this numpy code is slower, so we don't use it if we have torch...
+                    # this numpy code is slower, so we don't use it if we have torch...
                     probs = softmax(logits, axis=-1)
                 self.tokenizer.clean_duplicate_tokens(probs)
                 self._trie.compute_probs(probs)  # C++ impl
@@ -324,14 +334,16 @@ class Engine:
             # get the sampling order
             if current_temp == 0:
                 # we need numpy so the enumerate below does not get really slow...
-                sampling_order = np.argsort(-logits)  
+                sampling_order = np.argsort(-logits)
             else:
                 # assert top_p == 1, "Still need to add support for top_p!"
                 if torch_is_imported:
                     logits = torch.tensor(logits)
                     torch.div(logits, current_temp, out=logits)
                     probs_torch = torch.nn.functional.softmax(logits, dim=-1)
-                    sampling_order = torch.multinomial(probs_torch, len(probs_torch)).cpu().numpy()
+                    sampling_order = (
+                        torch.multinomial(probs_torch, len(probs_torch)).cpu().numpy()
+                    )
                 else:
                     # this numpy version allows us to drop our dependence on pytorch...but it is way slower
                     if probs is None:
@@ -351,7 +363,9 @@ class Engine:
                     break
 
                 # make sure it matches any forced prefix
-                used_forced_pos = min(self._forced_pos, self._start_pos + len(self._sampled_token))
+                used_forced_pos = min(
+                    self._forced_pos, self._start_pos + len(self._sampled_token)
+                )
                 if (
                     self._start_pos < self._forced_pos
                     and not self._sampled_token.startswith(
@@ -384,7 +398,7 @@ class Engine:
                         next_byte_mask = self._parser.next_byte_mask()
 
                         # we update all the children since the parser knows the full mask
-                        for byte in node.keys():  
+                        for byte in node.keys():
                             child = node.child(byte)
                             child.match_version = self._token_trie.match_version
                             child.match = next_byte_mask[byte[0]]
@@ -478,10 +492,14 @@ class Engine:
                     break  # if we already have a full match we don't try more tokens we just give up as soon as the model deviates from the grammar
 
         is_done = False
-        while True:  # each iteration generates one more token (and some of the associated bytes)
+        while (
+            True
+        ):  # each iteration generates one more token (and some of the associated bytes)
             if is_new_token:
                 # emit whatever we know will not be hidden
-                new_bytes = self._parser.bytes[self._generated_pos : self._parser.earliest_hidden_start()]
+                new_bytes = self._parser.bytes[
+                    self._generated_pos : self._parser.earliest_hidden_start()
+                ]
 
                 # if we cannot consume any more tokens then we are done
                 if (
@@ -502,7 +520,9 @@ class Engine:
                     #     self._cache_state["new_token_ids"].append(self._sampled_token_ind)
 
                     # capture the named groups from the parse tree
-                    self._parser.get_captures(self._captured_data, self._captured_log_prob_data)
+                    self._parser.get_captures(
+                        self._captured_data, self._captured_log_prob_data
+                    )
 
                     # we have no valid log prob data if we didn't compute it
                     # yield new_bytes[self._hidden_count:], self._is_generated, self._new_bytes_prob, self._captured_data, self._captured_log_prob_data, token_count - last_token_count
@@ -575,7 +595,7 @@ class Engine:
 
             # walk down the trie as far as possible before computing the logits
             self._trie = self._token_trie
-            
+
             # this invalidates all the match caches from the previous token
             self._trie.match_version += 1
             # self._trie.prob = 0.0 # need to reset when we reset the match_version
@@ -826,7 +846,7 @@ class Engine:
                 pos += len(self.tokenizer.tokens[id])
                 token_byte_positions.append(pos)
 
-            # ugly hack to deal with sentence piece craziness of space hiding after special tokens 
+            # ugly hack to deal with sentence piece craziness of space hiding after special tokens
             # TODO: figure out how to make this more robust
             if (
                 token_byte_positions[-1] == last_pos + 1
@@ -835,11 +855,19 @@ class Engine:
             ):
                 for i in range(1, len(token_byte_positions)):
                     token_byte_positions[i] -= 1
-            
+
             # another ugly hack for tokenizers that are not stable on encode/decode cycles
             # currently only Phi-3, should generalize this method if we see more of these
-            if not hasattr(self, "_disable_retokenize_check"):
-                assert token_byte_positions[-1] == last_pos, "Cross check last_pos"
+            if token_byte_positions[-1] != last_pos:
+                if not hasattr(self, "_disable_retokenize_check"):
+                    msg = textwrap.dedent(
+                        """Self-consistency check in _cleanup_tokens() failed.
+                        
+                        This is not a fatal issue, but if there are subsequent
+                        generation problems, please include this warning in
+                        your bug report."""
+                    )
+                    warnings.warn(msg)
 
         return token_ids, token_byte_positions
 
@@ -898,7 +926,9 @@ class Model:
         #     tokenizer = Tokenizer(tokenizer)
 
         self.engine = engine
-        self.chat_template = engine.get_chat_template() # TODO [HN]: Should this be a method or attr?
+        self.chat_template = (
+            engine.get_chat_template()
+        )  # TODO [HN]: Should this be a method or attr?
         self.echo = echo
         self.token_count = 0  # tracks how many tokens our byte state represents
         self.max_display_rate = 0.2  # this controls how frequently we are allowed to redraw the display (in seconds)
@@ -907,13 +937,19 @@ class Model:
 
         # private attributes
         self._variables = {}  # these are the state variables stored with the model
-        self._variables_log_probs = {}  # these are the state variables stored with the model
+        self._variables_log_probs = (
+            {}
+        )  # these are the state variables stored with the model
         self._cache_state = {}  # mutable caching state used to save computation
         self._state = ""  # the current bytes that represent the state of the model
         self._event_queue = None  # TODO: these are for streaming results in code, but that needs implemented
         self._event_parent = None
-        self._last_display = 0  # used to track the last display call to enable throttling
-        self._last_event_stream = 0  # used to track the last event streaming call to enable throttling
+        self._last_display = (
+            0  # used to track the last display call to enable throttling
+        )
+        self._last_event_stream = (
+            0  # used to track the last event streaming call to enable throttling
+        )
 
     @property
     def active_role_end(self):
@@ -978,7 +1014,9 @@ class Model:
         new_lm.opened_blocks = self.opened_blocks.copy()
 
         # create a new clean event queue
-        new_lm._event_queue = None  # we start with no event queue because nobody is listening to us yet
+        new_lm._event_queue = (
+            None  # we start with no event queue because nobody is listening to us yet
+        )
 
         if self._event_queue is not None:
             # if the current lm has an event queue, we make it our parent
@@ -986,7 +1024,7 @@ class Model:
 
         elif self._event_parent is not None:
             # otherwise if the current event que has an event parent then that is also our parent
-            new_lm._event_parent = self._event_parent  
+            new_lm._event_parent = self._event_parent
 
         return new_lm
 
@@ -1110,7 +1148,9 @@ class Model:
                 lm += context.opener
                 with grammar_only():
                     tmp = lm + context.closer
-                close_text = tmp._state[len(lm._state):]  # get the new state added by calling the closer
+                close_text = tmp._state[
+                    len(lm._state) :
+                ]  # get the new state added by calling the closer
                 lm.opened_blocks[context] = (len(lm._state), close_text)
 
                 # clear out names that we override
@@ -1405,7 +1445,9 @@ class Model:
                                 except UnicodeDecodeError:
                                     pass
 
-                                if k not in lm or not isinstance(lm._variables[k], list):
+                                if k not in lm or not isinstance(
+                                    lm._variables[k], list
+                                ):
                                     lm._variables[k] = []
                                     lm._variables_log_probs[k] = []
                                 lm._variables[k].append(inner_v)
@@ -1422,7 +1464,9 @@ class Model:
                             except UnicodeDecodeError:
                                 pass
                             lm._variables[k] = v
-                            lm._variables_log_probs[k] = chunk.capture_group_log_probs[k]
+                            lm._variables_log_probs[k] = chunk.capture_group_log_probs[
+                                k
+                            ]
 
             # if len(chunk.capture_groups) > 0:
             #     for k in chunk.capture_groups:
@@ -1606,7 +1650,9 @@ def _check_dominated(node, parser, match_version, next_byte_mask):
             return False  # this child does not dominate the node, so the node is not dominated
         elif child.value is None:  # this child might not dominate the node
             parser.consume_byte(next_byte, log_prob=0.0)
-            child_dominate = _check_dominated(child, parser, match_version, parser.next_byte_mask())
+            child_dominate = _check_dominated(
+                child, parser, match_version, parser.next_byte_mask()
+            )
             parser.pos = curr_pos
             if not child_dominate:
                 return False


### PR DESCRIPTION
This is an improvement on #867, which addressed a build issue by excluding the latest release of `llama-cpp-python` when setting up the GitHub runner machines. The assertion was checking for a self-consistency issue, but it need not be fatal (as evidenced by the fact that we turn it off for Phi3 models). However, if the check fails, it would be helpful to know in bug reports from subsequent failures. Hence, switch to `warnings.warn()`.