### PR TITLE
[Build] Re-enable server tests

### DIFF
--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -117,12 +117,23 @@ jobs:
       python-version: ${{ matrix.python-version }}
       model: ${{ matrix.model }}
 
-
+  server-tests:
+    needs: end-stage-1
+    strategy:
+      fail-fast: false # Don't cancel all on first failure
+      matrix:
+        # Need to figure out what happened to 3.12
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    uses: ./.github/workflows/action_server_tests.yml
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
 
   end-stage-2:
     needs:
       - basic-tests-linux-python-other
       - basic-tests-gpu-python-latest
+      - server-tests
     name: End Stage 2
     runs-on: ubuntu-latest
     steps:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_requires = {
     "azureai": ["openai>=1.0"],
     "openai": ["openai>=1.0"],
     "schemas": ["jsonschema"],
-    "server": ["fastapi", "uvicorn"],
+    "server": ["fastapi-slim", "uvicorn"],
 }
 
 # Create the union of all our requirements

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -15,7 +15,7 @@ from guidance.library._json import _to_compact_json
 # has to start up and get ready to
 # respond to requests. Just waiting is
 # not ideal, but is the simplest option
-PROCESS_DELAY_SECS = 40
+PROCESS_DELAY_SECS = 90
 
 
 def server_process(*, mock_string: Union[str, List[str]] = ""):


### PR DESCRIPTION
Use a reduced version of FastAPI, and increase the amount of time we allow for the server process to start. If this continues to be a problem, we should implement a liveliness endpoint, and have that polled by the test (with suitable backoff and retry count).