### PR TITLE
[Build] Fix CI and Notebook builds

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,6 +24,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: 'Run Azure CLI commands'
+        run: |
+            az account show
+            az group list
       - name: Install Rust
         shell: bash
         run: |
@@ -62,10 +72,8 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           # Configure endpoints for Azure OpenAI
           AZUREAI_CHAT_ENDPOINT: ${{ secrets.AZUREAI_CHAT_ENDPOINT }}
-          AZUREAI_CHAT_KEY: ${{ secrets.AZUREAI_CHAT_KEY }}
           AZUREAI_CHAT_MODEL: ${{ secrets.AZUREAI_CHAT_MODEL }}
           AZUREAI_COMPLETION_ENDPOINT: ${{ secrets.AZUREAI_COMPLETION_ENDPOINT }}
-          AZUREAI_COMPLETION_KEY: ${{ secrets.AZUREAI_COMPLETION_KEY }}
           AZUREAI_COMPLETION_MODEL: ${{ secrets.AZUREAI_COMPLETION_MODEL }}
           # Configure endpoints for Azure AI Studio
           AZURE_AI_STUDIO_PHI3_ENDPOINT: ${{ vars.AZURE_AI_STUDIO_PHI3_ENDPOINT }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,6 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: GUID Check
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -45,10 +49,6 @@ jobs:
         run: |
            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.75.0
            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Show GPUs
         run: |
           nvidia-smi

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,6 +13,10 @@ on:
     # Run at 1030 UTC every day
     - cron:  '30 10 * * *'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,8 +31,12 @@ jobs:
       - name: GUID Check
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run:
           python -c "import os; value = os.getenv('AZURE_CLIENT_ID'); print(' '.join(value))"
+          python -c "import os; value = os.getenv('AZURE_TENANT_ID'); print(' '.join(value))"
+          python -c "import os; value = os.getenv('AZURE_SUBSCRIPTION_ID'); print(' '.join(value))"
 
       - name: 'Az CLI login'
         uses: azure/login@v1

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -37,7 +37,6 @@ jobs:
           python -c "import os; value = os.getenv('AZURE_CLIENT_ID'); print(' '.join(value))"
           python -c "import os; value = os.getenv('AZURE_TENANT_ID'); print(' '.join(value))"
           python -c "import os; value = os.getenv('AZURE_SUBSCRIPTION_ID'); print(' '.join(value))"
-
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,6 +24,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: GUID Check
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        run:
+          python -c "import os; value = os.getenv('AZURE_CLIENT_ID'); print(' '.join(value))"
+
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -32,16 +32,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: 'Az CLI login'
-        uses: azure/login@v1
-        with:
-            client-id: ${{ secrets.AZURE_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: 'Run Azure CLI commands'
-        run: |
-            az account show
-            az group list
       - name: Install Rust
         shell: bash
         run: |
@@ -71,6 +61,16 @@ jobs:
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: 'Run Azure CLI commands'
+        run: |
+            az account show
+            az group list
       - name: Test with pytest
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -28,15 +28,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: GUID Check
-        env:
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        run: |
-          python -c "import os; value = os.getenv('AZURE_CLIENT_ID'); print(' '.join(value))"
-          python -c "import os; value = os.getenv('AZURE_TENANT_ID'); print(' '.join(value))"
-          python -c "import os; value = os.getenv('AZURE_SUBSCRIPTION_ID'); print(' '.join(value))"
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        run:
+        run: |
           python -c "import os; value = os.getenv('AZURE_CLIENT_ID'); print(' '.join(value))"
           python -c "import os; value = os.getenv('AZURE_TENANT_ID'); print(' '.join(value))"
           python -c "import os; value = os.getenv('AZURE_SUBSCRIPTION_ID'); print(' '.join(value))"

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -16,6 +16,10 @@ on:
     # Run at 0830 UTC every day
     - cron:  '30 08 * * *'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
 
@@ -60,15 +64,23 @@ jobs:
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: 'Run Azure CLI commands'
+        run: |
+            az account show
+            az group list
       - name: Test with pytest
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           # Configure endpoints for Azure OpenAI
           AZUREAI_CHAT_ENDPOINT: ${{ secrets.AZUREAI_CHAT_ENDPOINT }}
-          AZUREAI_CHAT_KEY: ${{ secrets.AZUREAI_CHAT_KEY }}
           AZUREAI_CHAT_MODEL: ${{ secrets.AZUREAI_CHAT_MODEL }}
           AZUREAI_COMPLETION_ENDPOINT: ${{ secrets.AZUREAI_COMPLETION_ENDPOINT }}
-          AZUREAI_COMPLETION_KEY: ${{ secrets.AZUREAI_COMPLETION_KEY }}
           AZUREAI_COMPLETION_MODEL: ${{ secrets.AZUREAI_COMPLETION_MODEL }}
           # Configure endpoints for Azure AI Studio
           AZURE_AI_STUDIO_PHI3_ENDPOINT: ${{ vars.AZURE_AI_STUDIO_PHI3_ENDPOINT }}

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -187,7 +187,7 @@ class Phi3MiniChatTemplate(ChatTemplate):
 CHAT_TEMPLATE_CACHE[phi3_mini_template] = Phi3MiniChatTemplate
 
 # https://huggingface.co/microsoft/Phi-3-small-8k-instruct/blob/main/tokenizer_config.json
-phi3_small_template = "{{ bos_token }}{% for message in messages %}{% if (message['role'] == 'user') %}{{'<|user|>' + '\n' + message['content'] + '<|end|>' + '\n' + '<|assistant|>' + '\n'}}{% elif (message['role'] == 'assistant') %}{{message['content'] + '<|end|>' + '\n'}}{% endif %}{% endfor %}"
+phi3_small_template = "{{ bos_token }}{% for message in messages %}{{'<|' + message['role'] + '|>' + '\n' + message['content'] + '<|end|>\n' }}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% else %}{{ eos_token }}{% endif %}"
 class Phi3SmallChatTemplate(ChatTemplate):
     # available_roles = ["user", "assistant"]
     template_str = phi3_small_template
@@ -204,6 +204,26 @@ class Phi3SmallChatTemplate(ChatTemplate):
         return "<|end|>"
 
 CHAT_TEMPLATE_CACHE[phi3_small_template] = Phi3SmallChatTemplate
+
+
+# https://huggingface.co/microsoft/Phi-3-medium-4k-instruct/blob/main/tokenizer_config.json#L119
+phi3_medium_template = "{% for message in messages %}{% if (message['role'] == 'user') %}{{'<|user|>' + '\n' + message['content'] + '<|end|>' + '\n' + '<|assistant|>' + '\n'}}{% elif (message['role'] == 'assistant') %}{{message['content'] + '<|end|>' + '\n'}}{% endif %}{% endfor %}"
+class Phi3MediumChatTemplate(ChatTemplate):
+    # available_roles = ["user", "assistant"]
+    template_str = phi3_medium_template
+
+    def get_role_start(self, role_name):
+        if role_name == "user":
+            return "<|user|>"
+        elif role_name == "assistant":
+            return "<|assistant|>"
+        else:
+            raise UnsupportedRoleException(role_name, self)
+        
+    def get_role_end(self, role_name=None):
+        return "<|end|>"
+
+CHAT_TEMPLATE_CACHE[phi3_medium_template] = Phi3MediumChatTemplate
 
 # --------------------------------------------------
 # @@@@ Mistral-7B-Instruct-v0.2 @@@@

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -37,7 +37,8 @@ class ChatTemplateCache:
 
 # Feels weird having to instantiate this, but it's a singleton for all purposes
 # TODO [HN]: Add an alias system so we can instantiate with other simple keys (e.g. "llama2" instead of the full template string)
-CHAT_TEMPLATE_CACHE = ChatTemplateCache() 
+CHAT_TEMPLATE_CACHE = ChatTemplateCache()
+
 
 class UnsupportedRoleException(Exception):
     def __init__(self, role_name, instance):
@@ -46,11 +47,12 @@ class UnsupportedRoleException(Exception):
         super().__init__(self._format_message())
 
     def _format_message(self):
-        return (f"Role {self.role_name} is not supported by the {self.instance.__class__.__name__} chat template. ")
+        return f"Role {self.role_name} is not supported by the {self.instance.__class__.__name__} chat template. "
+
 
 def load_template_class(chat_template=None):
     """Utility method to find the best chat template.
-    
+
     Order of precedence:
     - If it's a chat template class, use it directly
     - If it's a string, check the cache of popular model templates
@@ -60,9 +62,11 @@ def load_template_class(chat_template=None):
     """
     if inspect.isclass(chat_template) and issubclass(chat_template, ChatTemplate):
         if chat_template is ChatTemplate:
-            raise Exception("You can't use the base ChatTemplate class directly. Create or use a subclass instead.")
+            raise Exception(
+                "You can't use the base ChatTemplate class directly. Create or use a subclass instead."
+            )
         return chat_template
-    
+
     elif isinstance(chat_template, str):
         # First check the cache of popular model types
         # TODO: Expand keys of cache to include aliases for popular model types (e.g. "llama2, phi3")
@@ -70,13 +74,15 @@ def load_template_class(chat_template=None):
         if chat_template in CHAT_TEMPLATE_CACHE:
             return CHAT_TEMPLATE_CACHE[chat_template]
         # TODO: Add logic here to try to auto-create class dynamically via _template_class_from_string method
-    
+
     # Only warn when a user provided a chat template that we couldn't load
     if chat_template is not None:
-        warnings.warn(f"""Chat template {chat_template} was unable to be loaded directly into guidance.
+        warnings.warn(
+            f"""Chat template {chat_template} was unable to be loaded directly into guidance.
                         Defaulting to the ChatML format which may not be optimal for the selected model. 
-                        For best results, create and pass in a `guidance.ChatTemplate` subclass for your model.""")
-    
+                        For best results, create and pass in a `guidance.ChatTemplate` subclass for your model."""
+        )
+
     # By default, use the ChatML Template. Warnings to user will happen downstream only if they use chat roles.
     return ChatMLTemplate
 
@@ -94,14 +100,17 @@ def _template_class_from_string(template_str):
 # --------------------------------------------------
 # Note that all grammarless models will default to this syntax, since we typically send chat formatted messages.
 chatml_template = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}"
+
+
 class ChatMLTemplate(ChatTemplate):
     template_str = chatml_template
 
     def get_role_start(self, role_name):
         return f"<|im_start|>{role_name}\n"
-        
+
     def get_role_end(self, role_name=None):
         return "<|im_end|>\n"
+
 
 CHAT_TEMPLATE_CACHE[chatml_template] = ChatMLTemplate
 
@@ -111,6 +120,8 @@ CHAT_TEMPLATE_CACHE[chatml_template] = ChatMLTemplate
 # --------------------------------------------------
 # [05/08/24] https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/blob/main/tokenizer_config.json#L12
 llama2_template = "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = false %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 and system_message != false %}{% set content = '<<SYS>>\\n' + system_message + '\\n<</SYS>>\\n\\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ bos_token + '[INST] ' + content.strip() + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' '  + content.strip() + ' ' + eos_token }}{% endif %}{% endfor %}"
+
+
 class Llama2ChatTemplate(ChatTemplate):
     # available_roles = ["system", "user", "assistant"]
     template_str = llama2_template
@@ -124,7 +135,7 @@ class Llama2ChatTemplate(ChatTemplate):
             return " "
         else:
             raise UnsupportedRoleException(role_name, self)
-        
+
     def get_role_end(self, role_name=None):
         if role_name == "system":
             return "\n<</SYS>"
@@ -135,6 +146,7 @@ class Llama2ChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
+
 CHAT_TEMPLATE_CACHE[llama2_template] = Llama2ChatTemplate
 
 
@@ -143,6 +155,8 @@ CHAT_TEMPLATE_CACHE[llama2_template] = Llama2ChatTemplate
 # --------------------------------------------------
 # [05/08/24] https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/blob/main/tokenizer_config.json#L2053
 llama3_template = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{% if add_generation_prompt %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}{% endif %}"
+
+
 class Llama3ChatTemplate(ChatTemplate):
     # available_roles = ["system", "user", "assistant"]
     template_str = llama3_template
@@ -156,9 +170,10 @@ class Llama3ChatTemplate(ChatTemplate):
             return "<|start_header_id|>assistant<|end_header_id|>\n\n"
         else:
             raise UnsupportedRoleException(role_name, self)
-        
+
     def get_role_end(self, role_name=None):
         return "<|eot_id|>"
+
 
 CHAT_TEMPLATE_CACHE[llama3_template] = Llama3ChatTemplate
 
@@ -167,6 +182,8 @@ CHAT_TEMPLATE_CACHE[llama3_template] = Llama3ChatTemplate
 # --------------------------------------------------
 # [05/08/24] https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/tokenizer_config.json#L119
 phi3_mini_template = "{% for message in messages %}{% if message['role'] == 'system' %}{{'<|system|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'user' %}{{'<|user|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'assistant' %}{{'<|assistant|>\n' + message['content'] + '<|end|>\n'}}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% else %}{{ eos_token }}{% endif %}"
+
+
 class Phi3MiniChatTemplate(ChatTemplate):
     # available_roles = ["user", "assistant"]
     template_str = phi3_mini_template
@@ -180,15 +197,23 @@ class Phi3MiniChatTemplate(ChatTemplate):
             return "<|system|>"
         else:
             raise UnsupportedRoleException(role_name, self)
-        
+
     def get_role_end(self, role_name=None):
         return "<|end|>"
+
 
 CHAT_TEMPLATE_CACHE[phi3_mini_template] = Phi3MiniChatTemplate
 
 # https://huggingface.co/microsoft/Phi-3-small-8k-instruct/blob/main/tokenizer_config.json
 phi3_small_template = "{{ bos_token }}{% for message in messages %}{{'<|' + message['role'] + '|>' + '\n' + message['content'] + '<|end|>\n' }}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% else %}{{ eos_token }}{% endif %}"
-class Phi3SmallChatTemplate(ChatTemplate):
+
+
+# https://huggingface.co/microsoft/Phi-3-medium-4k-instruct/blob/main/tokenizer_config.json#L119
+phi3_medium_template = "{% for message in messages %}{% if (message['role'] == 'user') %}{{'<|user|>' + '\n' + message['content'] + '<|end|>' + '\n' + '<|assistant|>' + '\n'}}{% elif (message['role'] == 'assistant') %}{{message['content'] + '<|end|>' + '\n'}}{% endif %}{% endfor %}"
+
+
+# Although the templates are different, the roles are the same between medium and small (for now)
+class Phi3SmallMediumChatTemplate(ChatTemplate):
     # available_roles = ["user", "assistant"]
     template_str = phi3_small_template
 
@@ -199,37 +224,21 @@ class Phi3SmallChatTemplate(ChatTemplate):
             return "<|assistant|>"
         else:
             raise UnsupportedRoleException(role_name, self)
-        
+
     def get_role_end(self, role_name=None):
         return "<|end|>"
 
-CHAT_TEMPLATE_CACHE[phi3_small_template] = Phi3SmallChatTemplate
 
-
-# https://huggingface.co/microsoft/Phi-3-medium-4k-instruct/blob/main/tokenizer_config.json#L119
-phi3_medium_template = "{% for message in messages %}{% if (message['role'] == 'user') %}{{'<|user|>' + '\n' + message['content'] + '<|end|>' + '\n' + '<|assistant|>' + '\n'}}{% elif (message['role'] == 'assistant') %}{{message['content'] + '<|end|>' + '\n'}}{% endif %}{% endfor %}"
-class Phi3MediumChatTemplate(ChatTemplate):
-    # available_roles = ["user", "assistant"]
-    template_str = phi3_medium_template
-
-    def get_role_start(self, role_name):
-        if role_name == "user":
-            return "<|user|>"
-        elif role_name == "assistant":
-            return "<|assistant|>"
-        else:
-            raise UnsupportedRoleException(role_name, self)
-        
-    def get_role_end(self, role_name=None):
-        return "<|end|>"
-
-CHAT_TEMPLATE_CACHE[phi3_medium_template] = Phi3MediumChatTemplate
+CHAT_TEMPLATE_CACHE[phi3_small_template] = Phi3SmallMediumChatTemplate
+CHAT_TEMPLATE_CACHE[phi3_medium_template] = Phi3SmallMediumChatTemplate
 
 # --------------------------------------------------
 # @@@@ Mistral-7B-Instruct-v0.2 @@@@
 # --------------------------------------------------
 # [05/08/24] https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/tokenizer_config.json#L42
 mistral_7b_instruct_template = "{%- if messages[0]['role'] == 'system' %}\n    {%- set system_message = messages[0]['content'] %}\n    {%- set loop_messages = messages[1:] %}\n{%- else %}\n    {%- set loop_messages = messages %}\n{%- endif %}\n\n{{- bos_token }}\n{%- for message in loop_messages %}\n    {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}\n        {{- raise_exception('After the optional system message, conversation roles must alternate user/assistant/user/assistant/...') }}\n    {%- endif %}\n    {%- if message['role'] == 'user' %}\n        {%- if loop.first and system_message is defined %}\n            {{- ' [INST] ' + system_message + '\\n\\n' + message['content'] + ' [/INST]' }}\n        {%- else %}\n            {{- ' [INST] ' + message['content'] + ' [/INST]' }}\n        {%- endif %}\n    {%- elif message['role'] == 'assistant' %}\n        {{- ' ' + message['content'] + eos_token}}\n    {%- else %}\n        {{- raise_exception('Only user and assistant roles are supported, with the exception of an initial optional system message!') }}\n    {%- endif %}\n{%- endfor %}\n"
+
+
 class Mistral7BInstructChatTemplate(ChatTemplate):
     # available_roles = ["user", "assistant"]
     template_str = mistral_7b_instruct_template
@@ -243,7 +252,7 @@ class Mistral7BInstructChatTemplate(ChatTemplate):
             raise ValueError("Please include system instructions in the first user message")
         else:
             raise UnsupportedRoleException(role_name, self)
-        
+
     def get_role_end(self, role_name=None):
         if role_name == "user":
             return " [/INST]"
@@ -251,5 +260,6 @@ class Mistral7BInstructChatTemplate(ChatTemplate):
             return "</s>"
         else:
             raise UnsupportedRoleException(role_name, self)
+
 
 CHAT_TEMPLATE_CACHE[mistral_7b_instruct_template] = Mistral7BInstructChatTemplate

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -166,7 +166,7 @@ CHAT_TEMPLATE_CACHE[llama3_template] = Llama3ChatTemplate
 # @@@@ Phi-3 @@@@
 # --------------------------------------------------
 # [05/08/24] https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/tokenizer_config.json#L119
-phi3_template = "{{ bos_token }}{% for message in messages %}{% if (message['role'] == 'user') %}{{'<|user|>' + '\n' + message['content'] + '<|end|>' + '\n' + '<|assistant|>' + '\n'}}{% elif (message['role'] == 'assistant') %}{{message['content'] + '<|end|>' + '\n'}}{% endif %}{% endfor %}"
+phi3_template = "{% for message in messages %}{% if message['role'] == 'system' %}{{'<|system|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'user' %}{{'<|user|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'assistant' %}{{'<|assistant|>\n' + message['content'] + '<|end|>\n'}}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% else %}{{ eos_token }}{% endif %}"
 class Phi3ChatTemplate(ChatTemplate):
     # available_roles = ["user", "assistant"]
     template_str = phi3_template
@@ -176,6 +176,8 @@ class Phi3ChatTemplate(ChatTemplate):
             return "<|user|>"
         elif role_name == "assistant":
             return "<|assistant|>"
+        elif role_name == "system":
+            return "<|system|>"
         else:
             raise UnsupportedRoleException(role_name, self)
         

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -166,10 +166,10 @@ CHAT_TEMPLATE_CACHE[llama3_template] = Llama3ChatTemplate
 # @@@@ Phi-3 @@@@
 # --------------------------------------------------
 # [05/08/24] https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/tokenizer_config.json#L119
-phi3_template = "{% for message in messages %}{% if message['role'] == 'system' %}{{'<|system|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'user' %}{{'<|user|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'assistant' %}{{'<|assistant|>\n' + message['content'] + '<|end|>\n'}}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% else %}{{ eos_token }}{% endif %}"
-class Phi3ChatTemplate(ChatTemplate):
+phi3_mini_template = "{% for message in messages %}{% if message['role'] == 'system' %}{{'<|system|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'user' %}{{'<|user|>\n' + message['content'] + '<|end|>\n'}}{% elif message['role'] == 'assistant' %}{{'<|assistant|>\n' + message['content'] + '<|end|>\n'}}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% else %}{{ eos_token }}{% endif %}"
+class Phi3MiniChatTemplate(ChatTemplate):
     # available_roles = ["user", "assistant"]
-    template_str = phi3_template
+    template_str = phi3_mini_template
 
     def get_role_start(self, role_name):
         if role_name == "user":
@@ -184,8 +184,26 @@ class Phi3ChatTemplate(ChatTemplate):
     def get_role_end(self, role_name=None):
         return "<|end|>"
 
-CHAT_TEMPLATE_CACHE[phi3_template] = Phi3ChatTemplate
+CHAT_TEMPLATE_CACHE[phi3_mini_template] = Phi3MiniChatTemplate
 
+# https://huggingface.co/microsoft/Phi-3-small-8k-instruct/blob/main/tokenizer_config.json
+phi3_small_template = "{{ bos_token }}{% for message in messages %}{% if (message['role'] == 'user') %}{{'<|user|>' + '\n' + message['content'] + '<|end|>' + '\n' + '<|assistant|>' + '\n'}}{% elif (message['role'] == 'assistant') %}{{message['content'] + '<|end|>' + '\n'}}{% endif %}{% endfor %}"
+class Phi3SmallChatTemplate(ChatTemplate):
+    # available_roles = ["user", "assistant"]
+    template_str = phi3_small_template
+
+    def get_role_start(self, role_name):
+        if role_name == "user":
+            return "<|user|>"
+        elif role_name == "assistant":
+            return "<|assistant|>"
+        else:
+            raise UnsupportedRoleException(role_name, self)
+        
+    def get_role_end(self, role_name=None):
+        return "<|end|>"
+
+CHAT_TEMPLATE_CACHE[phi3_small_template] = Phi3SmallChatTemplate
 
 # --------------------------------------------------
 # @@@@ Mistral-7B-Instruct-v0.2 @@@@

--- a/guidance/models/_azure_guidance.py
+++ b/guidance/models/_azure_guidance.py
@@ -4,7 +4,7 @@ import base64
 import json
 import urllib.parse
 from ._model import Engine, Model, EngineCallResponse
-from ..chat import Phi3ChatTemplate
+from ..chat import Phi3MiniChatTemplate
 from ._byte_tokenizer import ByteTokenizer
 
 
@@ -30,7 +30,7 @@ class AzureGuidanceEngine(Engine):
 
         if chat_template is None:
             # TODO [PK]: obtain this from the server
-            chat_template=Phi3ChatTemplate
+            chat_template=Phi3MiniChatTemplate
 
         tokenizer = ByteTokenizer(chat_template)
 

--- a/notebooks/api_examples/models/AzureOpenAI.ipynb
+++ b/notebooks/api_examples/models/AzureOpenAI.ipynb
@@ -36,7 +36,7 @@
     "import os\n",
     "\n",
     "# Uncomment if using DefaultAzureCredential below\n",
-    "# from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
+    "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
     "\n",
     "# This is the name of the model deployed, such as 'gpt-4' or 'gpt-3.5-turbo\n",
     "model = os.getenv(\"AZUREAI_CHAT_MODEL\", \"Please set the model\")\n",
@@ -52,13 +52,13 @@
     "azure_api_version = os.getenv(\"AZUREAI_CHAT_API_VERSION\", \"Please set the API version\")\n",
     "\n",
     "# The environment variable should be set to the API key from the Azure AI playground:\n",
-    "api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
+    "# api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
     "\n",
     "# Alternatively, we can use Entra authentication\n",
-    "# token_provider = get_bearer_token_provider(\n",
-    "#     DefaultAzureCredential(),\n",
-    "#     \"https://cognitiveservices.azure.com/.default\"\n",
-    "#)"
+    "token_provider = get_bearer_token_provider(\n",
+    "     DefaultAzureCredential(),\n",
+    "     \"https://cognitiveservices.azure.com/.default\"\n",
+    ")"
    ]
   },
   {
@@ -84,9 +84,9 @@
     "    azure_deployment=azure_deployment,\n",
     "    version=azure_api_version,\n",
     "    # For authentication, use either\n",
-    "    api_key=api_key\n",
+    "    # api_key=api_key\n",
     "    # or\n",
-    "    # azure_ad_token_provider=token_provider\n",
+    "    azure_ad_token_provider=token_provider\n",
     ")"
    ]
   },

