### PR TITLE
[Bug] Passing through kwargs to `TransformersTokenizer`

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -22,9 +22,13 @@ from .._model import Engine, Model
 from .._tokenizer import Tokenizer
 
 # Formed by comparing model and tokenizer from_pretrained methods
+# transformers/models/auto/auto_factory.py
+# transformers/models/auto/tokenization_auto.py
 _COMMON_TRANSFORMERS_KWARGS = [
     "cache_dir",
     "force_download",
+    "proxies",
+    "resume_download",
     "revision",
     "subfolder",
     "trust_remote_code",
@@ -249,6 +253,7 @@ class TransformersEngine(Engine):
             if arg_name in kwargs:
                 passed_common_kwargs[arg_name] = kwargs[arg_name]
 
+        # Create the tokenizer
         my_tokenizer = TransformersTokenizer(
             model, tokenizer, chat_template, **passed_common_kwargs
         )

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -33,9 +33,10 @@ class TransformersTokenizer(Tokenizer):
         ],
         chat_template=None,
         ignore_bos_token=False,
+        **kwargs,
     ):
         if transformers_tokenizer is None:
-            transformers_tokenizer = self._tokenizer(model)
+            transformers_tokenizer = self._tokenizer(model, **kwargs)
         else:
             is_ptt = isinstance(transformers_tokenizer, transformers_package.PreTrainedTokenizer)
             is_ptt_fast = isinstance(


### PR DESCRIPTION
This is a fix for #909 . It ensures that any argument common to both `AutoModelForCausalLM.from_pretrained()` and `AutoTokenizer.from_pretrained()` will be passed from the former to the latter when a `TransformersModel` is created. The original issue was only about `trust_remote_code` but there are a few other arguments related to accessing Hugging Face which probably ought to be forwarded as well.

If there are LLM specific arguments which need to be shared, then users should instantiate the tokeniser separately, and pass it in.