### PR TITLE
[Refactor] Tokenizer refactor continued

### DIFF
--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -222,7 +222,7 @@ class GrammarlessEngine(Engine):
         if self._running_stream():
             # Stop stream and wait for thread to complete
             self._not_running_stream.set()
-            self._remote_thread.join()  # type: ignore # mypy being strange
+            self._model_interaction_thread.join()  # type: ignore # mypy being strange
 
         # clear the data queue
         while not self._data_queue.empty():

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -120,8 +120,11 @@ class GrammarlessTokenizer(Tokenizer):
         assert isinstance(byte_string, bytes)
         return self._orig_tokenizer.encode(byte_string.decode())
 
+
 class GrammarlessEngine(Engine):
-    def __init__(self, tokenizer, max_streaming_tokens:int, timeout, compute_log_probs:bool):
+    def __init__(
+        self, tokenizer, max_streaming_tokens: int, timeout, compute_log_probs: bool
+    ):
         self.max_streaming_tokens = max_streaming_tokens
         self.timeout = timeout
 
@@ -193,7 +196,7 @@ class GrammarlessEngine(Engine):
             b""
         )  # so we never get stuck waiting for a running stream to return something
 
-    def _start_new_stream(self, prompt:bytes, temperature:float):
+    def _start_new_stream(self, prompt: bytes, temperature: float):
         assert isinstance(prompt, bytes)
         # make sure the display is up to date (since we are about to delay for a while)
         # TODO: how can we handle this better since the engine is now separate from the client?
@@ -233,7 +236,7 @@ class GrammarlessEngine(Engine):
         self._data = new_data
         self._last_stream_start = self._data
 
