### PR TITLE
[Test] Environment variable for selected model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,10 @@ python -m pytest -m "not (needs_credentials or use_gpu or server)" --selected_mo
 ```
 where `<MODELNAME>` is taken from the `AVAILABLE_MODELS` dictionary defined in `conftest.py`.
 
+Alternatively, the default value for `--selected_model` can be set via the `GUIDANCE_SELECTED_MODEL` environment variable.
+This may be useful when trying to use a debugger when running `pytest`, and setting the extra command line argument in the debugger configuration is tricky.
+Just remember that the environment variable needs to be set _before_ starting PyCharm/VSCode etc.
+
 ## Adding LLMs to the test matrix
 
 Our tests run on a variety of LLMs.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import random
 import time
 
@@ -6,6 +7,9 @@ import pytest
 from guidance import models
 
 from .utils import get_model
+
+
+SELECTED_MODEL_ENV_VARIABLE = "GUIDANCE_SELECTED_MODEL"
 
 AVAILABLE_MODELS = {
     "gpt2cpu": dict(name="transformers:gpt2", kwargs=dict()),
@@ -54,12 +58,14 @@ AVAILABLE_MODELS = {
 
 
 def pytest_addoption(parser):
+    default_model = os.getenv(SELECTED_MODEL_ENV_VARIABLE, "gpt2cpu")
     parser.addoption(
         "--selected_model",
         action="store",
-        default="gpt2cpu",
+        default=default_model,
         type=str,
         choices=AVAILABLE_MODELS.keys(),
+        help=f"LLM to load when needed. Set default via environment variable {SELECTED_MODEL_ENV_VARIABLE}",
     )
 
 


### PR DESCRIPTION
Make debugging tests with a particular LLM easier by adding a `GUIDANCE_SELECTED_MODEL` environment variable.

We have the `--selected_model` command line argument for `pytest`, which loads a designated LLM in a fixture (if not set, currently `gpt2cpu` is the default). However, when debugging tests within VS Code, setting that command line argument is non-trivial, and our workaround was to patch the `selected_model_name()` fixture (which reads the command line argument). This change makes the default value for the command line argument be the `GUIDANCE_SELECTED_MODEL` environment variable, and if _that_ is not set, falls back to `gpt2cpu`.