### PR TITLE
[Bug] Exclude llama-cpp-python version

### DIFF
--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install sentencepiece
           pip uninstall -y llama-cpp-python
-          pip install "llama-cpp-python!=0.2.58"
+          pip install "llama-cpp-python!=0.2.58,!=0.2.79"
       - name: Run tests (except server)
         shell: bash
         run: |

--- a/tests/model_specific/test_llama_cpp.py
+++ b/tests/model_specific/test_llama_cpp.py
@@ -50,6 +50,7 @@ def test_llama_cpp_select2(llamacpp_model: guidance.models.Model):
 
 
 def test_repeat_calls(llamacpp_model: guidance.models.Model):
+    # llama-cpp-python 0.2.79 appears to have made models non-deterministic
     llama2 = llamacpp_model
     a = []
     lm = llama2 + "How much is 2 + 2? " + gen(name="test", max_tokens=10)

--- a/tests/model_specific/test_llama_cpp.py
+++ b/tests/model_specific/test_llama_cpp.py
@@ -50,7 +50,7 @@ def test_llama_cpp_select2(llamacpp_model: guidance.models.Model):
 
 
 def test_repeat_calls(llamacpp_model: guidance.models.Model):
-    # llama-cpp-python 0.2.79 appears to have made models non-deterministic
+    # llama-cpp-python 0.2.79 appears to have made models non-deterministic on Windows
     llama2 = llamacpp_model
     a = []
     lm = llama2 + "How much is 2 + 2? " + gen(name="test", max_tokens=10)


### PR DESCRIPTION
The latest release of llama-cpp-python (0.2.79) is causing issues with one of our tests (on Windows). The test in question is `test_repeat_calls`, and assumes that at T=0 (the default for `gen()`), then we can repeatedly call a LlamaCpp model and get the same result. This isn't happening, although stepping through the test itself with a debugger, I don't see anything untoward (I'm not seeing a pile up of previous prompts for example).

For now, exclude the latest llama-cpp-python version, but we may want to revisit this test if the problem persists.