-    def get_logits(self, token_ids, forced_bytes:bytes, current_temp):
+    def get_logits(self, token_ids, forced_bytes: bytes, current_temp):
         """Computes the logits for the given token state.
 
         This overrides a method from the Local class that is used to get
@@ -376,7 +379,7 @@ class GrammarlessEngine(Engine):
                     raise new_bytes
                 self._data += new_bytes
                 # reset out call time to allow the data stream to time out if we happen to be done with it
-                self._last_call = time.time()  
+                self._last_call = time.time()
 
         # # if we don't have the next byte of data yet then we wait for it (from the streaming thread)
         # if len(self._data) == len(prompt):

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -117,7 +117,8 @@ class GrammarlessTokenizer(Tokenizer):
 
     def encode(self, byte_string: bytes) -> Sequence[int]:
         """Returns a list of tokens that represent the given byte string."""
-        return self._orig_tokenizer.encode(byte_string)
+        assert isinstance(byte_string, bytes)
+        return self._orig_tokenizer.encode(byte_string.decode())
 
 class GrammarlessEngine(Engine):
     def __init__(self, tokenizer, max_streaming_tokens, timeout, compute_log_probs):

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -129,14 +129,14 @@ class GrammarlessEngine(Engine):
         self.timeout = timeout
 
         # this is where the streaming thread puts results
-        self._data_queue = queue.Queue()
+        self._data_queue: queue.Queue = queue.Queue()
         self._data = b""  # these are the bytes we are ready to use in the main thread
 
         # this is phrased negatively so we can wait for the stop event
-        self._not_running_stream = threading.Event()
+        self._not_running_stream: threading.Event = threading.Event()
         self._last_call = 0
         self._num_calls_made = 0
-        self._current_temp = 0
+        self._current_temp = 0.0
         self._last_stream_start = None
 
         self._not_running_stream.set()
@@ -317,7 +317,7 @@ class GrammarlessEngine(Engine):
                 logger.debug(f"Grammarless.get_logits: {leftover=}")
 
                 # record any active non-empty role ends. Ignore role ends that are spaces
-                parts = [
+                parts: Sequence[bytes] = [
                     b"<|im_end|>",
                     self.tokenizer.eos_token,
                 ]  # note we assume we are role tags that end with <|im_end|>
@@ -373,7 +373,7 @@ class GrammarlessEngine(Engine):
 
             # we wait for the running stream to put something in the queue
             else:
-                self._last_call = 10e9  # set to essentialy infinity so we don't stop the data stream while we are waiting for it
+                self._last_call = 1e9  # set to essentialy infinity so we don't stop the data stream while we are waiting for it
                 new_bytes = self._data_queue.get()
                 if isinstance(new_bytes, Exception):
                     raise new_bytes
@@ -424,14 +424,14 @@ class GrammarlessEngine(Engine):
             already_shown = len(self._current_prompt().encode())
             self += (
                 self._data[already_shown:match_len].decode()
-                + f"<||_html:<span style='color: rgba(165,0,0,1);' title='{leftover}'><span style='text-decoration: underline;'>{data_after_prompt.decode()}</span></span>_||>"
+                + f"<||_html:<span style='color: rgba(165,0,0,1);' title='{str(leftover)}'><span style='text-decoration: underline;'>{data_after_prompt.decode()}</span></span>_||>"
             )
         except:
             pass  # could not decode the data the model generated into a string...
 
         # create an exception for users to deal with (that our caller can throw)
         return ConstraintException(
-            f"The model attempted to generate {str(data_after_prompt)} after the prompt `{prompt_tail}`, but that does\n"
+            f"The model attempted to generate {str(data_after_prompt)} after the prompt `{str(prompt_tail)}`, but that does\n"
             + "not match the given grammar constraints! Since your model is a remote API that does not support full guidance\n"
             + "integration we cannot force the model to follow the grammar, only flag an error when it fails to match.\n"
             + "You can try to address this by improving the prompt, making your grammar more flexible, rerunning with\n"

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -325,7 +325,7 @@ class GrammarlessEngine(Engine):
                 logger.debug(f"Grammarless.get_logits: {leftover=}")
 
                 # record any active non-empty role ends. Ignore role ends that are spaces
-                parts: Sequence[bytes | None] = [
+                parts: Sequence[Optional[bytes]] = [
                     b"<|im_end|>",
                     self.tokenizer.eos_token,
                 ]  # note we assume we are role tags that end with <|im_end|>

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -203,7 +203,7 @@ class GrammarlessEngine(Engine):
             b""
         )  # so we never get stuck waiting for a running stream to return something
 
-    def _start_new_stream(self, prompt: bytes, temperature: float):
+    def _start_new_stream(self, prompt: bytes, temperature: float) -> None:
         assert isinstance(prompt, bytes)
         # make sure the display is up to date (since we are about to delay for a while)
         # TODO: how can we handle this better since the engine is now separate from the client?
@@ -216,10 +216,10 @@ class GrammarlessEngine(Engine):
             )
 
         # stop any running stream
-        if isinstance(self._model_interaction_thread, threading.Thread):
-            if self._running_stream():
-                self._not_running_stream.set()  # stop the generator
-                self._model_interaction_thread.join()  # wait for the thread to finish
+        if self._running_stream():
+            # Stop generator and wait for thread to complete
+            self._not_running_stream.set()
+            self._model_interaction_thread.join()  # type: ignore # mypy being strange
 
         # clear the data queue
         while not self._data_queue.empty():

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -144,7 +144,7 @@ class GrammarlessEngine(Engine):
         self._last_call = 0.0
         self._num_calls_made = 0
         self._current_temp = 0.0
-        self._last_stream_start = None
+        self._last_stream_start = b""
 
         self._not_running_stream.set()
 
@@ -240,8 +240,9 @@ class GrammarlessEngine(Engine):
         )
         self._model_interaction_thread.start()
 
-    def _reset_shared_data(self, new_data, temperature: float):
+    def _reset_shared_data(self, new_data: bytes, temperature: float):
         """Should be called by _generator calls to reset the shared data state."""
+        assert isinstance(new_data, bytes)
         if temperature == 0 and self._last_stream_start == new_data:
             raise self._report_failed_match(new_data)
         self._data = new_data

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -1,15 +1,16 @@
-import threading
-import numpy as np
-import queue
-import time
-import tiktoken
-import re
 import logging
-from ._model import Engine, Model, format_pattern, ConstraintException
-from ._tokenizer import Tokenizer
-from ..chat import ChatMLTemplate
+import queue
+import threading
+import time
 
-import warnings
+from typing import Sequence
+
+import numpy as np
+import tiktoken
+
+from ..chat import ChatMLTemplate
+from ._model import ConstraintException, Engine, Model, format_pattern
+from ._tokenizer import Tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -114,10 +115,9 @@ class GrammarlessTokenizer(Tokenizer):
         chat_template = ChatMLTemplate
         super().__init__(byte_tokens, chat_template, bos_token_id, eos_token_id)
 
-    def __call__(self, byte_string):
+    def encode(self, byte_string: bytes) -> Sequence[int]:
         """Returns a list of tokens that represent the given byte string."""
         return self._orig_tokenizer.encode(byte_string)
-
 
 class GrammarlessEngine(Engine):
     def __init__(self, tokenizer, max_streaming_tokens, timeout, compute_log_probs):

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -121,7 +121,7 @@ class GrammarlessTokenizer(Tokenizer):
         return self._orig_tokenizer.encode(byte_string.decode())
 
 class GrammarlessEngine(Engine):
-    def __init__(self, tokenizer, max_streaming_tokens, timeout, compute_log_probs):
+    def __init__(self, tokenizer, max_streaming_tokens:int, timeout, compute_log_probs:bool):
         self.max_streaming_tokens = max_streaming_tokens
         self.timeout = timeout
 
@@ -193,8 +193,8 @@ class GrammarlessEngine(Engine):
             b""
         )  # so we never get stuck waiting for a running stream to return something
 
-    def _start_new_stream(self, prompt, temperature):
-
+    def _start_new_stream(self, prompt:bytes, temperature:float):
+        assert isinstance(prompt, bytes)
         # make sure the display is up to date (since we are about to delay for a while)
         # TODO: how can we handle this better since the engine is now separate from the client?
         #       we could use a timeout for the GUI update throttling, those were just kind of slow... (but would be best)
@@ -233,7 +233,7 @@ class GrammarlessEngine(Engine):
         self._data = new_data
         self._last_stream_start = self._data
 
-    def get_logits(self, token_ids, forced_bytes, current_temp):
+    def get_logits(self, token_ids, forced_bytes:bytes, current_temp):
         """Computes the logits for the given token state.
 
         This overrides a method from the Local class that is used to get
