### PR TITLE
[Refactor] Tidy up Grammarless and OpenAI

### DIFF
--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -1,15 +1,13 @@
 import logging
 import queue
-import re
 import threading
 import time
-import warnings
 
 import numpy as np
 import tiktoken
 
 from ..chat import ChatMLTemplate
-from ._model import ConstraintException, Engine, Model, format_pattern
+from ._model import ConstraintException, Engine, Model
 from ._tokenizer import Tokenizer
 
 logger = logging.getLogger(__name__)

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -127,14 +127,14 @@ class GrammarlessEngine(Engine):
         self.timeout = timeout
 
         # this is where the streaming thread puts results
-        self._data_queue = queue.Queue()
+        self._data_queue: queue.Queue = queue.Queue()
         self._data = b""  # these are the bytes we are ready to use in the main thread
 
         # this is phrased negatively so we can wait for the stop event
-        self._not_running_stream = threading.Event()
-        self._last_call = 0
+        self._not_running_stream: threading.Event = threading.Event()
+        self._last_call = 0.0
         self._num_calls_made = 0
-        self._current_temp = 0
+        self._current_temp = 0.0
         self._last_stream_start = None
 
         self._not_running_stream.set()

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -156,6 +156,10 @@ class GrammarlessEngine(Engine):
         # build the Engine
         super().__init__(tokenizer=tokenizer, compute_log_probs=compute_log_probs)
 
+    def _generator(self, prompt: bytes, temperature: float):
+        # Not quite the implementation yet....
+        raise NotImplementedError("Child classes must implement _generator()")
+
     def __call__(self, *args, **kwargs):
         self._num_calls_made = 0  # reset the number of calls count so we only limit the number of calls within a single grammar execution
         return super().__call__(*args, **kwargs)
@@ -352,6 +356,7 @@ class GrammarlessEngine(Engine):
             # extend our data with a chunk from the model stream
             if not self._data_queue.empty():
                 new_bytes = self._data_queue.get_nowait()
+                logger.debug(f"Got {new_bytes} from _data_queue")
                 if isinstance(new_bytes, Exception):
                     raise new_bytes
 
@@ -372,8 +377,11 @@ class GrammarlessEngine(Engine):
 
             # we wait for the running stream to put something in the queue
             else:
-                self._last_call = 10e9  # set to essentialy infinity so we don't stop the data stream while we are waiting for it
+                # Set to essentialy infinity so we don't stop the data stream while we are waiting for it
+                self._last_call = 1e11
+
                 new_bytes = self._data_queue.get()
+                logger.debug(f"Got {new_bytes} from _data_queue")
                 if isinstance(new_bytes, Exception):
                     raise new_bytes
                 self._data += new_bytes

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -208,8 +208,9 @@ class GrammarlessEngine(Engine):
 
         # stop any running stream
         if self._running_stream():
-            self._not_running_stream.set()  # stop the generator
-            self._remote_thread.join()  # wait for the thread to finish
+            # Stop stream and wait for thread to complete
+            self._not_running_stream.set()
+            self._remote_thread.join()  # type: ignore # mypy being strange
 
         # clear the data queue
         while not self._data_queue.empty():

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -1,15 +1,16 @@
-import threading
-import numpy as np
-import queue
-import time
-import tiktoken
-import re
 import logging
-from ._model import Engine, Model, format_pattern, ConstraintException
-from ._tokenizer import Tokenizer
-from ..chat import ChatMLTemplate
-
+import queue
+import re
+import threading
+import time
 import warnings
+
+import numpy as np
+import tiktoken
+
+from ..chat import ChatMLTemplate
+from ._model import ConstraintException, Engine, Model, format_pattern
+from ._tokenizer import Tokenizer
 
 logger = logging.getLogger(__name__)
 

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -194,7 +194,7 @@ class GrammarlessEngine(Engine):
             b""
         )  # so we never get stuck waiting for a running stream to return something
 
-    def _start_new_stream(self, prompt, temperature):
+    def _start_new_stream(self, prompt, temperature: float):
 
         # make sure the display is up to date (since we are about to delay for a while)
         # TODO: how can we handle this better since the engine is now separate from the client?
@@ -227,14 +227,14 @@ class GrammarlessEngine(Engine):
         )
         self._remote_thread.start()
 
-    def _reset_shared_data(self, new_data, temperature):
+    def _reset_shared_data(self, new_data, temperature: float):
         """Should be called by _generator calls to reset the shared data state."""
         if temperature == 0 and self._last_stream_start == new_data:
             raise self._report_failed_match(new_data)
         self._data = new_data
         self._last_stream_start = self._data
 
-    def get_logits(self, token_ids, forced_bytes, current_temp):
+    def get_logits(self, token_ids, forced_bytes: bytes, current_temp: float):
         """Computes the logits for the given token state.
 
         This overrides a method from the Local class that is used to get

--- a/guidance/models/_grammarless.py
+++ b/guidance/models/_grammarless.py
@@ -3,6 +3,8 @@ import queue
 import threading
 import time
 
+from typing import Sequence
+
 import numpy as np
 import tiktoken
 
@@ -239,7 +241,9 @@ class GrammarlessEngine(Engine):
         self._data = new_data
         self._last_stream_start = self._data
 
-    def get_logits(self, token_ids, forced_bytes: bytes, current_temp: float):
+    def get_logits(
+        self, token_ids: Sequence[int], forced_bytes: bytes, current_temp: float
+    ):
         """Computes the logits for the given token state.
 
         This overrides a method from the Local class that is used to get

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -1,14 +1,8 @@
-import os
 import typing
 
-import diskcache as dc
-import hashlib
-import platformdirs
 import tiktoken
 
-
-from ._model import Chat, Instruct
-from ._grammarless import GrammarlessEngine, Grammarless, GrammarlessTokenizer
+from ._grammarless import Grammarless, GrammarlessEngine
 
 try:
     import openai
@@ -53,7 +47,7 @@ class OpenAIEngine(GrammarlessEngine):
 
         super().__init__(tokenizer, max_streaming_tokens, timeout, compute_log_probs)
 
-    def _generator_completion(self, prompt, temperature):
+    def _generator_completion(self, prompt, temperature: float):
         # Only runs on legacy openAI models that use old completion endpoints.
         self._reset_shared_data(prompt, temperature)  # update our shared data state
 
@@ -81,7 +75,7 @@ class OpenAIEngine(GrammarlessEngine):
             self.metrics.engine_output_tokens += len(self.tokenizer(chunk))
             yield chunk.encode("utf8")
 
-    def _generator_chat(self, prompt, temperature):
+    def _generator_chat(self, prompt, temperature: float):
         # find the role tags
         pos = 0
         role_end = b"<|im_end|>\n"
@@ -155,7 +149,7 @@ class OpenAIEngine(GrammarlessEngine):
             # TODO: add retry logic, keeping mind of token counts
             raise e
 
-    def _generator(self, prompt, temperature):
+    def _generator(self, prompt, temperature: float):
         if self.model_name in self._completion_models:
             return self._generator_completion(prompt, temperature)
         else:


### PR DESCRIPTION
Doing some general tidying up for `Grammarless` and `OpenAI`:

- Start adding some type hints
- Rationalise imports
- Trim code block apparently overlooked from the `Engine`/`Model` split