### PR TITLE
[Build] Drop Python 3.8

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-12]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         model:
           - "gpt2cpu"
           - "phi2cpu"
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false # Don't cancel all on first failure
       matrix:
         # Need to figure out what happened to 3.12
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     uses: ./.github/workflows/action_server_tests.yml
     with:
       os: ubuntu-latest
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           - "gpt2cpu"
           - "phi2cpu"
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           - "gpt2cpu"
           - "phi2cpu"
@@ -189,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     uses: ./.github/workflows/action_gpu_unit_tests.yml
     with:
       os: gpu-runner

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -172,7 +172,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           - "gpt2cpu"
-          - "phi2cpu"
+          # - "phi2cpu" Seems to get stuck
           # - "transformers_mistral_7b" See Issue 713
           - "hfllama7b"
           - "hfllama_mistral_7b"

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -144,7 +144,7 @@ jobs:
 # Third Stage ==============================================================
 # Windows and MacOS, plus other GPU Linux tests
   
-  unit-tests-mac:
+  unit-tests-mac-x86:
     needs: end-stage-2
     strategy:
       fail-fast: false # Don't cancel all on first failure
@@ -161,6 +161,26 @@ jobs:
     uses: ./.github/workflows/action_plain_unit_tests.yml
     with:
       os: macos-12
+      python-version: ${{ matrix.python-version }}
+      model: ${{ matrix.model }}
+
+  unit-tests-mac-arm:
+    needs: end-stage-2
+    strategy:
+      fail-fast: false # Don't cancel all on first failure
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        model:
+          - "gpt2cpu"
+          - "phi2cpu"
+          # - "transformers_mistral_7b" See Issue 713
+          - "hfllama7b"
+          - "hfllama_mistral_7b"
+          # - "transformers_phi3cpu_mini_4k_instruct" Gives trouble on MacOS
+          - "hfllama_phi3cpu_mini_4k_instruct"
+    uses: ./.github/workflows/action_plain_unit_tests.yml
+    with:
+      os: macos-latest
       python-version: ${{ matrix.python-version }}
       model: ${{ matrix.model }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ markers = [
 
 [tool.black]
 line-length = 88
-target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target_version = ['py39', 'py310', 'py311', 'py312']
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         )
     ],
     cmdclass={"build_ext": build_ext},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=install_requires,
     extras_require={
         "all": all_requires,


### PR DESCRIPTION
Python 3.8 is approaching EoL, and is starting to lose support from our dependencies. Bump our minimum supported version to Python 3.9. This allows us to include MacOS-ARM in the builds