### PR TITLE
[Bug] Pass-through kwargs in `TransformersTokenizer`

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -33,9 +33,10 @@ class TransformersTokenizer(Tokenizer):
         ],
         chat_template=None,
         ignore_bos_token=False,
+        **kwargs,
     ):
         if transformers_tokenizer is None:
-            transformers_tokenizer = self._tokenizer(model)
+            transformers_tokenizer = self._tokenizer(model, **kwargs)
         else:
             is_ptt = isinstance(transformers_tokenizer, transformers_package.PreTrainedTokenizer)
             is_ptt_fast = isinstance(
@@ -235,6 +236,7 @@ class TransformersEngine(Engine):
         super().__init__(
             TransformersTokenizer(model, tokenizer, chat_template),
             compute_log_probs=compute_log_probs,
+            **kwargs,
         )
         assert self._token_trie.match
 

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -234,9 +234,13 @@ class TransformersEngine(Engine):
                 self._disable_retokenize_check = True
 
         super().__init__(
-            TransformersTokenizer(model, tokenizer, chat_template),
+            TransformersTokenizer(
+                model,
+                tokenizer,
+                chat_template,
+                **kwargs,
+            ),
             compute_log_probs=compute_log_probs,
-            **kwargs,
         )
         assert self._token_trie.match
 


### PR DESCRIPTION
If `TransformersModel` has `kwargs`, make sure that they reach the tokeniser.

Closes #909