--- a/notebooks/art_of_prompt_design/use_clear_syntax.ipynb
+++ b/notebooks/art_of_prompt_design/use_clear_syntax.ipynb
@@ -479,7 +479,7 @@
     "import time\n",
     "\n",
     "# Uncomment if using DefaultAzureCredential below\n",
-    "# from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
+    "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
     "\n",
     "# This is the name of the model deployed, such as 'gpt-4' or 'gpt-3.5-turbo\n",
     "model = os.getenv(\"AZUREAI_CHAT_MODEL\", \"Please set the model\")\n",
@@ -495,13 +495,13 @@
     "azure_api_version = os.getenv(\"AZUREAI_CHAT_API_VERSION\", \"Please set the API version\")\n",
     "\n",
     "# The environment variable should be set to the API key from the Azure AI playground:\n",
-    "api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
+    "# api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
     "\n",
     "# Alternatively, we can use Entra authentication\n",
-    "# token_provider = get_bearer_token_provider(\n",
-    "#     DefaultAzureCredential(),\n",
-    "#     \"https://cognitiveservices.azure.com/.default\"\n",
-    "#)"
+    "token_provider = get_bearer_token_provider(\n",
+    "    DefaultAzureCredential(),\n",
+    "    \"https://cognitiveservices.azure.com/.default\"\n",
+    ")"
    ]
   },
   {
@@ -526,9 +526,9 @@
     "    azure_deployment=azure_deployment,\n",
     "    version=azure_api_version,\n",
     "    # For authentication, use either\n",
-    "    api_key=api_key\n",
+    "    # api_key=api_key\n",
     "    # or\n",
-    "    # azure_ad_token_provider=token_provider\n",
+    "    azure_ad_token_provider=token_provider\n",
     ")"
    ]
   },