@@ -247,7 +247,7 @@ class GrammarlessEngine(Engine):
             raise ValueError("token_ids must contain some tokens.")
 
         # compute the prompt bytes
-        whole_token_prompt = b"".join([self.tokenizer.tokens[i] for i in token_ids])
+        whole_token_prompt = self.tokenizer.decode(token_ids)
         prompt = whole_token_prompt + forced_bytes
         logger.debug(f"Grammarless.get_logits: {prompt=}")
 
@@ -393,7 +393,7 @@ class GrammarlessEngine(Engine):
             logits[self.tokenizer.eos_token_id] = 0
         return logits
 
-    def _report_failed_match(self, prompt):
+    def _report_failed_match(self, prompt: bytes):
         logger.debug(f"_report_failed_match: {prompt=}")
         # check the length of the prefix match
         match_len = 0

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -1,8 +1,20 @@
+from typing import Sequence
+
 import numpy as np
 
 from ._model import Engine, Model, Chat
 from ._remote import RemoteEngine
 from ._tokenizer import Tokenizer
+
+
+class MockTokenizer(Tokenizer):
+    def __init__(self, tokens: Sequence[bytes]):
+
+        super().__init__(tokens, chat_template=None, bos_token_id=0, eos_token_id=0)
+
+    def recode(self, tokens: Sequence[int]) -> Sequence[int]:
+        # Make a no-op for now
+        return tokens
 
 
 class MockEngine(Engine):
@@ -83,18 +95,16 @@ class Mock(Model):
         if isinstance(byte_patterns, str) and byte_patterns.startswith("http"):
             engine = RemoteEngine(byte_patterns, **kwargs)
         else:
-            tokenizer = Tokenizer(
-                # our tokens are all bytes and all lowercase letter pairs
-                [b"<s>"]
-                + [
-                    bytes([i, j])
-                    for i in range(ord("a"), ord("z"))
-                    for j in range(ord("a"), ord("z"))
-                ]
-                + [bytes([i]) for i in range(256)],
-                0,
-                0,
-            )
+            # Our tokens are all bytes and all lowercase letter pairs
+            all_lc_pairs = [
+                bytes([i, j])
+                for i in range(ord("a"), ord("z"))
+                for j in range(ord("a"), ord("z"))
+            ]
+            all_bytes = [bytes([i]) for i in range(256)]
+            tokens = [b"<s>"] + all_lc_pairs + all_bytes
+
+            tokenizer = MockTokenizer(tokens)
             engine = MockEngine(tokenizer, byte_patterns, compute_log_probs, force)
 
         super().__init__(engine, echo=echo)

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1000,7 +1000,7 @@ class Model:
             clear_output(wait=True)
         return self._html()
 
