### PR TITLE
[Fix] Remove Mistral from CI

### DIFF
--- a/tests/models/test_azureai_studio.py
+++ b/tests/models/test_azureai_studio.py
@@ -1,4 +1,4 @@
-import pytest
+import logging
 
 import pytest
 
@@ -7,6 +7,8 @@ from guidance import assistant, gen, models, system, user
 
 from . import common_chat_testing
 from ..utils import env_or_fail
+
+logger = logging.getLogger(__name__)
 
 # Everything in here needs credentials to work
 # Mark is configured in pyproject.toml
@@ -23,6 +25,9 @@ def _get_chat_model(model_name: str):
     azureai_studio_endpoint = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_ENDPOINT")
     azureai_studio_deployment = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_DEPLOYMENT")
     azureai_studio_key = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_KEY")
+
+    logger.info(f"{azureai_studio_endpoint=}")
+    logger.info(f"{azureai_studio_deployment=}")
 
     lm = models.AzureAIStudioChat(
         azureai_studio_endpoint=azureai_studio_endpoint,

--- a/tests/models/test_azureai_studio.py
+++ b/tests/models/test_azureai_studio.py
@@ -12,7 +12,8 @@ pytestmark = pytest.mark.needs_credentials
 
 # How to fill out the environment variables to
 # set up the models
-_chat_models = {"phi3": "PHI3", "mistral": "MISTRAL_CHAT", "llama3": "LLAMA3_CHAT"}
+# Temporarily remove mistral pending endpoint investigation
+_chat_models = {"phi3": "PHI3", "llama3": "LLAMA3_CHAT"}
 
 
 def _get_chat_model(model_name: str):
@@ -21,9 +22,6 @@ def _get_chat_model(model_name: str):
     azureai_studio_endpoint = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_ENDPOINT")
     azureai_studio_deployment = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_DEPLOYMENT")
     azureai_studio_key = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_KEY")
-
-    print(f"{azureai_studio_endpoint=}")
-    print(f"{azureai_studio_deployment=}")
 
     lm = models.AzureAIStudioChat(
         azureai_studio_endpoint=azureai_studio_endpoint,

--- a/tests/models/test_azureai_studio.py
+++ b/tests/models/test_azureai_studio.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from guidance import assistant, gen, models, system, user
@@ -7,9 +5,6 @@ from guidance import assistant, gen, models, system, user
 
 from . import common_chat_testing
 from ..utils import env_or_fail
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # Everything in here needs credentials to work
 # Mark is configured in pyproject.toml
@@ -27,8 +22,8 @@ def _get_chat_model(model_name: str):
     azureai_studio_deployment = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_DEPLOYMENT")
     azureai_studio_key = env_or_fail(f"AZURE_AI_STUDIO_{env_string}_KEY")
 
-    logger.info(f"{azureai_studio_endpoint=}")
-    logger.info(f"{azureai_studio_deployment=}")
+    print(f"{azureai_studio_endpoint=}")
+    print(f"{azureai_studio_deployment=}")
 
     lm = models.AzureAIStudioChat(
         azureai_studio_endpoint=azureai_studio_endpoint,

--- a/tests/models/test_azureai_studio.py
+++ b/tests/models/test_azureai_studio.py
@@ -9,6 +9,7 @@ from . import common_chat_testing
 from ..utils import env_or_fail
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Everything in here needs credentials to work
 # Mark is configured in pyproject.toml


### PR DESCRIPTION
The Mistral endpoint is consistently failing in the CI. Take it out of the test matrix for now.