### PR TITLE
[Refactor] Move Tokenizer to own file

### DIFF
--- a/guidance/models/_byte_tokenizer.py
+++ b/guidance/models/_byte_tokenizer.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ._model import Tokenizer
+from ._tokenizer import Tokenizer
 from ..chat import load_template_class
 import typing
 

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -5,7 +5,8 @@ import time
 import tiktoken
 import re
 import logging
-from ._model import Tokenizer, Engine, Model, format_pattern, ConstraintException
+from ._model import Engine, Model, format_pattern, ConstraintException
+from ._tokenizer import Tokenizer
 from ..chat import ChatMLTemplate
 
 import warnings

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from ._model import Tokenizer, Engine, Model, Chat
+from ._model import Engine, Model, Chat
 from ._remote import RemoteEngine
+from ._tokenizer import Tokenizer
 
 
 class MockEngine(Engine):

--- a/guidance/models/_remote.py
+++ b/guidance/models/_remote.py
@@ -2,8 +2,9 @@ import requests
 import os
 import base64
 
-from ._model import Tokenizer, Engine, EngineCallResponse
+from ._model import Engine, EngineCallResponse
 from ..chat import ChatMLTemplate
+from ._tokenizer import Tokenizer
 from ._grammarless import GrammarlessTokenizer
 
 class RemoteEngine(Engine):

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -83,15 +83,15 @@ class Tokenizer:
         return self._chat_template
 
     def __call__(self, byte_string: bytes):
-        return self.bytes_to_tokens(byte_string)
+        return self.encode(byte_string)
 
-    def bytes_to_tokens(self, byte_string: bytes) -> Sequence[int]:
+    def encode(self, byte_string: bytes) -> Sequence[int]:
         """Returns a list of tokens that represent the given byte string."""
         raise NotImplementedError(
             "You need to use a Tokenize subclass that overrides the bytes_to_tokens method"
         )
 
