### PR TITLE
[Test] Basic checks on chat templates

### DIFF
--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -190,16 +190,16 @@ class Phi3MiniChatTemplate(ChatTemplate):
 
     def get_role_start(self, role_name):
         if role_name == "user":
-            return "<|user|>"
+            return "<|user|>\n"
         elif role_name == "assistant":
-            return "<|assistant|>"
+            return "<|assistant|>\n"
         elif role_name == "system":
-            return "<|system|>"
+            return "<|system|>\n"
         else:
             raise UnsupportedRoleException(role_name, self)
 
     def get_role_end(self, role_name=None):
-        return "<|end|>"
+        return "<|end|>\n"
 
 
 CHAT_TEMPLATE_CACHE[phi3_mini_template] = Phi3MiniChatTemplate
@@ -219,14 +219,14 @@ class Phi3SmallMediumChatTemplate(ChatTemplate):
 
     def get_role_start(self, role_name):
         if role_name == "user":
-            return "<|user|>"
+            return "<|user|>\n"
         elif role_name == "assistant":
-            return "<|assistant|>"
+            return "<|assistant|>\n"
         else:
             raise UnsupportedRoleException(role_name, self)
 
     def get_role_end(self, role_name=None):
-        return "<|end|>"
+        return "<|end|>\n"
 
 
 CHAT_TEMPLATE_CACHE[phi3_small_template] = Phi3SmallMediumChatTemplate


### PR DESCRIPTION
Add a smoke test of the chat templates, ensuring that they produce output which matches the rendering by the corresponding tokeniser.