### PR TITLE
[Bug] Pass `trust_remote_code` to `transformers.AutoTokenizer`

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -33,9 +33,10 @@ class TransformersTokenizer(Tokenizer):
         ],
         chat_template=None,
         ignore_bos_token=False,
+        **kwargs
     ):
         if transformers_tokenizer is None:
-            transformers_tokenizer = self._tokenizer(model)
+            transformers_tokenizer = self._tokenizer(model, **kwargs)
         else:
             is_ptt = isinstance(transformers_tokenizer, transformers_package.PreTrainedTokenizer)
             is_ptt_fast = isinstance(
@@ -233,7 +234,12 @@ class TransformersEngine(Engine):
                 self._disable_retokenize_check = True
 
         super().__init__(
-            TransformersTokenizer(model, tokenizer, chat_template),
+            TransformersTokenizer(
+                model,
+                tokenizer,
+                chat_template,
+                trust_remote_code=kwargs.get("trust_remote_code", False),
+            ),
             compute_log_probs=compute_log_probs,
         )
         assert self._token_trie.match


### PR DESCRIPTION
Addressing issue #909. It looks like some `transformers` tokenizers require passing the `trust_remote_code` kwarg. 

Mirroring the way we pass the kwargs of `TransformersEngine` down to `_model`, this PR passes the kwargs of `TransformersTokenizer` down to `_tokenizer`. 

Furthermore we are now getting the value of `trust_remote_code` from the engine kwargs and passing it to `TransformersTokenizer` -- this is the one bit that gives me pause because it treats this kwarg as "special".

It's not in general straightforward to determine which kwargs belong to `_model` and which belong to `_tokenizer` unless we want users passing explicit dictionaries for each (or just the tokenizer).