### PR TITLE
[Build] Disable Azure AI tests

### DIFF
--- a/tests/need_credentials/test_azureai_studio.py
+++ b/tests/need_credentials/test_azureai_studio.py
@@ -6,6 +6,8 @@ from guidance import models
 from ..model_specific import common_chat_testing
 from ..utils import env_or_fail
 
+pytest.skip("Deployments temporarily deleted", allow_module_level=True)
+
 # How to fill out the environment variables to
 # set up the models
 # Temporarily remove mistral pending endpoint investigation


### PR DESCRIPTION
We have had to delete the Azure AI deployments used by our tests. Disable them for now, pending redeployment of the relevant endpoints.