-    def _current_prompt(self) -> bytes:
+    def _current_prompt(self) -> str:
         """The current prompt in bytes (which is the state without the context close tags)."""
         return format_pattern.sub("", self._state)
 

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1000,7 +1000,7 @@ class Model:
             clear_output(wait=True)
         return self._html()
 
-    def _current_prompt(self):
+    def _current_prompt(self) -> bytes:
         """The current prompt in bytes (which is the state without the context close tags)."""
         return format_pattern.sub("", self._state)
 

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -55,6 +55,8 @@ from .._grammar import (
 from .. import _serialization_pb2
 from ..chat import load_template_class
 
+from ._tokenizer import Tokenizer
+
 if TYPE_CHECKING:
     from ..library._block import ContextBlock
 
@@ -140,7 +142,7 @@ class Engine:
     Server so a single server can serve many clients' model objects through a single Engine object.
     """
 
-    def __init__(self, tokenizer, compute_log_probs=False):
+    def __init__(self, tokenizer: Tokenizer, compute_log_probs=False):
         self.tokenizer = tokenizer
         self.compute_log_probs = compute_log_probs
 
@@ -747,7 +749,7 @@ class Engine:
     def _cleanup_tokens(self, token_ids, token_byte_positions):
 
         # compute a joint tokenization
-        joint_token_ids = self._joint_tokenize(token_ids)
+        joint_token_ids = self.tokenizer.recode(token_ids)
 
         # see if we need to redo the tokenization
         redo = False
@@ -805,10 +807,6 @@ class Engine:
             "We can't consume any more tokens, but we are not yet done! Perhaps your model's token set is incomplete? This happened after the prompt:"
             + str(prompt[-40:])
         )
-
-    def _joint_tokenize(self, token_ids):
-        """What a full joint tokenizer would give for a given byte string"""
-        return token_ids
 
 
 class Model:

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1000,7 +1000,7 @@ class Model:
             clear_output(wait=True)
         return self._html()
 
-    def _current_prompt(self) -> str:
+    def _current_prompt(self):
         """The current prompt in bytes (which is the state without the context close tags)."""
         return format_pattern.sub("", self._state)
 

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -106,9 +106,7 @@ class OpenAIEngine(GrammarlessEngine):
                     btext = prompt[pos : pos + end_pos]
                     pos += end_pos + len(role_end)
                     message_content: str = btext.decode("utf8")
-                    input_token_count += len(
-                        self.tokenizer.encode(btext)
-                    )
+                    input_token_count += len(self.tokenizer.encode(btext))
                     messages.append({"role": role_name, "content": message_content})
                     found = True
                     break

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -1,14 +1,9 @@
-import os
 import typing
 
-import diskcache as dc
-import hashlib
-import platformdirs
 import tiktoken
 
 
-from ._model import Chat, Instruct
-from ._grammarless import GrammarlessEngine, Grammarless, GrammarlessTokenizer
+from ._grammarless import GrammarlessEngine, Grammarless
 
 try:
     import openai

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -107,7 +107,7 @@ class OpenAIEngine(GrammarlessEngine):
                     pos += end_pos + len(role_end)
                     message_content: str = btext.decode("utf8")
                     input_token_count += len(
-                        self.tokenizer.encode(message_content.encode())
+                        self.tokenizer.encode(btext)
                     )
                     messages.append({"role": role_name, "content": message_content})
                     found = True

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -53,7 +53,7 @@ class OpenAIEngine(GrammarlessEngine):
 
         super().__init__(tokenizer, max_streaming_tokens, timeout, compute_log_probs)
 
-    def _generator_completion(self, prompt :bytes, temperature: float):
+    def _generator_completion(self, prompt: bytes, temperature: float):
         # Only runs on legacy openAI models that use old completion endpoints.
         self._reset_shared_data(prompt, temperature)  # update our shared data state
 
@@ -78,10 +78,12 @@ class OpenAIEngine(GrammarlessEngine):
                 chunk = part.choices[0].text or ""
             else:
                 chunk = ""
-            self.metrics.engine_output_tokens += len(self.tokenizer.encode(chunk.encode()))
+            self.metrics.engine_output_tokens += len(
+                self.tokenizer.encode(chunk.encode())
+            )
             yield chunk.encode("utf8")
 
-    def _generator_chat(self, prompt:bytes, temperature:float):
+    def _generator_chat(self, prompt: bytes, temperature: float):
         # find the role tags
         pos = 0
         role_end = b"<|im_end|>\n"
@@ -108,8 +110,10 @@ class OpenAIEngine(GrammarlessEngine):
                         break
                     btext = prompt[pos : pos + end_pos]
                     pos += end_pos + len(role_end)
-                    message_content :str = btext.decode("utf8")
-                    input_token_count += len(self.tokenizer.encode(message_content.encode()))
+                    message_content: str = btext.decode("utf8")
+                    input_token_count += len(
+                        self.tokenizer.encode(message_content.encode())
+                    )
                     messages.append({"role": role_name, "content": message_content})
                     found = True
                     break
@@ -148,14 +152,16 @@ class OpenAIEngine(GrammarlessEngine):
                 else:
                     chunk = ""
                 encoded_chunk = chunk.encode("utf8")
-                self.metrics.engine_output_tokens += len(self.tokenizer.encode(encoded_chunk))
+                self.metrics.engine_output_tokens += len(
+                    self.tokenizer.encode(encoded_chunk)
+                )
                 yield encoded_chunk
 
         except Exception as e:
             # TODO: add retry logic, keeping mind of token counts
             raise e
 
-    def _generator(self, prompt: bytes, temperature:float):
+    def _generator(self, prompt: bytes, temperature: float):
         assert isinstance(prompt, bytes)
         if self.model_name in self._completion_models:
             return self._generator_completion(prompt, temperature)

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -14,7 +14,7 @@ class Tokenizer:
 
     def __init__(
         self,
-        tokens: Union[list, np.ndarray],
+        tokens: Union[Sequence[bytes], np.ndarray],
         chat_template: Union[str, ChatTemplate, None],
         bos_token_id: Union[int, None] = None,
         eos_token_id: Union[int, None] = None,

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -88,14 +88,29 @@ class Tokenizer:
     def encode(self, byte_string: bytes) -> Sequence[int]:
         """Returns a list of tokens that represent the given byte string."""
         raise NotImplementedError(
-            "You need to use a Tokenize subclass that overrides the bytes_to_tokens method"
+            "You need to use a Tokenize subclass that overrides the encode method"
         )
 
     def decode(self, tokens: Sequence[int]) -> bytes:
         """Returns the bytes represented by the given list of tokens."""
-        raise NotImplementedError(
-            "You need to use a Tokenize subclass that overrides the tokens_to_bytes method"
-        )
+        return b"".join([self.tokens[t] for t in tokens])
+    
+    def recode(self, tokens: Sequence[int]) -> Sequence[int]:
+        """Redoes a tokenisation.
+
+        Encoding a string into tokens does not distribute over concatenation.
+        That is, in general, `encode(A)+encode(B) != encode(A+B)` (although it
+        it may in some cases).
+        An LLM will generate token-by-token, but it is possible (even likely) that
+        when the generation is considered as a whole, a better tokenisation may
+        be possible.
+        This method takes in a sequence of tokens, and returns an 'improved' sequence.
+        """
+
+        # This is the notional behaviour
+        # It may need to be overridden in particular cases because
+        # we are dealing with LLM ecosystems in the real world
+        return self.encode(self.decode(tokens))
 
     def clean_duplicate_tokens(self, probs):
         """This moves all the probability mass from duplicate positons on to their primary index."""

--- a/guidance/models/_tokenizer.py
+++ b/guidance/models/_tokenizer.py
@@ -94,7 +94,7 @@ class Tokenizer:
     def decode(self, tokens: Sequence[int]) -> bytes:
         """Returns the bytes represented by the given list of tokens."""
         return b"".join([self.tokens[t] for t in tokens])
-    
+
     def recode(self, tokens: Sequence[int]) -> Sequence[int]:
         """Redoes a tokenisation.
 

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -1,10 +1,14 @@
-import os
 import atexit
-from pathlib import Path
-from itertools import takewhile
-import operator
-import sys
 import logging
+import operator
+import os
+import sys
+
+from typing import Sequence
+
+from itertools import takewhile
+from pathlib import Path
+
 import numpy as np
 
 from .._model import Engine, Model, Chat
@@ -75,7 +79,7 @@ class LlamaCppTokenizer(Tokenizer):
             tokens, chat_template, tokenizer.llama.token_bos(), tokenizer.llama.token_eos()
         )
 
