### PR TITLE
[Feature] Automatic Chat Template

### DIFF
--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -2,7 +2,7 @@ import inspect
 import re
 import warnings
 
-from typing import Dict, Union
+from typing import Dict, Mapping, Sequence, Union
 
 
 class ChatTemplate:
@@ -266,6 +266,11 @@ class Mistral7BInstructChatTemplate(ChatTemplate):
 CHAT_TEMPLATE_CACHE[mistral_7b_instruct_template] = Mistral7BInstructChatTemplate
 
 
+class GeneralChatTemplate(ChatTemplate):
+    def __init__(self, role_dict: Mapping[str, Sequence[str]]):
+        self._role_dict = role_dict
+
+
 def auto_chat_template(
     transformers_tokenizer: Union[
         "transformers_package.PreTrainedTokenizer",
@@ -279,13 +284,17 @@ def auto_chat_template(
     ]
 
     system_0 = transformers_tokenizer.apply_chat_template(messages[:1], tokenize=False)
-    assistant_0 = transformers_tokenizer.apply_chat_template(messages[:2], tokenize=False)
-    user_0 = transformers_tokenizer.apply_chat_template(messages[:3], tokenize=False)
+    user_0 = transformers_tokenizer.apply_chat_template(messages[:2], tokenize=False)
+    assistant_0 = transformers_tokenizer.apply_chat_template(messages[:3], tokenize=False)
 
-    re_system = "(.*)AAAA(.*)"
-    system_result = re.search(pattern=re_system, string=system_0, flags=re.MULTILINE)
-    print(f"{system_result=}")
-    
+    system_parts = system_0.split("AAAA")
+
+    user_substr = user_0[len(system_0) :]
+    user_parts = user_substr.split("BBBB")
+    print(f"{user_parts=}")
+
+    assistant_substr = assistant_0[len(user_0) :]
+    assistant_parts = assistant_substr.split("CCCC")
+    print(f"{assistant_parts=}")
+
     raise NotImplementedError("TBD")
-
-

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -268,7 +268,18 @@ CHAT_TEMPLATE_CACHE[mistral_7b_instruct_template] = Mistral7BInstructChatTemplat
 
 class GeneralChatTemplate(ChatTemplate):
     def __init__(self, role_dict: Mapping[str, Sequence[str]]):
+        for v in role_dict.values():
+            if len(v) != 2:
+                raise ValueError("All role_dict lists must be of length 2")
         self._role_dict = role_dict
+
+    def get_role_start(self, role_name: str, **kwargs):
+        return self._role_dict[role_name][0]
+
+    def get_role_end(self, role_name: Union[str, None] = None):
+        if role_name is None:
+            raise ValueError("GeneralChatTemplate requires a role_name")
+        return self._role_dict[role_name][1]
 
 
 def auto_chat_template(
@@ -276,25 +287,42 @@ def auto_chat_template(
         "transformers_package.PreTrainedTokenizer",
         "transformers_package.PreTrainedTokenizerFast",
     ]
-):
+) -> GeneralChatTemplate:
+    """Attempts to extract a ChatTemplate from a Transformer Tokenizer.
+
+    This is a very crude initial implementation. At the very least, it
+    should probably be extended to cope with models which don't support
+    the 'system' role.
+    This said, it is also likely impractical to make it support any
+    weird model (since they are using Jinja2 internally, and that's
+    a full programming language).
+    """
     messages = [
         {"role": "system", "content": "AAAA"},
         {"role": "user", "content": "BBBB"},
         {"role": "assistant", "content": "CCCC"},
     ]
 
+    # Progressively render the conversation
     system_0 = transformers_tokenizer.apply_chat_template(messages[:1], tokenize=False)
     user_0 = transformers_tokenizer.apply_chat_template(messages[:2], tokenize=False)
     assistant_0 = transformers_tokenizer.apply_chat_template(messages[:3], tokenize=False)
 
+    # Split up the 'system' part
     system_parts = system_0.split("AAAA")
 
+    # Extract just the 'user' part and split it up
     user_substr = user_0[len(system_0) :]
     user_parts = user_substr.split("BBBB")
-    print(f"{user_parts=}")
 
+    # And the 'assistant part
     assistant_substr = assistant_0[len(user_0) :]
     assistant_parts = assistant_substr.split("CCCC")
-    print(f"{assistant_parts=}")
 
-    raise NotImplementedError("TBD")
+    # Build the dictionary of starts and stops
+    role_dict = dict(system=system_parts, user=user_parts, assistant=assistant_parts)
+
+    # Construct the final template
+    result = GeneralChatTemplate(role_dict)
+
+    return result

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import warnings
 
 from typing import Dict, Union
@@ -263,3 +264,28 @@ class Mistral7BInstructChatTemplate(ChatTemplate):
 
 
 CHAT_TEMPLATE_CACHE[mistral_7b_instruct_template] = Mistral7BInstructChatTemplate
+
+
+def auto_chat_template(
+    transformers_tokenizer: Union[
+        "transformers_package.PreTrainedTokenizer",
+        "transformers_package.PreTrainedTokenizerFast",
+    ]
+):
+    messages = [
+        {"role": "system", "content": "AAAA"},
+        {"role": "user", "content": "BBBB"},
+        {"role": "assistant", "content": "CCCC"},
+    ]
+
+    system_0 = transformers_tokenizer.apply_chat_template(messages[:1], tokenize=False)
+    assistant_0 = transformers_tokenizer.apply_chat_template(messages[:2], tokenize=False)
+    user_0 = transformers_tokenizer.apply_chat_template(messages[:3], tokenize=False)
+
+    re_system = "(.*)AAAA(.*)"
+    system_result = re.search(pattern=re_system, string=system_0, flags=re.MULTILINE)
+    print(f"{system_result=}")
+    
+    raise NotImplementedError("TBD")
+
+

--- a/tests/need_credentials/test_chat_templates.py
+++ b/tests/need_credentials/test_chat_templates.py
@@ -1,6 +1,6 @@
 import pytest
 
-from guidance.chat import CHAT_TEMPLATE_CACHE
+from guidance.chat import CHAT_TEMPLATE_CACHE, auto_chat_template
 import transformers
 
 from ..utils import env_or_fail
@@ -38,3 +38,12 @@ def test_popular_models_in_cache(model_id: str, should_pass: bool):
 
 # TODO: Expand testing to verify that tokenizer.apply_chat_template() produces same results as our ChatTemplate subclasses
 # once I hook up the new ChatTemplate to guidance.models.Transformers and guidance.models.LlamaCPP, we can do this
+
+
+@pytest.mark.parametrize(("model_id"), ["HuggingFaceH4/zephyr-7b-beta"])
+def test_auto_chat_template(model_id):
+    hf_token = env_or_fail("HF_TOKEN")
+    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_id, token=hf_token, trust_remote_code=True
+    )
+    auto_chat_template(hf_tokenizer)

