### PR TITLE
remove unneeded torch dep for top-level tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import uuid
 
 import pytest
 import requests
-import torch
 
 from guidance import models
 
@@ -33,13 +32,13 @@ AVAILABLE_MODELS = {
         # Note that this model requires an appropriate
         # HF_TOKEN environment variable
         name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
-        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16},
+        kwargs={"trust_remote_code": True},
     ),
     "transformers_llama3gpu_8b": dict(
         # Note that this model requires an appropriate
         # HF_TOKEN environment variable
         name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
-        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16, "device_map": "cuda:0"},
+        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
     ),
     "hfllama_phi3cpu_mini_4k_instruct": dict(
         name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",


### PR DESCRIPTION
`config.json` for the llama-3 already specifies bfloat16 dtype. Thus removing torch dependency from the top-level tests (many tests do not require torch to run).

CC @riedgar-ms @hudson-ai 