### PR TITLE
[Bug] Fix for LlamaCpp tokeniser prepending

### DIFF
--- a/tests/models/test_llama_cpp.py
+++ b/tests/models/test_llama_cpp.py
@@ -160,6 +160,7 @@ class TestLlamaCppTokenizers:
         " two words ",
         "two words ",
         "’",
+        "’•¶∂ƒ˙∆£Ħ爨ൠᅘ∰፨",
     ]
 
     @pytest.mark.parametrize("target_string", ROUND_TRIP_STRINGS)

--- a/tests/models/test_llama_cpp.py
+++ b/tests/models/test_llama_cpp.py
@@ -37,9 +37,7 @@ def test_llama_cpp_recursion_error(llamacpp_model: guidance.models.Model):
     {gen('verse', max_tokens=2)}
     """
     )
-    assert len(str(lm)) > len(
-        "Tweak this proverb to apply to model instructions instead.\n\n"
-    )
+    assert len(str(lm)) > len("Tweak this proverb to apply to model instructions instead.\n\n")
 
 
 def test_llama_cpp_select2(llamacpp_model: guidance.models.Model):
@@ -67,11 +65,7 @@ def test_repeat_calls(llamacpp_model: guidance.models.Model):
 
 def test_suffix(llamacpp_model: guidance.models.Model):
     llama2 = llamacpp_model
-    lm = (
-        llama2
-        + "1. Here is a sentence "
-        + gen(name="bla", list_append=True, suffix="\n")
-    )
+    lm = llama2 + "1. Here is a sentence " + gen(name="bla", list_append=True, suffix="\n")
     assert (str(lm))[-1] == "\n"
     assert (str(lm))[-2] != "\n"
 
@@ -153,3 +147,27 @@ def test_max_tokens(llamacpp_model: guidance.models.Model):
     assert (
         str(lm)[-1] != "<"
     )  # the output should not end with "<" because that is coming from the stop sequence...
+
+
+class TestLlamaCppTokenizers:
+    ROUND_TRIP_STRINGS = [
+        "",
+        " ",
+        "hello",
+        " hello",
+        "two words",
+        " two words",
+        " two words ",
+        "two words ",
+        "’",
+    ]
+
+    @pytest.mark.parametrize("target_string", ROUND_TRIP_STRINGS)
+    def test_string_roundtrip(self, llamacpp_model: guidance.models.Model, target_string: str):
+        my_tok = llamacpp_model.engine.tokenizer
+
+        encoded = my_tok.encode(target_string.encode())
+        decoded = my_tok.decode(encoded)
+        final_string = decoded.decode()
+
+        assert final_string != target_string


### PR DESCRIPTION
There seems to be a bug in the `LlamaCpp` tokenisers, where they [prepend spaces](https://github.com/abetlen/llama-cpp-python/issues/1531). Fix this following @mmoskal , by prepending a byte which is extremely unlikely to occur in a real string, and using it to figure out the offending prefix.