@@ -957,9 +957,9 @@
     "    azure_deployment=azure_deployment,\n",
     "    version=azure_api_version,\n",
     "    # For authentication, use either\n",
-    "    api_key=api_key\n",
+    "    # api_key=api_key\n",
     "    # or\n",
-    "    # azure_ad_token_provider=token_provider\n",
+    "    azure_ad_token_provider=token_provider\n",
     ")"
    ]
   },

--- a/notebooks/tutorials/chat.ipynb
+++ b/notebooks/tutorials/chat.ipynb
@@ -51,7 +51,7 @@
     "import os\n",
     "\n",
     "# Uncomment if using DefaultAzureCredential below\n",
-    "# from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
+    "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
     "\n",
     "# This is the name of the model deployed, such as 'gpt-4' or 'gpt-3.5-turbo\n",
     "model = os.getenv(\"AZUREAI_CHAT_MODEL\", \"Please set the model\")\n",
@@ -67,13 +67,13 @@
     "azure_api_version = os.getenv(\"AZUREAI_CHAT_API_VERSION\", \"Please set the API version\")\n",
     "\n",
     "# The environment variable should be set to the API key from the Azure AI playground:\n",
-    "api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
+    "# api_key=os.getenv(\"AZUREAI_CHAT_KEY\", \"Please set API key\")\n",
     "\n",
     "# Alternatively, we can use Entra authentication\n",
