### PR TITLE
[WIP] Structured model state

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -966,10 +966,6 @@ def _re_with_temperature(grammar, temperature, visited_set):
 #     return ModelVariable(name)
 
 
-def active_role_end() -> ModelVariable:
-    return ModelVariable("active_role_end")
-
-
 def eos_token() -> ModelVariable:
     return ModelVariable("eos_token")
 

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -8,7 +8,7 @@ from .._grammar import commit_point
 from ._any_char import any_char
 from .._grammar import capture
 from ._regex import regex as regex_grammar
-from .._grammar import token_limit, eos_token, active_role_end, with_temperature
+from .._grammar import token_limit, eos_token, with_temperature
 from ._tool import Tool
 from ._block import block
 
@@ -129,7 +129,7 @@ def gen(
         if isinstance(stop, str):
             stop = [stop]
         if regex is None:
-            stop = stop + [select([eos_token(), active_role_end()])]
+            stop = stop + [eos_token()]
 
         if stop_regex is None:
             stop_regex = []

--- a/guidance/library/_role.py
+++ b/guidance/library/_role.py
@@ -1,11 +1,18 @@
 from .._guidance import guidance
-from ._block import block
+from ._block import ContextBlock
 from ._set_attribute import set_attribute
 
 nodisp_start = "<||_#NODISP_||>"
 nodisp_end = "<||_/NODISP_||>"
 span_start = "<||_html:<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>_||>"
 span_end = "<||_html:</span>_||>"
+
+
+class RoleBlock(ContextBlock):
+    def __init__(self, role_name, opener, closer, name=None):
+        super().__init__(opener, closer, name=name)
+        self.role_name = role_name
+
 
 @guidance
 def role_opener(lm, role_name, **kwargs):
@@ -73,7 +80,8 @@ def role_closer(lm, role_name, **kwargs):
 # TODO HN: Add a docstring to better describe arbitrary role functions
 def role(role_name, text=None, **kwargs):
     if text is None:
-        return block(
+        return RoleBlock(
+            role_name=role_name,
             opener=role_opener(role_name, **kwargs),
             closer=role_closer(role_name, **kwargs),
         )

--- a/guidance/library/_role.py
+++ b/guidance/library/_role.py
@@ -16,19 +16,6 @@ class RoleBlock(ContextBlock):
 
 @guidance
 def role_opener(lm, role_name, **kwargs):
-    indent = getattr(lm, "indent_roles", True)
-
-
-    # Block start container (centers elements)
-    if indent:
-        lm += f"<||_html:<div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>{role_name.lower()}</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>_||>"
-
-    # Start of either debug or HTML no disp block
-    if indent:
-        lm += nodisp_start
-    else:
-        lm += span_start
-    
     # TODO [HN]: Temporary change while I instrument chat_template in transformers only.
     # Eventually have all models use chat_template.
     if hasattr(lm, "get_role_start"):
@@ -39,43 +26,19 @@ def role_opener(lm, role_name, **kwargs):
         raise Exception(
             f"You need to use a chat model in order the use role blocks like `with {role_name}():`! Perhaps you meant to use the {type(lm).__name__}Chat class?"
         )
-
-    # End of either debug or HTML no disp block
-    if indent:
-        lm += nodisp_end
-    else:
-        lm += span_end
-
     return lm
 
 
 @guidance
 def role_closer(lm, role_name, **kwargs):
-    indent = getattr(lm, "indent_roles", True)
-    # Start of either debug or HTML no disp block
-    if indent:
-        lm += nodisp_start
-    else:
-        lm += span_start
-
     # TODO [HN]: Temporary change while I instrument chat_template in transformers only.
     # Eventually have all models use chat_template.
     if hasattr(lm, "get_role_end"):
         lm += lm.get_role_end(role_name)
     elif hasattr(lm, "chat_template"):
         lm += lm.chat_template.get_role_end(role_name)
-
-    # End of either debug or HTML no disp block
-    if indent:
-        lm += nodisp_end
-    else:
-        lm += span_end
-
-    # End of top container
-    if indent:
-        lm += "<||_html:</div></div>_||>"
-
     return lm
+
 
 # TODO HN: Add a docstring to better describe arbitrary role functions
 def role(role_name, text=None, **kwargs):

--- a/guidance/library/_role.py
+++ b/guidance/library/_role.py
@@ -2,11 +2,6 @@ from .._guidance import guidance
 from ._block import ContextBlock
 from ._set_attribute import set_attribute
 
-nodisp_start = "<||_#NODISP_||>"
-nodisp_end = "<||_/NODISP_||>"
-span_start = "<||_html:<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>_||>"
-span_end = "<||_html:</span>_||>"
-
 
 class RoleBlock(ContextBlock):
     def __init__(self, role_name, opener, closer, name=None):

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -857,23 +857,6 @@ class Model:
         self._last_display = 0  # used to track the last display call to enable throttling
         self._last_event_stream = 0  # used to track the last event streaming call to enable throttling
 
-    @property
-    def active_role_end(self):
-        """The default end patterns we should use for `gen` calls.
-        TODO: move this logic into the gen call...we can do with if we allow model_variables to run functions.
-
-        These patterns are computed dynamically by the model object because they can depend on
-        what the current open roles are, which is something
-        """
-
-        # add any active non-empty role ends. Ignore role ends that are spaces
-        parts = []
-        for _, role_end_str in self.opened_blocks.values():
-            role_end_str = role_end_str
-            if len(role_end_str) > 0 and not re.fullmatch(r"\s+", role_end_str):
-                parts.append(role_end_str)
-
-        return select(parts)
 
     def _send_to_event_queue(self, value):
         """For streaming in code.

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -988,23 +988,11 @@ class Model:
 
     def __str__(self):
         """A string representation of the current model object (that includes context closers)."""
-        # Import in function to guard against circular import
-        from ..library._role import RoleBlock
-        lm = self.copy()
+        out = str(self._state)
         for context in reversed(self.opened_blocks):
             _, close_text = self.opened_blocks[context]
-            assert close_text is not None
-            if isinstance(context, RoleBlock):
-                lm._inplace_append(
-                    RoleCloser(
-                        role_name=context.role_name,
-                        text=close_text,
-                        indent=getattr(lm, "indent_roles", True)
-                    )
-                )
-            else:
-                lm += close_text
-        return str(lm._state)
+            out += close_text
+        return out
 
     def __add__(self, value):
         """Adding is the primary mechanism for extending model state.

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -1031,7 +1031,7 @@ class Model:
                     new_blocks.append(context)
 
                     # mark this so we don't re-add when computing the opener or closer (even though we don't know the close text yet)
-                    lm.opened_blocks[context] = (0, "")
+                    lm.opened_blocks[context] = (0, None)
 
             # find what old blocks need to be removed
             old_blocks = []
@@ -1044,6 +1044,7 @@ class Model:
 
             # close any newly closed contexts
             for (pos, close_text), context in old_blocks:
+                assert close_text is not None
                 if context.name is not None:
                     # Capture
                     lm._variables[context.name] = str(lm._state[pos:])

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -980,7 +980,7 @@ class Model:
     def _repr_html_(self):
         if ipython_is_imported:
             clear_output(wait=True)
-        return self._html()
+        return self._state._html()
 
     def _current_prompt(self) -> str:
         """The current prompt in bytes (which is the state without the context close tags)."""

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -905,6 +905,7 @@ class Model:
         new_lm._variables = self._variables.copy()
         new_lm._variables_log_probs = self._variables_log_probs.copy()
         new_lm.opened_blocks = self.opened_blocks.copy()
+        new_lm._state = self._state.copy()
 
         # create a new clean event queue
         new_lm._event_queue = None  # we start with no event queue because nobody is listening to us yet

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -64,13 +64,6 @@ if TYPE_CHECKING:
 
 # define some constants we will reuse many times
 _null_grammar = string("")
-nodisp_pattern = re.compile(
-    r"&lt;\|\|_#NODISP_\|\|&gt;.*?&lt;\|\|_/NODISP_\|\|&gt;", flags=re.DOTALL
-)
-html_pattern = re.compile(r"&lt;\|\|_html:(.*?)_\|\|&gt;", flags=re.DOTALL)
-image_pattern = re.compile(r"&lt;\|_image:(.*?)\|&gt;")
-
-
 
 
 class EngineCallResponse:

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
 
 # define some constants we will reuse many times
 _null_grammar = string("")
-format_pattern = re.compile(r"<\|\|_.*?_\|\|>", flags=re.DOTALL)
 nodisp_pattern = re.compile(
     r"&lt;\|\|_#NODISP_\|\|&gt;.*?&lt;\|\|_/NODISP_\|\|&gt;", flags=re.DOTALL
 )
@@ -877,7 +876,7 @@ class Model:
         # add any active non-empty role ends. Ignore role ends that are spaces
         parts = []
         for _, role_end_str in self.opened_blocks.values():
-            role_end_str = format_pattern.sub("", role_end_str)
+            role_end_str = role_end_str
             if len(role_end_str) > 0 and not re.fullmatch(r"\s+", role_end_str):
                 parts.append(role_end_str)
 
@@ -1156,9 +1155,8 @@ class Model:
         else:
             for context in list(reversed(self.opened_blocks)):
                 if context.name == key:
-                    return format_pattern.sub(
-                        "", self._state[self.opened_blocks[context][0] :]
-                    )
+                    pos, _ = self.opened_blocks[context]
+                    return str(self._state[pos:])
 
         raise KeyError(f"Model does not contain the variable '{key}'")
 

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -951,7 +951,7 @@ class Model:
 
             if ipython_is_imported:
                 clear_output(wait=True)
-                display(HTML(self._state._html()))
+                display(HTML(self._html()))
             else:
                 pprint(self._state)
 
@@ -969,10 +969,18 @@ class Model:
             self._variables_log_probs = {}
         return self
 
+    def _html(self):
+        out = self._state._html()
+        for context in reversed(self.opened_blocks):
+            _, closer = self.opened_blocks[context]
+            if closer is not None:
+                out += closer._html()
+        return out
+
     def _repr_html_(self):
         if ipython_is_imported:
             clear_output(wait=True)
-        return self._state._html()
+        return self._html()
 
     def _current_prompt(self) -> str:
         """The current prompt in bytes (which is the state without the context close tags)."""

--- a/guidance/models/_model_state.py
+++ b/guidance/models/_model_state.py
@@ -42,6 +42,46 @@ class Image(Object):
         return f"""<img src="data:image/png;base64,'{base64.b64encode(self.data).decode()}'" style="max-width: 400px; vertical-align: middle; margin: 4px;">"""
 
 
+@dataclass
+class RoleOpener(Object):
+    role_name: str
+    text: str
+    indent: bool
+
+    def _html(self) -> str:
+        out = ""
+        if self.indent:
+            out += f"<div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>{self.role_name.lower()}</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>"
+        else:
+            out += "<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>"
+            out += self.text
+            out += "</span>"
+        return out
+
+    def __str__(self) -> str:
+        return self.text
+
+
+@dataclass()
+class RoleCloser(Object):
+    role_name: str
+    text: str
+    indent: bool
+
+    def _html(self) -> str:
+        out = ""
+        if self.indent:
+            out += "</div></div>"
+        else:
+            out += "<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>"
+            out += self.text
+            out += "</span>"
+        return out
+
+    def __str__(self) -> str:
+        return self.text
+
+
 class ModelState:
     def __init__(self) -> None:
         self.objects: list[Object] = []

--- a/guidance/models/_model_state.py
+++ b/guidance/models/_model_state.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+import base64
+import html
+
+@dataclass
+class Object:
+    def _html(self) -> str:
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass
+class Text(Object):
+    text: str
+    probability: Optional[float] = None
+
+    def __str__(self) -> str:
+        return self.text
+
+    def _html(self) -> str:
+        escaped_text = html.escape(self.text)
+        if self.probability is not None:
+            style = f"background-color: rgba({165*(1-self.probability) + 0}, {165*self.probability + 0}, 0, {0.15}); border-radius: 3px;"
+            return f"<span style='{style}' title='{self.probability}'>{escaped_text}</span>"
+        return escaped_text
+
+
+@dataclass
+class Image(Object):
+    id: str
+    data: bytes
+
+    def __str__(self) -> str:
+        raise NotImplementedError
+    
+    def _html(self) -> str:
+        return f"""<img src="data:image/png;base64,'{base64.b64encode(self.data).decode()}'" style="max-width: 400px; vertical-align: middle; margin: 4px;">"""
+
+
+class ModelState(list[Object]):
+    # TODO: opened blocks
+    def __str__(self) -> str:
+        out = ""
+        for obj in self:
+            out += str(obj)
+        return out
+
+    def _html(self) -> str:
+        out = "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>"
+        for obj in self:
+            out += obj._html()
+        out += "</pre>"
+        return out

--- a/guidance/models/_model_state.py
+++ b/guidance/models/_model_state.py
@@ -5,7 +5,7 @@ import base64
 import html
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Object:
     def _html(self) -> str:
         raise NotImplementedError
@@ -14,7 +14,7 @@ class Object:
         raise NotImplementedError
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Text(Object):
     text: str
     probability: Optional[float] = None
@@ -30,7 +30,7 @@ class Text(Object):
         return escaped_text
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Image(Object):
     id: str
     data: bytes
@@ -42,7 +42,7 @@ class Image(Object):
         return f"""<img src="data:image/png;base64,'{base64.b64encode(self.data).decode()}'" style="max-width: 400px; vertical-align: middle; margin: 4px;">"""
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class RoleOpener(Object):
     role_name: str
     text: str
@@ -62,7 +62,7 @@ class RoleOpener(Object):
         return self.text
 
 
-@dataclass()
+@dataclass(frozen=True, slots=True)
 class RoleCloser(Object):
     role_name: str
     text: str
@@ -83,6 +83,8 @@ class RoleCloser(Object):
 
 
 class ModelState:
+    __slots__ = ["objects"]
+
     def __init__(self) -> None:
         self.objects: list[Object] = []
 

--- a/guidance/models/_model_state.py
+++ b/guidance/models/_model_state.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, overload
 import base64
 import html
+
 
 @dataclass
 class Object:
@@ -36,22 +37,51 @@ class Image(Object):
 
     def __str__(self) -> str:
         raise NotImplementedError
-    
+
     def _html(self) -> str:
         return f"""<img src="data:image/png;base64,'{base64.b64encode(self.data).decode()}'" style="max-width: 400px; vertical-align: middle; margin: 4px;">"""
 
 
-class ModelState(list[Object]):
+class ModelState:
+    def __init__(self) -> None:
+        self.objects: list[Object] = []
+
+    def copy(self) -> ModelState:
+        new = ModelState()
+        new.objects = self.objects.copy()
+        return new
+
+    @overload
+    def __getitem__(self, index: int) -> Object: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> ModelState: ...
+
+    def __getitem__(self, index):
+        if isinstance(index, int):
+            return self.objects[index]
+        elif isinstance(index, slice):
+            new = ModelState()
+            new.objects = self.objects[index]
+            return new
+        raise TypeError(f"Index must be int or slice, not {type(index)}")
+
+    def append(self, obj: Object) -> None:
+        self.objects.append(obj)
+
+    def __len__(self) -> int:
+        return len(self.objects)
+
     # TODO: opened blocks
     def __str__(self) -> str:
         out = ""
-        for obj in self:
+        for obj in self.objects:
             out += str(obj)
         return out
 
     def _html(self) -> str:
         out = "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>"
-        for obj in self:
+        for obj in self.objects:
             out += obj._html()
         out += "</pre>"
         return out


### PR DESCRIPTION
This PR primarily replaces the implementation of model state (`Model._state`) with a list of python objects. Currently, state is a `str` with embedded "tags" that represent special embedded objects, e.g. html for formatting, images for multimodal models, etc.

On the one hand, the existing implementation is "nice" because it allows adding these special objects as strings inside of normal (and even stateless) guidance functions without having do anything "dirty" like reach into private methods on `Model` -- everything is string concatenation.

On the other hand, this means that this string has to be "parsed" to produce actual prompts (usually pretty straight-forwardly via `re.replace`), introspect on token probabilities, or extract image data from tags. This feels fragile as a model could easily produce strings that correspond to our tags and blow everything up. Furthermore, if we ever have a guidance function that produces "special" strings with formatting, etc. inside of a select block, we're actually asking the model to produce this special structure instead of just the actual textual content...

A few TODOS:
- [ ] Rethink formatting-only context blocks like `silent` and `monospace`
- [ ] See if this approach simplifies the implementation of multimodal models (@nking-1)
- [ ] See if this approach simplifies chat engines
    - e.g. have a method on `ModelState` that turns it into a list of `{"role": "user", "message": ...`} objects

Thank you @nking-1 for the help and feedback on this so far!