-    def __call__(self, byte_string):
+    def encode(self, byte_string: bytes) -> Sequence[int]:
         return self._model_obj.tokenize(byte_string, add_bos=False, special=True)
 
 

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -140,10 +140,6 @@ class LlamaCppEngine(Engine):
 
         self._n_vocab = len(self.tokenizer.tokens)
 
-    def _joint_tokenize(self, token_ids):
-        """What a full joint tokenizer would give for a given byte string"""
-        byte_string = b"".join([self.tokenizer.tokens[t] for t in token_ids])
-        return self.tokenizer(byte_string)
 
     def get_logits(self, token_ids, forced_bytes, current_temp):
         """Computes the logits for the given token state.

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -1,5 +1,8 @@
 import os
 import re
+import textwrap
+
+from typing import Sequence
 
 try:
     import torch
@@ -67,14 +70,23 @@ class TransformersTokenizer(Tokenizer):
                     reconstructed += bytes(
                         [byte_decoder[c] for c in t.convert_ids_to_tokens(i)]
                     )
-                # Check if the tokenizer has a bos_token attribute, and if it does, check if it's at the start of the reconstructed bytes
-                # Some tokenizers add this automatically as part of the call function, so we need to remove it to compare
-                if hasattr(t, "bos_token") and reconstructed.startswith(t.bos_token.encode()):
+                # Check if the tokenizer has a bos_token attribute, and if it does, check
+                # if it's at the start of the reconstructed bytes
+                # Some tokenizers add this automatically as part of the call function, so
+                # we need to remove it to compare
+                if hasattr(t, "bos_token") and reconstructed.startswith(
+                    t.bos_token.encode()
+                ):
                     reconstructed = reconstructed[len(t.bos_token) :]
             except:
-                raise ValueError(
-                    f"The tokenizer being used is unable to convert a special character in {s}. For models with sentencepiece based tokenizers (e.g. llama, phi-3-mini), installing sentencepiece often fixes this issue (pip install sentencepiece)."
+                msg = textwrap.dedent(
+                    f"""
+                    The tokenizer being used is unable to convert a special character in {s}.
+                    For models with sentencepiece based tokenizers (e.g. llama, phi-3-mini),
+                    installing sentencepiece often fixes this issue (pip install sentencepiece).
+                    """
                 )
+                raise ValueError(msg)
             assert (
                 reconstructed.decode() == s
             ), "The passed tokenizer does not have a byte_decoder property and using a standard gpt2 byte_decoder fails!"
@@ -105,7 +117,7 @@ class TransformersTokenizer(Tokenizer):
                 import transformers
             except:
                 raise Exception(
-                    "Please install transformers with `pip install transformers` in order to use guidance.models.togetherai!"
+                    "Please install transformers with `pip install transformers`"
                 )
 
             try:
@@ -132,13 +144,20 @@ class TransformersTokenizer(Tokenizer):
 
         return tokenizer
 
-    def __call__(self, byte_string):
+    def encode(self, byte_string: bytes) -> Sequence[int]:
+        assert isinstance(byte_string, bytes)
         tokenisation = self._orig_tokenizer(byte_string)
         return tokenisation["input_ids"]
 
+    def decode(self, tokens: Sequence[int]) -> bytes:
+        decoded_str = self._orig_tokenizer.decode(tokens)
+        return decoded_str.encode()
+
 
 class TransformersEngine(Engine):
-    def __init__(self, model, tokenizer, compute_log_probs, chat_template=None, **kwargs):
+    def __init__(
+        self, model, tokenizer, compute_log_probs, chat_template=None, **kwargs
+    ):
         # fill in default model value
         if model is None:
             model = os.environ.get("TRANSFORMERS_MODEL", None)
@@ -166,7 +185,8 @@ class TransformersEngine(Engine):
                 self._disable_retokenize_check = True
 
         super().__init__(
-            TransformersTokenizer(model, tokenizer, chat_template), compute_log_probs=compute_log_probs
+            TransformersTokenizer(model, tokenizer, chat_template),
+            compute_log_probs=compute_log_probs,
         )
         assert self._token_trie.match
 
@@ -200,7 +220,9 @@ class TransformersEngine(Engine):
                 else:
                     used_tokens -= 1
 
-        new_ids = self.tokenizer._orig_tokenizer(first_decode, add_special_tokens=False)["input_ids"]
+        new_ids = self.tokenizer._orig_tokenizer(
+            first_decode, add_special_tokens=False
+        )["input_ids"]
         if used_tokens < len(token_ids):
             new_ids += token_ids[used_tokens:]
 
@@ -223,7 +245,9 @@ class TransformersEngine(Engine):
         """
 
         # make sure we don't run off the end of the model