-    "# token_provider = get_bearer_token_provider(\n",
-    "#     DefaultAzureCredential(),\n",
-    "#     \"https://cognitiveservices.azure.com/.default\"\n",
-    "#)"
+    "token_provider = get_bearer_token_provider(\n",
+    "    DefaultAzureCredential(),\n",
+    "    \"https://cognitiveservices.azure.com/.default\"\n",
+    ")"
    ]
   },
   {
@@ -97,9 +97,9 @@
     "    azure_deployment=azure_deployment,\n",
     "    version=azure_api_version,\n",
     "    # For authentication, use either\n",
-    "    # azure_ad_token_provider=token_provider,\n",
+    "    azure_ad_token_provider=token_provider,\n",
     "    # or\n",
-    "    api_key=api_key,\n",
+    "    # api_key=api_key,\n",
     ")"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ doc_requires = [
     "llama-cpp-python",
 ]
 test_requires = [
+    "azure-identity",
     "jupyter",
     "papermill",
     "pytest",

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -2,53 +2,47 @@ import pathlib
 
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+
 from guidance import assistant, gen, models, system, user
 
 from ..model_specific import common_chat_testing
 from ..utils import env_or_fail
 
-def test_azureai_openai_chat_smoke(rate_limiter):
+
+@pytest.fixture(scope="function")
+def azureai_chat_model(rate_limiter):
     azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
-    azureai_key = env_or_fail("AZUREAI_CHAT_KEY")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
+    token_provider = get_bearer_token_provider(
+        DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+    )
+
     lm = models.AzureOpenAI(
-        model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
+        model=model, azure_endpoint=azureai_endpoint, azure_ad_token_provider=token_provider
     )
     assert isinstance(lm, models.AzureOpenAI)
 
-    common_chat_testing.smoke_chat(lm)
+    return lm
 
 
-def test_azureai_openai_chat_longer_1(rate_limiter):
-    azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
-    azureai_key = env_or_fail("AZUREAI_CHAT_KEY")
-    model = env_or_fail("AZUREAI_CHAT_MODEL")
-
-    lm = models.AzureOpenAI(
-        model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
-    )
-    assert isinstance(lm, models.AzureOpenAI)
-
-    common_chat_testing.longer_chat_1(lm)
+def test_azureai_openai_chat_smoke(azureai_chat_model):
+    common_chat_testing.smoke_chat(azureai_chat_model)
 
 
-def test_azureai_openai_chat_longer_2(rate_limiter):
-    azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
-    azureai_key = env_or_fail("AZUREAI_CHAT_KEY")
-    model = env_or_fail("AZUREAI_CHAT_MODEL")
+def test_azureai_openai_chat_longer_1(azureai_chat_model):
+    common_chat_testing.longer_chat_1(azureai_chat_model)
 
-    lm = models.AzureOpenAI(
-        model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
-    )
-    assert isinstance(lm, models.AzureOpenAI)
 
-    common_chat_testing.longer_chat_2(lm)
+def test_azureai_openai_chat_longer_2(azureai_chat_model):
+    common_chat_testing.longer_chat_2(azureai_chat_model)
 
 
 def test_azureai_openai_chat_alt_args(rate_limiter):
     azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
-    azureai_key = env_or_fail("AZUREAI_CHAT_KEY")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
     parsed_url = urlparse(azureai_endpoint)
@@ -56,12 +50,16 @@ def test_azureai_openai_chat_alt_args(rate_limiter):
     azureai_deployment = pathlib.Path(parsed_url.path).parts[3]
     version = parsed_query["api-version"]
     min_azureai_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    
+    token_provider = get_bearer_token_provider(
+        DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+    )
 
     lm = models.AzureOpenAI(
         model=model,
         azure_endpoint=min_azureai_endpoint,
         version=version,
-        api_key=azureai_key,
+        azure_ad_token_provider=token_provider,
         azure_deployment=azureai_deployment,
     )
 
@@ -76,9 +74,7 @@ def test_azureai_openai_completion_smoke(rate_limiter):
     print(f"endpoint: {' '.join(azureai_endpoint)}")
     print(f"model: {' '.join(model)}")
 
-    lm = models.AzureOpenAI(
-        model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
-    )
+    lm = models.AzureOpenAI(model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key)
     assert isinstance(lm, models.AzureOpenAI)
     assert isinstance(lm.engine, models._openai.OpenAIEngine)
 
@@ -122,9 +118,7 @@ def test_azureai_openai_chat_loop(rate_limiter):
     azureai_key = env_or_fail("AZUREAI_CHAT_KEY")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
-    lm = models.AzureOpenAI(
-        model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key
-    )
+    lm = models.AzureOpenAI(model=model, azure_endpoint=azureai_endpoint, api_key=azureai_key)
     assert isinstance(lm, models.AzureOpenAI)
 
     for i in range(2):

--- a/tests/need_credentials/test_chat_templates.py
+++ b/tests/need_credentials/test_chat_templates.py
@@ -7,22 +7,23 @@ from ..utils import env_or_fail
 
 
 @pytest.mark.parametrize(
-    "model_info",
+    ("model_id", "should_pass"),
     [
         ("microsoft/Phi-3-mini-4k-instruct", True),  # Phi-3-Mini
         ("microsoft/Phi-3-small-8k-instruct", True),  # Phi-3-Small
+        ("microsoft/Phi-3-medium-4k-instruct", True),  # Phi-3-Medium
         ("meta-llama/Meta-Llama-3-8B-Instruct", True),  # Llama-3
         ("meta-llama/Llama-2-7b-chat-hf", True),  # Llama-2
         ("mistralai/Mistral-7B-Instruct-v0.2", True),  # Mistral-7B-Instruct-v0.2
         ("HuggingFaceH4/zephyr-7b-beta", False),  # Have a test for model not in cache
     ],
 )
-def test_popular_models_in_cache(model_info):
+def test_popular_models_in_cache(model_id: str, should_pass: bool):
     # This test simply checks to make sure the chat_templates haven't changed, and that they're still in our cache.
     # If this fails, the models have had their templates updated, and we need to fix the cache manually.
     hf_token = env_or_fail("HF_TOKEN")
 
-    model_id, should_pass = model_info
+    # model_id, should_pass = model_info
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         model_id, token=hf_token, trust_remote_code=True

--- a/tests/need_credentials/test_chat_templates.py
+++ b/tests/need_credentials/test_chat_templates.py
@@ -5,14 +5,16 @@ import transformers
 
 from ..utils import env_or_fail
 
+
 @pytest.mark.parametrize(
     "model_info",
     [
-        ("microsoft/Phi-3-mini-4k-instruct", True), # Phi-3
-        ("meta-llama/Meta-Llama-3-8B-Instruct", True), # Llama-3
-        ("meta-llama/Llama-2-7b-chat-hf", True), # Llama-2
-        ("mistralai/Mistral-7B-Instruct-v0.2", True), # Mistral-7B-Instruct-v0.2
-        ("HuggingFaceH4/zephyr-7b-beta", False) # Have a test for model not in cache
+        ("microsoft/Phi-3-mini-4k-instruct", True),  # Phi-3-Mini
+        ("microsoft/Phi-3-small-8k-instruct", True),  # Phi-3-Small
+        ("meta-llama/Meta-Llama-3-8B-Instruct", True),  # Llama-3
+        ("meta-llama/Llama-2-7b-chat-hf", True),  # Llama-2
+        ("mistralai/Mistral-7B-Instruct-v0.2", True),  # Mistral-7B-Instruct-v0.2
+        ("HuggingFaceH4/zephyr-7b-beta", False),  # Have a test for model not in cache
     ],
 )
 def test_popular_models_in_cache(model_info):
@@ -22,7 +24,9 @@ def test_popular_models_in_cache(model_info):
 
     model_id, should_pass = model_info
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained(model_id, token=hf_token)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_id, token=hf_token, trust_remote_code=True
+    )
     model_chat_template = tokenizer.chat_template
     if should_pass:
         assert model_chat_template in CHAT_TEMPLATE_CACHE
@@ -30,9 +34,6 @@ def test_popular_models_in_cache(model_info):
         # TODO: Expand this test to verify that a warning gets thrown when a model isn't in the cache and we have to default to chatML syntax
         assert model_chat_template not in CHAT_TEMPLATE_CACHE
 
-    
 
 # TODO: Expand testing to verify that tokenizer.apply_chat_template() produces same results as our ChatTemplate subclasses
 # once I hook up the new ChatTemplate to guidance.models.Transformers and guidance.models.LlamaCPP, we can do this
-
-


### PR DESCRIPTION
Get the CI and Notebook builds working again. The main fix involves the authentication to the AzureAI endpoints; we now have an Entra ID to use, rather than an `api_key`. The instructions are [on the Microsoft site](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure).

Also update the chat templates again, for Phi3 and Mistral. The fix for Mistral is not ideal. It appears that it now 'supports' a `system` message by inserting it into the first `user` message. I don't think our approach can really support this.