### PR TITLE
[Feature] Constant elements in JSON schemas

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -260,6 +260,10 @@ def _gen_json(
             reference=json_schema[REF_STRING], definitions=definitions
         )
 
+    CONST_STRING = "const"
+    if CONST_STRING in json_schema:
+        return lm + _to_compact_json(json_schema[CONST_STRING])
+
     ENUM_STRING = "enum"
     if ENUM_STRING in json_schema:
         return lm + _process_enum(options=json_schema["enum"])
@@ -292,10 +296,6 @@ def _gen_json(
                 definitions=definitions,
             )
         raise ValueError(f"Unsupported type in schema: {target_type}")
-
-    CONST_STRING = "const"
-    if CONST_STRING in json_schema:
-        return lm + _to_compact_json(json_schema[CONST_STRING])
 
     raise ValueError(f"Can't process JSON node: {json_schema}")
 

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -293,6 +293,10 @@ def _gen_json(
             )
         raise ValueError(f"Unsupported type in schema: {target_type}")
 
+    CONST_STRING = "const"
+    if CONST_STRING in json_schema:
+        return lm + _to_compact_json(json_schema[CONST_STRING])
+
     raise ValueError(f"Can't process JSON node: {json_schema}")
 
 

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -1079,19 +1079,59 @@ class TestEnum:
 
 
 class TestConst:
-    simple_schema = """{
-        "const": 1
-    }
-    """
-    target_obj = 1
-
-    def test_const(self):
+    def test_constant_int(self):
         # First sanity check what we're setting up
-        schema_obj = json.loads(self.simple_schema)
-        validate(instance=self.target_obj, schema=schema_obj)
+        schema_obj = {"const": 1}
+        target_obj = 1
+        validate(instance=target_obj, schema=schema_obj)
 
         # The actual check
-        generate_and_check(self.target_obj, schema_obj)
+        generate_and_check(target_obj, schema_obj)
+
+    def test_constant_string(self):
+        # First sanity check what we're setting up
+        schema_obj = {"const": "hello"}
+        target_obj = "hello"
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        generate_and_check(target_obj, schema_obj)
+
+    def test_constant_array(self):
+        # First sanity check what we're setting up
+        schema_obj = {"const": [1, 2, 3]}
+        target_obj = [1, 2, 3]
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        generate_and_check(target_obj, schema_obj)
+
+    def test_constant_object(self):
+        # First sanity check what we're setting up
+        schema_obj = {"const": {"a": 1, "b": 2}}
+        target_obj = {"a": 1, "b": 2}
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        generate_and_check(target_obj, schema_obj)
+
+    def test_nested_constant(self):
+        # First sanity check what we're setting up
+        schema_obj = {"type": "object", "properties": {"a": {"const": 1}}}
+        target_obj = {"a": 1}
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        generate_and_check(target_obj, schema_obj)
+
+    def test_type_specified_constant(self):
+        # First sanity check what we're setting up
+        schema_obj = {"type": "integer", "const": 1}
+        target_obj = 1
+        validate(instance=target_obj, schema=schema_obj)
+
+        # The actual check
+        generate_and_check(target_obj, schema_obj)
 
 
 class TestAdditionalProperties:

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -1078,6 +1078,22 @@ class TestEnum:
         )
 
 
+class TestConst:
+    simple_schema = """{
+        "const": 1
+    }
+    """
+    target_obj = 1
+
+    def test_const(self):
+        # First sanity check what we're setting up
+        schema_obj = json.loads(self.simple_schema)
+        validate(instance=self.target_obj, schema=schema_obj)
+
+        # The actual check
+        generate_and_check(self.target_obj, schema_obj)
+
+
 class TestAdditionalProperties:
 
     simple_schema = """{

--- a/tests/library/test_json.py
+++ b/tests/library/test_json.py
@@ -1124,14 +1124,17 @@ class TestConst:
         # The actual check
         generate_and_check(target_obj, schema_obj)
 
-    def test_type_specified_constant(self):
-        # First sanity check what we're setting up
+    def test_constant_precedence(self):
         schema_obj = {"type": "integer", "const": 1}
-        target_obj = 1
-        validate(instance=target_obj, schema=schema_obj)
+        bad_string = _to_compact_json(2)
 
-        # The actual check
-        generate_and_check(target_obj, schema_obj)
+        check_match_failure(
+            bad_string=bad_string,
+            good_bytes=b"",
+            failure_byte=b"2",
+            allowed_bytes={Byte(b"1")},
+            schema_obj=schema_obj,
+        )
 
 
 class TestAdditionalProperties:


### PR DESCRIPTION
This is a super quick PR as I work toward supporting some large JSON schemas I'm working with. All it does is support the `const` keyword in JSON schemas, which are a way of hard coding constant elements: https://json-schema.org/understanding-json-schema/reference/const