-        if len(token_ids) >= getattr(self.model_obj.config, "max_position_embeddings", 1e10):
+        if len(token_ids) >= getattr(
+            self.model_obj.config, "max_position_embeddings", 1e10
+        ):
             raise Exception(
                 f"Attempted to run a transformers model past its maximum context window size of {self.model_obj.config.max_position_embeddings}!"
             )
@@ -242,11 +266,15 @@ class TransformersEngine(Engine):
 
         # reset the cache length according to that number of positions
         past_key_values = self._past_key_values
-        past_length = past_key_values[0][0].size(-2) if past_key_values is not None else 0
+        past_length = (
+            past_key_values[0][0].size(-2) if past_key_values is not None else 0
+        )
         if past_length > num_cached:
             # note we recompute the last token because we don't bother to handle the special case of just computing logits
-            past_length = max(0, num_cached - 1)  
-            self._past_key_values = tuple(tuple(p[..., :past_length, :] for p in v) for v in past_key_values)
+            past_length = max(0, num_cached - 1)
+            self._past_key_values = tuple(
+                tuple(p[..., :past_length, :] for p in v) for v in past_key_values
+            )
         cache_token_ids[past_length:] = []
 
         # call the model
@@ -257,8 +285,14 @@ class TransformersEngine(Engine):
                     input_ids=torch.tensor(new_token_ids).unsqueeze(0).to(self.device),
                     past_key_values=self._past_key_values,
                     use_cache=True,
