### PR TITLE
Terminal colors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ extras_requires = {
     "openai": ["openai>=1.0"],
     "schemas": ["jsonschema"],
     "server": ["fastapi", "uvicorn"],
+    "cli": ["colored"]
 }
 
 # Create the union of all our requirements


### PR DESCRIPTION
This PR:
1. Automatically detects whether the user is running in the command-line or in a notebook
   - When in a notebook, `echo=True` gives a pretty HTML display
   - When in the command-line, raw text is printed to stdout (no more `<IPython.core.display.HTML object>`!)
3. Uses ANSI color codes to color generated text
   - Green by default
   - If `colored` package is installed (added as optional dependency), colors will depend on log-probabilities of generated tokens

Thank you @dimondjik for your [implementation](https://github.com/guidance-ai/guidance/discussions/850)!

In action:
![terminal_color](https://github.com/guidance-ai/guidance/assets/927410/5b9eae26-ff13-4f5e-b092-a2dff1f3c120)