-    def tokens_to_bytes(self, tokens: Sequence[int]) -> bytes:
+    def decode(self, tokens: Sequence[int]) -> bytes:
         """Returns the bytes represented by the given list of tokens."""
         raise NotImplementedError(
             "You need to use a Tokenize subclass that overrides the tokens_to_bytes method"

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence, Union
+from typing import Any, Dict, Sequence, Union
 
 import numpy as np
 
@@ -51,7 +51,7 @@ class Tokenizer:
 
         # track which tokens are duplicates
         self._duplicate_tokens = []
-        found = {}
+        found: Dict[int, bytes] = {}
         for i, t in enumerate(self.tokens):
             if t in found:
                 self._duplicate_tokens.append((i, found[t]))

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Sequence, Union
 
 import numpy as np
 
@@ -12,18 +12,17 @@ class Tokenizer:
     tokenizer in the corresponding Engine subclass.
     """
 
-    # TODO: We should probably have encode and decode methods on here...
     def __init__(
         self,
         tokens: Union[list, np.ndarray],
         chat_template: Union[str, ChatTemplate, None],
-        bos_token_id: Optional[int] = None,
-        eos_token_id: Optional[int] = None,
+        bos_token_id: Union[int, None] = None,
+        eos_token_id: Union[int, None] = None,
     ):
 
         # a numpy array of token byte strings indexed by their token id
         if isinstance(tokens, list):
-            # note that we need np.bytes_ to zero bytes are not treated as null terminations
+            # note that we need np.bytes_ so zero bytes are not treated as null terminations
             self._tokens = np.array(tokens, dtype="object")
 
         # a numpy array of token byte strings indexed by their token id
@@ -80,13 +79,22 @@ class Tokenizer:
         return self._eos_token
 
     def __call__(self, byte_string: bytes):
+        return self.bytes_to_tokens(byte_string)
+
+    def bytes_to_tokens(self, byte_string: bytes) -> Sequence[int]:
         """Returns a list of tokens that represent the given byte string."""
         raise NotImplementedError(
-            "You need to use a Tokenize subclass that overrides the __call__ method"
+            "You need to use a Tokenize subclass that overrides the bytes_to_tokens method"
+        )
+
+    def tokens_to_bytes(self, tokens: Sequence[int]) -> bytes:
+        """Returns the bytes represented by the given list of tokens."""
+        raise NotImplementedError(
+            "You need to use a Tokenize subclass that overrides the tokens_to_bytes method"
         )
 
     def clean_duplicate_tokens(self, probs):
         """This moves all the probability mass from duplicate positons on to their primary index."""
-        for i, j in self.duplicate_tokens:
+        for i, j in self._duplicate_tokens:
             probs[j] += probs[i]
             probs[i] = 0

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -51,7 +51,7 @@ class Tokenizer:
 
         # track which tokens are duplicates
         self._duplicate_tokens = []
-        found: Dict[int, bytes] = {}
+        found: Dict[bytes, int] = {}
         for i, t in enumerate(self.tokens):
             if t in found:
                 self._duplicate_tokens.append((i, found[t]))

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union
+from typing import Any, Sequence, Union
 
 import numpy as np
 
@@ -38,7 +38,7 @@ class Tokenizer:
 
         # This method supports None, a huggingface style jinja2_template_str, or a ChatTemplate subclass
         # Defaults to ChatML if nothing is found
-        self.chat_template = load_template_class(chat_template)
+        self._chat_template = load_template_class(chat_template)
 
         self._bos_token_id = bos_token_id
         self._bos_token = (
@@ -77,6 +77,10 @@ class Tokenizer:
     @property
     def eos_token(self) -> Union[bytes, None]:
         return self._eos_token
+
+    @property
+    def chat_template(self) -> Union[Any, None]:
+        return self._chat_template
 
     def __call__(self, byte_string: bytes):
         return self.bytes_to_tokens(byte_string)

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -1,0 +1,92 @@
+from typing import Optional, Union
+
+import numpy as np
+
+from ..chat import load_template_class, ChatTemplate
+
+
+class Tokenizer:
+    """This is the standardized tokenizer interface used by guidance models.
+
+    This class should be subclassed by specific implementations and then used as the
+    tokenizer in the corresponding Engine subclass.
+    """
+
+    # TODO: We should probably have encode and decode methods on here...
+    def __init__(
+        self,
+        tokens: Union[list, np.ndarray],
+        chat_template: Union[str, ChatTemplate, None],
+        bos_token_id: Optional[int] = None,
+        eos_token_id: Optional[int] = None,
+    ):
+
+        # a numpy array of token byte strings indexed by their token id
+        if isinstance(tokens, list):
+            # note that we need np.bytes_ to zero bytes are not treated as null terminations
+            self._tokens = np.array(tokens, dtype="object")
+
+        # a numpy array of token byte strings indexed by their token id
+        elif isinstance(tokens, np.ndarray):
+            self._tokens = tokens
+
+        else:
+            raise ValueError("Unknown tokenizer was passed!")
+
+        assert isinstance(
+            self.tokens[0], bytes
+        ), "The tokens need to be provided as bytes!"
+
+        # This method supports None, a huggingface style jinja2_template_str, or a ChatTemplate subclass
+        # Defaults to ChatML if nothing is found
+        self.chat_template = load_template_class(chat_template)
+
+        self._bos_token_id = bos_token_id
+        self._bos_token = (
+            None if self.bos_token_id is None else self.tokens[self.bos_token_id]
+        )
+        self._eos_token_id = eos_token_id if eos_token_id is not None else bos_token_id
+        self._eos_token = (
+            None if self.eos_token_id is None else self.tokens[self.eos_token_id]
+        )
+
+        # track which tokens are duplicates
+        self._duplicate_tokens = []
+        found = {}
+        for i, t in enumerate(self.tokens):
+            if t in found:
+                self._duplicate_tokens.append((i, found[t]))
+            else:
+                found[t] = i
+
+    @property
+    def tokens(self) -> np.ndarray:
+        return self._tokens
+
+    @property
+    def bos_token_id(self) -> Union[int, None]:
+        return self._bos_token_id
+
+    @property
+    def eos_token_id(self) -> Union[int, None]:
+        return self._eos_token_id
+
+    @property
+    def bos_token(self) -> Union[bytes, None]:
+        return self._bos_token
+
+    @property
+    def eos_token(self) -> Union[bytes, None]:
+        return self._eos_token
+
+    def __call__(self, byte_string: bytes):
+        """Returns a list of tokens that represent the given byte string."""
+        raise NotImplementedError(
+            "You need to use a Tokenize subclass that overrides the __call__ method"
+        )
+
+    def clean_duplicate_tokens(self, probs):
+        """This moves all the probability mass from duplicate positons on to their primary index."""
+        for i, j in self.duplicate_tokens:
+            probs[j] += probs[i]
+            probs[i] = 0

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -7,8 +7,9 @@ import sys
 import logging
 import numpy as np
 
-from .._model import Tokenizer, Engine, Model, Chat
+from .._model import Engine, Model, Chat
 from .._remote import RemoteEngine
+from .._tokenizer import Tokenizer
 from ..._utils import normalize_notebook_stdout_stderr
 
 try:
@@ -60,18 +61,28 @@ class LlamaCppTokenizer(Tokenizer):
         # get the bytes strings for all the tokens
         tokens = []
         for i in range(tokenizer.llama.n_vocab()):
-            tok = tokenizer.llama.detokenize([i])  # note that detokenize returns bytes directly
+            tok = tokenizer.llama.detokenize(
+                [i]
+            )  # note that detokenize returns bytes directly
             if tok == b"":
-                tok = llama_cpp.llama_token_get_text(model_obj.model, i)  # get text rep of special tokens
+                tok = llama_cpp.llama_token_get_text(
+                    model_obj.model, i
+                )  # get text rep of special tokens
             tokens.append(tok)
 
         # Chat Template logic
         if chat_template is None:
-            if hasattr(self._model_obj, "metadata") and "tokenizer.chat_template" in self._model_obj.metadata:
+            if (
+                hasattr(self._model_obj, "metadata")
+                and "tokenizer.chat_template" in self._model_obj.metadata
+            ):
                 chat_template = self._model_obj.metadata["tokenizer.chat_template"]
 
         super().__init__(
-            tokens, chat_template, tokenizer.llama.token_bos(), tokenizer.llama.token_eos()
+            tokens,
+            chat_template,
+            tokenizer.llama.token_bos(),
+            tokenizer.llama.token_eos(),
         )
 
     def __call__(self, byte_string):
@@ -119,7 +130,9 @@ class LlamaCppEngine(Engine):
                 )
 
             with normalize_notebook_stdout_stderr():
-                self.model_obj = llama_cpp.Llama(model_path=model, logits_all=True, **kwargs)
+                self.model_obj = llama_cpp.Llama(
+                    model_path=model, logits_all=True, **kwargs
+                )
         elif isinstance(model, llama_cpp.Llama):
             self.model = model.__class__.__name__
             self.model_obj = model
@@ -134,7 +147,8 @@ class LlamaCppEngine(Engine):
         self._cache_token_ids = []
 
         super().__init__(
-            LlamaCppTokenizer(self.model_obj, chat_template=chat_template), compute_log_probs=compute_log_probs
+            LlamaCppTokenizer(self.model_obj, chat_template=chat_template),
+            compute_log_probs=compute_log_probs,
         )
 
         self._n_vocab = len(self.tokenizer.tokens)
@@ -227,7 +241,10 @@ class LlamaCpp(Model):
             engine = RemoteEngine(model, api_key=api_key, **llama_cpp_kwargs)
         else:
             engine = LlamaCppEngine(
-                model, compute_log_probs=compute_log_probs, chat_template=chat_template, **llama_cpp_kwargs
+                model,
+                compute_log_probs=compute_log_probs,
+                chat_template=chat_template,
+                **llama_cpp_kwargs,
             )
 
         super().__init__(engine, echo=echo)

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -61,28 +61,18 @@ class LlamaCppTokenizer(Tokenizer):
         # get the bytes strings for all the tokens
         tokens = []
         for i in range(tokenizer.llama.n_vocab()):
-            tok = tokenizer.llama.detokenize(
-                [i]
-            )  # note that detokenize returns bytes directly
+            tok = tokenizer.llama.detokenize([i])  # note that detokenize returns bytes directly
             if tok == b"":
-                tok = llama_cpp.llama_token_get_text(
-                    model_obj.model, i
-                )  # get text rep of special tokens
+                tok = llama_cpp.llama_token_get_text(model_obj.model, i)  # get text rep of special tokens
             tokens.append(tok)
 
         # Chat Template logic
         if chat_template is None:
-            if (
-                hasattr(self._model_obj, "metadata")
-                and "tokenizer.chat_template" in self._model_obj.metadata
-            ):
+            if hasattr(self._model_obj, "metadata") and "tokenizer.chat_template" in self._model_obj.metadata:
                 chat_template = self._model_obj.metadata["tokenizer.chat_template"]
 
         super().__init__(
-            tokens,
-            chat_template,
-            tokenizer.llama.token_bos(),
-            tokenizer.llama.token_eos(),
+            tokens, chat_template, tokenizer.llama.token_bos(), tokenizer.llama.token_eos()
         )
 
     def __call__(self, byte_string):
@@ -130,9 +120,7 @@ class LlamaCppEngine(Engine):
                 )
 
             with normalize_notebook_stdout_stderr():
-                self.model_obj = llama_cpp.Llama(
-                    model_path=model, logits_all=True, **kwargs
-                )
+                self.model_obj = llama_cpp.Llama(model_path=model, logits_all=True, **kwargs)
         elif isinstance(model, llama_cpp.Llama):
             self.model = model.__class__.__name__
             self.model_obj = model
@@ -147,8 +135,7 @@ class LlamaCppEngine(Engine):
         self._cache_token_ids = []
 
         super().__init__(
-            LlamaCppTokenizer(self.model_obj, chat_template=chat_template),
-            compute_log_probs=compute_log_probs,
+            LlamaCppTokenizer(self.model_obj, chat_template=chat_template), compute_log_probs=compute_log_probs
         )
 
         self._n_vocab = len(self.tokenizer.tokens)
@@ -241,10 +228,7 @@ class LlamaCpp(Model):
             engine = RemoteEngine(model, api_key=api_key, **llama_cpp_kwargs)
         else:
             engine = LlamaCppEngine(
-                model,
-                compute_log_probs=compute_log_probs,
-                chat_template=chat_template,
-                **llama_cpp_kwargs,
+                model, compute_log_probs=compute_log_probs, chat_template=chat_template, **llama_cpp_kwargs
             )
 
         super().__init__(engine, echo=echo)

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -6,7 +6,8 @@ try:
 except ModuleNotFoundError:
     pass
 
-from .._model import Tokenizer, Engine, Model
+from .._model import Engine, Model
+from .._tokenizer import Tokenizer
 
 
 class TransformersTokenizer(Tokenizer):


### PR DESCRIPTION
Move the `Tokenizer` class to its own file, and try to define the interface better.

Subsequent changes should build on this, making the invocations of the `Tokenizer` objects more uniform throughout the codebase.