-                    position_ids=torch.arange(past_length, past_length + len(new_token_ids)).unsqueeze(0).to(self.device),
-                    attention_mask=torch.ones(1, past_length + len(new_token_ids)).to(self.device),
+                    position_ids=torch.arange(
+                        past_length, past_length + len(new_token_ids)
+                    )
+                    .unsqueeze(0)
+                    .to(self.device),
+                    attention_mask=torch.ones(1, past_length + len(new_token_ids)).to(
+                        self.device
+                    ),
                     return_dict=True,
                     output_attentions=False,
                     output_hidden_states=False,
@@ -268,7 +302,9 @@ class TransformersEngine(Engine):
             self._past_key_values = model_out.past_key_values
             cache_token_ids.extend(new_token_ids)
             # Need to add special truncating logic here for weird models that have a different output size than tokenizer vocab
-            self._cached_logits = model_out.logits[0, -1, : len(self.tokenizer.tokens)].cpu().numpy()
+            self._cached_logits = (
+                model_out.logits[0, -1, : len(self.tokenizer.tokens)].cpu().numpy()
+            )
             self.metrics.engine_input_tokens += len(new_token_ids)
             self.metrics.engine_output_tokens += 1
 
@@ -277,9 +313,22 @@ class TransformersEngine(Engine):
 
 class Transformers(Model):
     def __init__(
-        self, model=None, tokenizer=None, echo=True, compute_log_probs=False, chat_template=None, **kwargs
+        self,
+        model=None,
+        tokenizer=None,
+        echo=True,
+        compute_log_probs=False,
+        chat_template=None,
+        **kwargs,
     ):
         """Build a new Transformers model object that represents a model in a given state."""
         super().__init__(
-            TransformersEngine(model, tokenizer, compute_log_probs, chat_template=chat_template, **kwargs), echo=echo
+            TransformersEngine(
+                model,
+                tokenizer,
+                compute_log_probs,
+                chat_template=chat_template,
+                **kwargs,
+            ),
+            echo=echo,
         )


### PR DESCRIPTION
The next stage of refactoring `Tokenizer`; start having the product code conform to the tweaked `Tokenizer` class. Included in this:

- Moving `_joint_tokenize()` onto the `Tokenizer` (as `recode()`), since it really belongs there
- Making the `Tokenizer`s on the 'grammarless' side of things conform to the same contract (i.e. deal with bytes not strings)
- Added some MyPy annotations, and fixed a few issues