--- a/tests/need_credentials/test_chat_templates.py
+++ b/tests/need_credentials/test_chat_templates.py
@@ -112,11 +112,29 @@ def test_chat_format_smoke_with_system(model_id: str):
     assert str(lm) in tokeniser_render
 
 
-
 @pytest.mark.parametrize(("model_id"), ["HuggingFaceH4/zephyr-7b-beta"])
 def test_auto_chat_template(model_id):
     hf_token = env_or_fail("HF_TOKEN")
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained(
         model_id, token=hf_token, trust_remote_code=True
     )
-    auto_chat_template(hf_tokenizer)
+    my_ct = auto_chat_template(hf_tokenizer)
+
+    lm = guidance.models.Mock("")
+    lm.chat_template = my_ct
+
+    messages = [
+        {"role": "system", "content": "You are an LLM"},
+        {"role": "user", "content": "Good day to you!"},
+        {"role": "assistant", "content": "Salutations!"},
+    ]
+    tokeniser_render = hf_tokenizer.apply_chat_template(messages, tokenize=False)
+
+    with guidance.system():
+        lm += "You are an LLM"
+    with guidance.user():
+        lm += "Good day to you!"
+    with guidance.assistant():
+        lm += "Salutations!"
+    # Only check substring due to BOS/EOS tokens
+    assert str(lm) in tokeniser_render


### PR DESCRIPTION
Create a very basic function to extract  a `guidance.ChatTemplate` from a given Transformers Tokenizer. This can be extended over time as we discover new and exciting tokenisers. However, this will have to be balanced against the probability that it can never be fully general - Transformers uses Jinja2 templates, which have all sorts of goodies like loops and branches.