### PR TITLE
[WIP] Fix infinite loop when computing parse tree for recursive nullable grammars

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -594,10 +594,14 @@ class EarleyCommitParser(Parser):
 
     def _compute_parse_tree(self, initial_pos, initial_item, reversed_state_sets):
         stack = [(initial_pos, initial_item)]
+        seen = set()
 
         while stack:
             pos, item = stack.pop()
-
+            if (pos, item) in seen:
+                # Skip items we have already processed
+                continue
+            seen.add((pos, item))
             # compute the children for this item
             assert self._compute_children(pos, item, reversed_state_sets)
 

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -538,9 +538,12 @@ class EarleyCommitParser(Parser):
         used_names = (
             set()
         )  # track which capture names have been used so self-recursive children don't overwrite their parents
-
+        seen = set()
         while stack:
             item, byte_pos = stack.pop()
+            if (item, byte_pos) in seen:
+                continue
+            seen.add((item, byte_pos))
             # terminal nodes
             if isinstance(item, Terminal):
 

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -535,13 +535,14 @@ class EarleyCommitParser(Parser):
     def _record_captures_from_root(self, initial_item, data, log_prob_data):
         byte_data = self.bytes
         stack = [(initial_item, 0)]
-        used_names = (
-            set()
-        )  # track which capture names have been used so self-recursive children don't overwrite their parents
+        # track which capture names have been used so self-recursive children don't overwrite their parents
+        used_names = set()
+        # track which items we have seen so we don't process them multiple times, leading to infinite loops
         seen = set()
         while stack:
             item, byte_pos = stack.pop()
             if (item, byte_pos) in seen:
+                # skip items we have already processed
                 continue
             seen.add((item, byte_pos))
             # terminal nodes
@@ -597,12 +598,12 @@ class EarleyCommitParser(Parser):
 
     def _compute_parse_tree(self, initial_pos, initial_item, reversed_state_sets):
         stack = [(initial_pos, initial_item)]
+        # track which items we have seen so we don't process them multiple times, leading to infinite loops
         seen = set()
-
         while stack:
             pos, item = stack.pop()
             if (pos, item) in seen:
-                # Skip items we have already processed
+                # skip items we have already processed
                 continue
             seen.add((pos, item))
             # compute the children for this item

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ test_requires = [
     "papermill",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",
     "torch",
     "transformers",
     "mypy==1.9.0",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -156,8 +156,6 @@ class TestRecursiveNullableGrammars:
         parser = EarleyCommitParser(A)
         # Test that computing the parse tree doesn't hang
         parser.parse_tree()
-        # Test that getting captures doesn't hang
-        parser.get_captures()
 
     @pytest.mark.timeout(5)
     def test_no_infinite_loop_with_terminal(self):
@@ -174,8 +172,6 @@ class TestRecursiveNullableGrammars:
         parser = EarleyCommitParser(A)
         # Test that computing the parse tree doesn't hang
         parser.parse_tree()
-        # Test that getting captures doesn't hang
-        parser.get_captures()
 
     @pytest.mark.timeout(5)
     def test_no_infinite_loop_extra_indirection(self):
@@ -200,8 +196,6 @@ class TestRecursiveNullableGrammars:
         parser = EarleyCommitParser(A)
         # Test that computing the parse tree doesn't hang
         parser.parse_tree()
-        # Test that getting captures doesn't hang
-        parser.get_captures()
 
     @pytest.mark.timeout(5)
     def test_captures_from_root(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -137,6 +137,10 @@ def test_string_utf8():
 
 
 class TestRecursiveNullableGrammars:
+    """
+    Computing parse tree of recursive nullable grammars will cause an infinite
+    loop if not handled correctly
+    """
     @pytest.mark.timeout(5)
     def test_no_infinite_loop(self):
         """


### PR DESCRIPTION
Computing the parse tree (needed for getting captures) previously caused an infinite loop if the grammar has loops of nullable rules, where a nullable rule is any rule where every symbol on the RHS is nullable.

E.g., the grammar
```
  A -> A C
  A -> B
  A ->
  B -> A
  C -> 'x'
```
has nullable rules
```
  A -> B
  A ->
  B -> A
```
and there is a loop in these rules formed by `A -> B` and `B -> A`.

For a deeper discussion on this, see section "One Last Trap" of https://loup-vaillant.fr/tutorials/earley-parsing/parser

This PR solves the issue by keeping a set of visited nodes when computing the parse tree (or getting captures) and skipping any node that has already been seen. AFAIK, the only way this can happen is when we have these nullable loops, but admittedly I still have a lot to learn about the parser (so more eyes on this would be really helpful!)

This closes #863