### PR TITLE
[Test] Reorganise AVAILABLE_MODELS

### DIFF
--- a/.github/workflows/action_gpu_basic_tests.yml
+++ b/.github/workflows/action_gpu_basic_tests.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false # Don't cancel all on first failure
       matrix:
         model:
-          - "gpt2gpu"
-          - "phi2gpu"
+          - "transformers_gpt2gpu"
+          - "transformers_phi2gpu"
           # - "transformers_phi3_small_8k_instruct" Does not run on tesla t4
-          # - "hfllama_7b_gpu" Keeps causing intermittent segfaults
+          # - "hfllama_llama2_7b_gpu" Keeps causing intermittent segfaults
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/.github/workflows/action_gpu_basic_tests.yml
+++ b/.github/workflows/action_gpu_basic_tests.yml
@@ -19,7 +19,7 @@ jobs:
           - "transformers_gpt2_gpu"
           - "transformers_phi2_gpu"
           # - "transformers_phi3_small_8k_instruct_gpu" Does not run on tesla t4
-          # - "hfllama_llama2_7b_gpu" Keeps causing intermittent segfaults
+          # - "llamacpp_llama2_7b_gpu" Keeps causing intermittent segfaults
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/.github/workflows/action_gpu_basic_tests.yml
+++ b/.github/workflows/action_gpu_basic_tests.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false # Don't cancel all on first failure
       matrix:
         model:
-          - "transformers_gpt2gpu"
-          - "transformers_phi2gpu"
+          - "transformers_gpt2_gpu"
+          - "transformers_phi2_gpu"
           # - "transformers_phi3_small_8k_instruct_gpu" Does not run on tesla t4
           # - "hfllama_llama2_7b_gpu" Keeps causing intermittent segfaults
     runs-on: ${{ inputs.os }}

--- a/.github/workflows/action_gpu_basic_tests.yml
+++ b/.github/workflows/action_gpu_basic_tests.yml
@@ -18,7 +18,7 @@ jobs:
         model:
           - "transformers_gpt2gpu"
           - "transformers_phi2gpu"
-          # - "transformers_phi3_small_8k_instruct" Does not run on tesla t4
+          # - "transformers_phi3_small_8k_instruct_gpu" Does not run on tesla t4
           # - "hfllama_llama2_7b_gpu" Keeps causing intermittent segfaults
     runs-on: ${{ inputs.os }}
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -105,7 +105,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - hfllama_gemma2_9b_cpu
+          - llamacpp_gemma2_9b_cpu
           - transformers_gemma2_9b_cpu
           - transformers_gemma2_9b_gpu
           - transformers_llama3_8b_cpu

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -105,11 +105,11 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - hfllama_gemma2cpu_9b
-          - transformers_gemma2cpu_9b
-          - transformers_gemma2gpu_9b
-          - transformers_llama3cpu_8b
-          # - transformers_llama3gpu_8b Does not reliably work on GPU build machines
+          - hfllama_gemma2_9b_cpu
+          - transformers_gemma2_9b_cpu
+          - transformers_gemma2_9b_gpu
+          - transformers_llama3_8b_cpu
+          # - transformers_llama3_8b_gpu Does not reliably work on GPU build machines
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -63,10 +63,10 @@ jobs:
       fail-fast: false # Don't cancel all on first failure
       matrix:
         model:
-          - "gpt2cpu"
-          - "phi2cpu"
+          - "transformers_gpt2cpu"
+          - "transformers_phi2cpu"
           # - "transformers_mistral_7b" See Issue 713
-          - "hfllama7b"
+          - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
           - "transformers_phi3cpu_mini_4k_instruct"
           - "hfllama_phi3cpu_mini_4k_instruct"
@@ -104,10 +104,10 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
         model:
-          - "gpt2cpu"
-          - "phi2cpu"
+          - "transformers_gpt2cpu"
+          - "transformers_phi2cpu"
           # - "transformers_mistral_7b" See Issue 713
-          - "hfllama7b"
+          - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
           - "transformers_phi3cpu_mini_4k_instruct"
           - "hfllama_phi3cpu_mini_4k_instruct"
@@ -149,10 +149,10 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "gpt2cpu"
-          - "phi2cpu"
+          - "transformers_gpt2cpu"
+          - "transformers_phi2cpu"
           # - "transformers_mistral_7b" See Issue 713
-          - "hfllama7b"
+          - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
           # - "transformers_phi3cpu_mini_4k_instruct" Gives trouble on MacOS
           - "hfllama_phi3cpu_mini_4k_instruct"
@@ -169,10 +169,10 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "gpt2cpu"
-          # - "phi2cpu" Seems to get stuck
+          - "transformers_gpt2cpu"
+          # - "transformers_phi2cpu" Seems to get stuck
           # - "transformers_mistral_7b" See Issue 713
-          # - "hfllama7b" Getting stuck with llama-cpp-python 0.2.77
+          # - "hfllama_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
           # - "hfllama_mistral_7b"
           # - "transformers_phi3cpu_mini_4k_instruct" Gives trouble on MacOS
           - "hfllama_phi3cpu_mini_4k_instruct"
@@ -189,10 +189,10 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "gpt2cpu"
-          - "phi2cpu"
+          - "transformers_gpt2cpu"
+          - "transformers_phi2cpu"
           # - "transformers_mistral_7b" See Issue 713
-          - "hfllama7b"
+          - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
           - "transformers_phi3cpu_mini_4k_instruct"
           - "hfllama_phi3cpu_mini_4k_instruct"

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -66,10 +66,10 @@ jobs:
           - "transformers_gpt2_cpu"
           - "transformers_phi2_cpu"
           # - "transformers_mistral_7b_cpu" See Issue 713
-          - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b_cpu"
+          - "llamacpp_llama2_7b_cpu"
+          - "llamacpp_mistral_7b_cpu"
           - "transformers_phi3_mini_4k_instruct_cpu"
-          - "hfllama_phi3_mini_4k_instruct_cpu"
+          - "llamacpp_phi3_mini_4k_instruct_cpu"
     with:
       os: Large_Linux
       python-version: "3.12"
@@ -107,10 +107,10 @@ jobs:
           - "transformers_gpt2_cpu"
           - "transformers_phi2_cpu"
           # - "transformers_mistral_7b_cpu" See Issue 713
-          - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b_cpu"
+          - "llamacpp_llama2_7b_cpu"
+          - "llamacpp_mistral_7b_cpu"
           - "transformers_phi3_mini_4k_instruct_cpu"
-          - "hfllama_phi3_mini_4k_instruct_cpu"
+          - "llamacpp_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: Large_Linux
@@ -152,10 +152,10 @@ jobs:
           - "transformers_gpt2_cpu"
           - "transformers_phi2_cpu"
           # - "transformers_mistral_7b_cpu" See Issue 713
-          - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b_cpu"
+          - "llamacpp_llama2_7b_cpu"
+          - "llamacpp_mistral_7b_cpu"
           # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
-          - "hfllama_phi3_mini_4k_instruct_cpu"
+          - "llamacpp_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: macos-12
@@ -172,10 +172,10 @@ jobs:
           - "transformers_gpt2_cpu"
           # - "transformers_phi2_cpu" Seems to get stuck
           # - "transformers_mistral_7b_cpu" See Issue 713
-          # - "hfllama_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
-          # - "hfllama_mistral_7b_cpu"
+          # - "llamacpp_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
+          # - "llamacpp_mistral_7b_cpu"
           # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
-          - "hfllama_phi3_mini_4k_instruct_cpu"
+          - "llamacpp_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: macos-latest
@@ -192,10 +192,10 @@ jobs:
           - "transformers_gpt2_cpu"
           - "transformers_phi2_cpu"
           # - "transformers_mistral_7b_cpu" See Issue 713
-          - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b_cpu"
+          - "llamacpp_llama2_7b_cpu"
+          - "llamacpp_mistral_7b_cpu"
           - "transformers_phi3_mini_4k_instruct_cpu"
-          - "hfllama_phi3_mini_4k_instruct_cpu"
+          - "llamacpp_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: Large_Windows

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -68,8 +68,8 @@ jobs:
           # - "transformers_mistral_7b" See Issue 713
           - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
-          - "transformers_phi3cpu_mini_4k_instruct"
-          - "hfllama_phi3cpu_mini_4k_instruct"
+          - "transformers_phi3_mini_4k_instruct_cpu"
+          - "hfllama_phi3_mini_4k_instruct_cpu"
     with:
       os: Large_Linux
       python-version: "3.12"
@@ -109,8 +109,8 @@ jobs:
           # - "transformers_mistral_7b" See Issue 713
           - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
-          - "transformers_phi3cpu_mini_4k_instruct"
-          - "hfllama_phi3cpu_mini_4k_instruct"
+          - "transformers_phi3_mini_4k_instruct_cpu"
+          - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: Large_Linux
@@ -154,8 +154,8 @@ jobs:
           # - "transformers_mistral_7b" See Issue 713
           - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
-          # - "transformers_phi3cpu_mini_4k_instruct" Gives trouble on MacOS
-          - "hfllama_phi3cpu_mini_4k_instruct"
+          # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
+          - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: macos-12
@@ -174,8 +174,8 @@ jobs:
           # - "transformers_mistral_7b" See Issue 713
           # - "hfllama_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
           # - "hfllama_mistral_7b"
-          # - "transformers_phi3cpu_mini_4k_instruct" Gives trouble on MacOS
-          - "hfllama_phi3cpu_mini_4k_instruct"
+          # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
+          - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: macos-latest
@@ -194,8 +194,8 @@ jobs:
           # - "transformers_mistral_7b" See Issue 713
           - "hfllama_llama2_7b_cpu"
           - "hfllama_mistral_7b"
-          - "transformers_phi3cpu_mini_4k_instruct"
-          - "hfllama_phi3cpu_mini_4k_instruct"
+          - "transformers_phi3_mini_4k_instruct_cpu"
+          - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:
       os: Large_Windows

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -63,11 +63,11 @@ jobs:
       fail-fast: false # Don't cancel all on first failure
       matrix:
         model:
-          - "transformers_gpt2cpu"
-          - "transformers_phi2cpu"
-          # - "transformers_mistral_7b" See Issue 713
+          - "transformers_gpt2_cpu"
+          - "transformers_phi2_cpu"
+          # - "transformers_mistral_7b_cpu" See Issue 713
           - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b"
+          - "hfllama_mistral_7b_cpu"
           - "transformers_phi3_mini_4k_instruct_cpu"
           - "hfllama_phi3_mini_4k_instruct_cpu"
     with:
@@ -104,11 +104,11 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
         model:
-          - "transformers_gpt2cpu"
-          - "transformers_phi2cpu"
-          # - "transformers_mistral_7b" See Issue 713
+          - "transformers_gpt2_cpu"
+          - "transformers_phi2_cpu"
+          # - "transformers_mistral_7b_cpu" See Issue 713
           - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b"
+          - "hfllama_mistral_7b_cpu"
           - "transformers_phi3_mini_4k_instruct_cpu"
           - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
@@ -149,11 +149,11 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "transformers_gpt2cpu"
-          - "transformers_phi2cpu"
-          # - "transformers_mistral_7b" See Issue 713
+          - "transformers_gpt2_cpu"
+          - "transformers_phi2_cpu"
+          # - "transformers_mistral_7b_cpu" See Issue 713
           - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b"
+          - "hfllama_mistral_7b_cpu"
           # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
           - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
@@ -169,11 +169,11 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "transformers_gpt2cpu"
-          # - "transformers_phi2cpu" Seems to get stuck
-          # - "transformers_mistral_7b" See Issue 713
+          - "transformers_gpt2_cpu"
+          # - "transformers_phi2_cpu" Seems to get stuck
+          # - "transformers_mistral_7b_cpu" See Issue 713
           # - "hfllama_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
-          # - "hfllama_mistral_7b"
+          # - "hfllama_mistral_7b_cpu"
           # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
           - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
@@ -189,11 +189,11 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "transformers_gpt2cpu"
-          - "transformers_phi2cpu"
-          # - "transformers_mistral_7b" See Issue 713
+          - "transformers_gpt2_cpu"
+          - "transformers_phi2_cpu"
+          # - "transformers_mistral_7b_cpu" See Issue 713
           - "hfllama_llama2_7b_cpu"
-          - "hfllama_mistral_7b"
+          - "hfllama_mistral_7b_cpu"
           - "transformers_phi3_mini_4k_instruct_cpu"
           - "hfllama_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml

--- a/tests/ReadMe.md
+++ b/tests/ReadMe.md
@@ -27,6 +27,8 @@ def phi3_model(selected_model, selected_model_name):
 
 As noted above the `need_credentials` tests are mainly for `Grammarless` models - those for remote endpoints which do not support Guidance grammars (there are a few exceptions, which is why the directory isn't simply named `grammarless`).
 As endpoints with Guidance grammar support come online, their tests should *not* go in there; these should go into `model_integration` and `model_specific`, but will only be run in CI builds.
+Similarly, some models (e.g. LLama3) require credentials in order to download their weights from Hugging Face.
+These should be run through the `model_integration` and `model_specific` tests, but this run will happen from the CI build, and hence have credential access.
 
 ## Testing Goal
 

--- a/tests/ReadMe.md
+++ b/tests/ReadMe.md
@@ -17,7 +17,7 @@ A sample means of achieving this:
 ```python
 @pytest.fixture(scope="module")
 def phi3_model(selected_model, selected_model_name):
-    if selected_model_name in ["transformers_phi3cpu_mini_4k_instruct"]:
+    if selected_model_name in ["transformers_phi3_mini_4k_instruct_cpu"]:
         return selected_model
     else:
         pytest.skip("Requires Phi3 model")

--- a/tests/_llms_for_testing.py
+++ b/tests/_llms_for_testing.py
@@ -1,20 +1,35 @@
 import torch
 import transformers
 
-
-_GPT_2 = {
-    "transformers_gpt2cpu": dict(name="transformers:gpt2", kwargs=dict()),
-    "transformers_gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
+_GEMMA_2 = {
+    "hfllama_gemma2_9b_cpu": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="huggingface_hubllama:bartowski/gemma-2-9b-it-GGUF:gemma-2-9b-it-IQ2_XS.gguf",
+        kwargs={"verbose": True, "n_ctx": 4096},
+    ),
+    "transformers_gemma2_9b_cpu": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:google/gemma-2-9b-it",
+        kwargs={
+            "quantization_config": transformers.BitsAndBytesConfig(load_in_8bit=True),
+        },
+    ),
+    "transformers_gemma2_9b_gpu": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:google/gemma-2-9b-it",
+        kwargs={
+            "device_map": "cuda:0",
+            "quantization_config": transformers.BitsAndBytesConfig(load_in_4bit=True),
+        },
+    ),
 }
 
-_PHI_2 = {
-    "transformers_phi2cpu": dict(
-        name="transformers:microsoft/phi-2", kwargs={"trust_remote_code": True}
-    ),
-    "transformers_phi2gpu": dict(
-        name="transformers:microsoft/phi-2",
-        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
-    ),
+_GPT_2 = {
+    "transformers_gpt2_cpu": dict(name="transformers:gpt2", kwargs=dict()),
+    "transformers_gpt2_gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
 }
 
 _LLAMA_2 = {
@@ -25,6 +40,41 @@ _LLAMA_2 = {
     "hfllama_llama2_7b_gpu": dict(
         name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
         kwargs={"verbose": True, "n_gpu_layers": -1, "n_ctx": 4096},
+    ),
+}
+
+_LLAMA_3 = {
+    "transformers_llama3_8b_cpu": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
+        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16},
+    ),
+    "transformers_llama3_8b_gpu": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
+        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16, "device_map": "cuda:0"},
+    ),
+}
+
+_MISTRAL = {
+    "transformers_mistral_7b_cpu": dict(
+        name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()
+    ),
+    "hfllama_mistral_7b_cpu": dict(
+        name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
+        kwargs={"verbose": True, "n_ctx": 2048},
+    ),
+}
+
+_PHI_2 = {
+    "transformers_phi2_cpu": dict(
+        name="transformers:microsoft/phi-2", kwargs={"trust_remote_code": True}
+    ),
+    "transformers_phi2_gpu": dict(
+        name="transformers:microsoft/phi-2",
+        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
     ),
 }
 
@@ -48,49 +98,12 @@ AVAILABLE_MODELS = {
         name="azure_guidance:",
         kwargs={},
     ),
-    "transformers_llama3cpu_8b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
-        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16},
-    ),
-    "transformers_llama3gpu_8b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
-        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16, "device_map": "cuda:0"},
-    ),
-    "hfllama_gemma2cpu_9b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="huggingface_hubllama:bartowski/gemma-2-9b-it-GGUF:gemma-2-9b-it-IQ2_XS.gguf",
-        kwargs={"verbose": True, "n_ctx": 4096},
-    ),
-    "transformers_gemma2cpu_9b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:google/gemma-2-9b-it",
-        kwargs={
-            "quantization_config": transformers.BitsAndBytesConfig(load_in_8bit=True),
-        },
-    ),
-    "transformers_gemma2gpu_9b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:google/gemma-2-9b-it",
-        kwargs={
-            "device_map": "cuda:0",
-            "quantization_config": transformers.BitsAndBytesConfig(load_in_4bit=True),
-        },
-    ),
-    "transformers_mistral_7b": dict(name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()),
-    "hfllama_mistral_7b": dict(
-        name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
-        kwargs={"verbose": True, "n_ctx": 2048},
-    ),
 }
 
+AVAILABLE_MODELS.update(_GEMMA_2)
 AVAILABLE_MODELS.update(_GPT_2)
-AVAILABLE_MODELS.update(_PHI_2)
 AVAILABLE_MODELS.update(_LLAMA_2)
+AVAILABLE_MODELS.update(_LLAMA_3)
+AVAILABLE_MODELS.update(_MISTRAL)
+AVAILABLE_MODELS.update(_PHI_2)
 AVAILABLE_MODELS.update(_PHI_3)

--- a/tests/_llms_for_testing.py
+++ b/tests/_llms_for_testing.py
@@ -1,0 +1,82 @@
+import torch
+import transformers
+
+
+_GPT_2 = {
+    "gpt2cpu": dict(name="transformers:gpt2", kwargs=dict()),
+    "gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
+}
+
+AVAILABLE_MODELS = {
+    "phi2cpu": dict(name="transformers:microsoft/phi-2", kwargs={"trust_remote_code": True}),
+    "azure_guidance": dict(
+        name="azure_guidance:",
+        kwargs={},
+    ),
+    "transformers_phi3cpu_mini_4k_instruct": dict(
+        name="transformers:microsoft/Phi-3-mini-4k-instruct",
+        kwargs={"trust_remote_code": True},
+    ),
+    "transformers_llama3cpu_8b": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
+        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16},
+    ),
+    "transformers_llama3gpu_8b": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
+        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16, "device_map": "cuda:0"},
+    ),
+    "hfllama_gemma2cpu_9b": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="huggingface_hubllama:bartowski/gemma-2-9b-it-GGUF:gemma-2-9b-it-IQ2_XS.gguf",
+        kwargs={"verbose": True, "n_ctx": 4096},
+    ),
+    "transformers_gemma2cpu_9b": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:google/gemma-2-9b-it",
+        kwargs={
+            "quantization_config": transformers.BitsAndBytesConfig(load_in_8bit=True),
+        },
+    ),
+    "transformers_gemma2gpu_9b": dict(
+        # Note that this model requires an appropriate
+        # HF_TOKEN environment variable
+        name="transformers:google/gemma-2-9b-it",
+        kwargs={
+            "device_map": "cuda:0",
+            "quantization_config": transformers.BitsAndBytesConfig(load_in_4bit=True),
+        },
+    ),
+    "hfllama_phi3cpu_mini_4k_instruct": dict(
+        name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",
+        kwargs={"verbose": True, "n_ctx": 4096},
+    ),
+    "hfllama7b": dict(
+        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
+        kwargs={"verbose": True, "n_ctx": 4096},
+    ),
+    "transformers_phi3_small_8k_instruct": dict(
+        name="transformers:microsoft/Phi-3-small-8k-instruct",
+        kwargs={"trust_remote_code": True, "load_in_8bit": True, "device_map": "cuda:0"},
+    ),
+    "transformers_mistral_7b": dict(name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()),
+    "hfllama_mistral_7b": dict(
+        name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
+        kwargs={"verbose": True, "n_ctx": 2048},
+    ),
+    "phi2gpu": dict(
+        name="transformers:microsoft/phi-2",
+        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
+    ),
+    "hfllama_7b_gpu": dict(
+        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
+        kwargs={"verbose": True, "n_gpu_layers": -1, "n_ctx": 4096},
+    ),
+}
+
+AVAILABLE_MODELS.update(_GPT_2)

--- a/tests/_llms_for_testing.py
+++ b/tests/_llms_for_testing.py
@@ -4,12 +4,12 @@ import transformers
 # This file contains the configurations of the models used in our test runs
 
 # The naming convention for the keys is "<loader>_<model>_<host>" where:
-# - 'loader' is 'transformers' or 'hfllama' (for LlamaCpp models accessed via HF)
+# - 'loader' is 'transformers' or 'llamacpp'
 # - 'model' contains relevant information about the model itself
 # - 'host' is 'cpu' or 'gpu' as appropriate
 
 _GEMMA_2 = {
-    "hfllama_gemma2_9b_cpu": dict(
+    "llamacpp_gemma2_9b_cpu": dict(
         # Note that this model requires an appropriate
         # HF_TOKEN environment variable
         name="huggingface_hubllama:bartowski/gemma-2-9b-it-GGUF:gemma-2-9b-it-IQ2_XS.gguf",
@@ -40,11 +40,11 @@ _GPT_2 = {
 }
 
 _LLAMA_2 = {
-    "hfllama_llama2_7b_cpu": dict(
+    "llamacpp_llama2_7b_cpu": dict(
         name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
         kwargs={"verbose": True, "n_ctx": 4096},
     ),
-    "hfllama_llama2_7b_gpu": dict(
+    "llamacpp_llama2_7b_gpu": dict(
         name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
         kwargs={"verbose": True, "n_gpu_layers": -1, "n_ctx": 4096},
     ),
@@ -69,7 +69,7 @@ _MISTRAL = {
     "transformers_mistral_7b_cpu": dict(
         name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()
     ),
-    "hfllama_mistral_7b_cpu": dict(
+    "llamacpp_mistral_7b_cpu": dict(
         name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
         kwargs={"verbose": True, "n_ctx": 2048},
     ),
@@ -90,7 +90,7 @@ _PHI_3 = {
         name="transformers:microsoft/Phi-3-mini-4k-instruct",
         kwargs={"trust_remote_code": True},
     ),
-    "hfllama_phi3_mini_4k_instruct_cpu": dict(
+    "llamacpp_phi3_mini_4k_instruct_cpu": dict(
         name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",
         kwargs={"verbose": True, "n_ctx": 4096},
     ),

--- a/tests/_llms_for_testing.py
+++ b/tests/_llms_for_testing.py
@@ -1,6 +1,13 @@
 import torch
 import transformers
 
+# This file contains the configurations of the models used in our test runs
+
+# The naming convention for the keys is "<loader>_<model>_<host>" where:
+# - 'loader' is 'transformers' or 'hfllama' (for LlamaCpp models accessed via HF)
+# - 'model' contains relevant information about the model itself
+# - 'host' is 'cpu' or 'gpu' as appropriate
+
 _GEMMA_2 = {
     "hfllama_gemma2_9b_cpu": dict(
         # Note that this model requires an appropriate
@@ -100,6 +107,7 @@ AVAILABLE_MODELS = {
     ),
 }
 
+# Add in all the other models
 AVAILABLE_MODELS.update(_GEMMA_2)
 AVAILABLE_MODELS.update(_GPT_2)
 AVAILABLE_MODELS.update(_LLAMA_2)

--- a/tests/_llms_for_testing.py
+++ b/tests/_llms_for_testing.py
@@ -28,14 +28,25 @@ _LLAMA_2 = {
     ),
 }
 
+_PHI_3 = {
+    "transformers_phi3_mini_4k_instruct_cpu": dict(
+        name="transformers:microsoft/Phi-3-mini-4k-instruct",
+        kwargs={"trust_remote_code": True},
+    ),
+    "hfllama_phi3_mini_4k_instruct_cpu": dict(
+        name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",
+        kwargs={"verbose": True, "n_ctx": 4096},
+    ),
+    "transformers_phi3_small_8k_instruct_gpu": dict(
+        name="transformers:microsoft/Phi-3-small-8k-instruct",
+        kwargs={"trust_remote_code": True, "load_in_8bit": True, "device_map": "cuda:0"},
+    ),
+}
+
 AVAILABLE_MODELS = {
     "azure_guidance": dict(
         name="azure_guidance:",
         kwargs={},
-    ),
-    "transformers_phi3cpu_mini_4k_instruct": dict(
-        name="transformers:microsoft/Phi-3-mini-4k-instruct",
-        kwargs={"trust_remote_code": True},
     ),
     "transformers_llama3cpu_8b": dict(
         # Note that this model requires an appropriate
@@ -72,14 +83,6 @@ AVAILABLE_MODELS = {
             "quantization_config": transformers.BitsAndBytesConfig(load_in_4bit=True),
         },
     ),
-    "hfllama_phi3cpu_mini_4k_instruct": dict(
-        name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",
-        kwargs={"verbose": True, "n_ctx": 4096},
-    ),
-    "transformers_phi3_small_8k_instruct": dict(
-        name="transformers:microsoft/Phi-3-small-8k-instruct",
-        kwargs={"trust_remote_code": True, "load_in_8bit": True, "device_map": "cuda:0"},
-    ),
     "transformers_mistral_7b": dict(name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()),
     "hfllama_mistral_7b": dict(
         name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
@@ -90,3 +93,4 @@ AVAILABLE_MODELS = {
 AVAILABLE_MODELS.update(_GPT_2)
 AVAILABLE_MODELS.update(_PHI_2)
 AVAILABLE_MODELS.update(_LLAMA_2)
+AVAILABLE_MODELS.update(_PHI_3)

--- a/tests/_llms_for_testing.py
+++ b/tests/_llms_for_testing.py
@@ -3,12 +3,32 @@ import transformers
 
 
 _GPT_2 = {
-    "gpt2cpu": dict(name="transformers:gpt2", kwargs=dict()),
-    "gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
+    "transformers_gpt2cpu": dict(name="transformers:gpt2", kwargs=dict()),
+    "transformers_gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
+}
+
+_PHI_2 = {
+    "transformers_phi2cpu": dict(
+        name="transformers:microsoft/phi-2", kwargs={"trust_remote_code": True}
+    ),
+    "transformers_phi2gpu": dict(
+        name="transformers:microsoft/phi-2",
+        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
+    ),
+}
+
+_LLAMA_2 = {
+    "hfllama_llama2_7b_cpu": dict(
+        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
+        kwargs={"verbose": True, "n_ctx": 4096},
+    ),
+    "hfllama_llama2_7b_gpu": dict(
+        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
+        kwargs={"verbose": True, "n_gpu_layers": -1, "n_ctx": 4096},
+    ),
 }
 
 AVAILABLE_MODELS = {
-    "phi2cpu": dict(name="transformers:microsoft/phi-2", kwargs={"trust_remote_code": True}),
     "azure_guidance": dict(
         name="azure_guidance:",
         kwargs={},
@@ -56,10 +76,6 @@ AVAILABLE_MODELS = {
         name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",
         kwargs={"verbose": True, "n_ctx": 4096},
     ),
-    "hfllama7b": dict(
-        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
-        kwargs={"verbose": True, "n_ctx": 4096},
-    ),
     "transformers_phi3_small_8k_instruct": dict(
         name="transformers:microsoft/Phi-3-small-8k-instruct",
         kwargs={"trust_remote_code": True, "load_in_8bit": True, "device_map": "cuda:0"},
@@ -69,14 +85,8 @@ AVAILABLE_MODELS = {
         name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
         kwargs={"verbose": True, "n_ctx": 2048},
     ),
-    "phi2gpu": dict(
-        name="transformers:microsoft/phi-2",
-        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
-    ),
-    "hfllama_7b_gpu": dict(
-        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
-        kwargs={"verbose": True, "n_gpu_layers": -1, "n_ctx": 4096},
-    ),
 }
 
 AVAILABLE_MODELS.update(_GPT_2)
+AVAILABLE_MODELS.update(_PHI_2)
+AVAILABLE_MODELS.update(_LLAMA_2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,11 +64,11 @@ def selected_model(selected_model_info: str) -> models.Model:
 @pytest.fixture(scope="module")
 def llamacpp_model(selected_model, selected_model_name):
     if selected_model_name in [
-        "hfllama_llama2_7b_cpu",
-        "hfllama_llama2_7b_gpu",
-        "hfllama_gemma2_9b_cpu",
-        "hfllama_phi3_mini_4k_instruct_cpu",
-        "hfllama_mistral_7b_cpu",
+        "llamacpp_llama2_7b_cpu",
+        "llamacpp_llama2_7b_gpu",
+        "llamacpp_gemma2_9b_cpu",
+        "llamacpp_phi3_mini_4k_instruct_cpu",
+        "llamacpp_mistral_7b_cpu",
     ]:
         return selected_model
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ SELECTED_MODEL_ENV_VARIABLE = "GUIDANCE_SELECTED_MODEL"
 
 
 def pytest_addoption(parser):
-    default_model = os.getenv(SELECTED_MODEL_ENV_VARIABLE, "gpt2cpu")
+    default_model = os.getenv(SELECTED_MODEL_ENV_VARIABLE, "transformers_gpt2cpu")
     parser.addoption(
         "--selected_model",
         action="store",
@@ -64,8 +64,8 @@ def selected_model(selected_model_info: str) -> models.Model:
 @pytest.fixture(scope="module")
 def llamacpp_model(selected_model, selected_model_name):
     if selected_model_name in [
-        "hfllama7b",
-        "hfllama_7b_gpu",
+        "hfllama_llama2_7b_cpu",
+        "hfllama_llama2_7b_gpu",
         "hfllama_gemma2cpu_9b",
         "hfllama_phi3cpu_mini_4k_instruct",
         "hfllama_mistral_7b",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def llamacpp_model(selected_model, selected_model_name):
         "hfllama_llama2_7b_cpu",
         "hfllama_llama2_7b_gpu",
         "hfllama_gemma2cpu_9b",
-        "hfllama_phi3cpu_mini_4k_instruct",
+        "hfllama_phi3_mini_4k_instruct_cpu",
         "hfllama_mistral_7b",
     ]:
         return selected_model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ SELECTED_MODEL_ENV_VARIABLE = "GUIDANCE_SELECTED_MODEL"
 
 
 def pytest_addoption(parser):
-    default_model = os.getenv(SELECTED_MODEL_ENV_VARIABLE, "transformers_gpt2cpu")
+    default_model = os.getenv(SELECTED_MODEL_ENV_VARIABLE, "transformers_gpt2_cpu")
     parser.addoption(
         "--selected_model",
         action="store",
@@ -66,9 +66,9 @@ def llamacpp_model(selected_model, selected_model_name):
     if selected_model_name in [
         "hfllama_llama2_7b_cpu",
         "hfllama_llama2_7b_gpu",
-        "hfllama_gemma2cpu_9b",
+        "hfllama_gemma2_9b_cpu",
         "hfllama_phi3_mini_4k_instruct_cpu",
-        "hfllama_mistral_7b",
+        "hfllama_mistral_7b_cpu",
     ]:
         return selected_model
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,90 +7,16 @@ import uuid
 
 import pytest
 import requests
-import torch
-import transformers
 
 from guidance import models
 
 # Ensure that asserts from tests/utils.py are rewritten by pytest to show helpful messages
 pytest.register_assert_rewrite("tests.utils")
 
+from ._llms_for_testing import AVAILABLE_MODELS
 from .utils import get_model
 
 SELECTED_MODEL_ENV_VARIABLE = "GUIDANCE_SELECTED_MODEL"
-
-AVAILABLE_MODELS = {
-    "gpt2cpu": dict(name="transformers:gpt2", kwargs=dict()),
-    "phi2cpu": dict(name="transformers:microsoft/phi-2", kwargs={"trust_remote_code": True}),
-    "azure_guidance": dict(
-        name="azure_guidance:",
-        kwargs={},
-    ),
-    "transformers_phi3cpu_mini_4k_instruct": dict(
-        name="transformers:microsoft/Phi-3-mini-4k-instruct",
-        kwargs={"trust_remote_code": True},
-    ),
-    "transformers_llama3cpu_8b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
-        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16},
-    ),
-    "transformers_llama3gpu_8b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:meta-llama/Meta-Llama-3-8B-Instruct",
-        kwargs={"trust_remote_code": True, "torch_dtype": torch.bfloat16, "device_map": "cuda:0"},
-    ),
-    "hfllama_gemma2cpu_9b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="huggingface_hubllama:bartowski/gemma-2-9b-it-GGUF:gemma-2-9b-it-IQ2_XS.gguf",
-        kwargs={"verbose": True, "n_ctx": 4096},
-    ),
-    "transformers_gemma2cpu_9b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:google/gemma-2-9b-it",
-        kwargs={
-            "quantization_config": transformers.BitsAndBytesConfig(load_in_8bit=True),},
-    ),
-    "transformers_gemma2gpu_9b": dict(
-        # Note that this model requires an appropriate
-        # HF_TOKEN environment variable
-        name="transformers:google/gemma-2-9b-it",
-        kwargs={
-            "device_map": "cuda:0",
-            "quantization_config": transformers.BitsAndBytesConfig(load_in_4bit=True),
-        },
-    ),
-    "hfllama_phi3cpu_mini_4k_instruct": dict(
-        name="huggingface_hubllama:microsoft/Phi-3-mini-4k-instruct-gguf:Phi-3-mini-4k-instruct-q4.gguf",
-        kwargs={"verbose": True, "n_ctx": 4096},
-    ),
-    "hfllama7b": dict(
-        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
-        kwargs={"verbose": True, "n_ctx": 4096},
-    ),
-    "transformers_phi3_small_8k_instruct": dict(
-        name="transformers:microsoft/Phi-3-small-8k-instruct",
-        kwargs={"trust_remote_code": True, "load_in_8bit": True, "device_map": "cuda:0"},
-    ),
-    "transformers_mistral_7b": dict(name="transformers:mistralai/Mistral-7B-v0.1", kwargs=dict()),
-    "hfllama_mistral_7b": dict(
-        name="huggingface_hubllama:TheBloke/Mistral-7B-Instruct-v0.2-GGUF:mistral-7b-instruct-v0.2.Q8_0.gguf",
-        kwargs={"verbose": True, "n_ctx": 2048},
-    ),
-    "gpt2gpu": dict(name="transformers:gpt2", kwargs={"device_map": "cuda:0"}),
-    "phi2gpu": dict(
-        name="transformers:microsoft/phi-2",
-        kwargs={"trust_remote_code": True, "device_map": "cuda:0"},
-    ),
-    "hfllama_7b_gpu": dict(
-        name="huggingface_hubllama:TheBloke/Llama-2-7B-GGUF:llama-2-7b.Q5_K_M.gguf",
-        kwargs={"verbose": True, "n_gpu_layers": -1, "n_ctx": 4096},
-    ),
-}
 
 
 def pytest_addoption(parser):

--- a/tests/model_integration/library/test_gen.py
+++ b/tests/model_integration/library/test_gen.py
@@ -170,9 +170,9 @@ def test_various_regexes(selected_model: models.Model, prompt: str, pattern: str
 @pytest.mark.resource_intensive
 def test_long_prompt(selected_model: models.Model, selected_model_name: str):
     if selected_model_name in [
-        "hfllama_llama2_7b_cpu",
-        "hfllama_llama2_7b_gpu",
-        "hfllama_mistral_7b_cpu",
+        "llamacpp_llama2_7b_cpu",
+        "llamacpp_llama2_7b_gpu",
+        "llamacpp_mistral_7b_cpu",
         "transformers_mistral_7b_cpu",
     ]:
         pytest.xfail("Insufficient context window in model")

--- a/tests/model_integration/library/test_gen.py
+++ b/tests/model_integration/library/test_gen.py
@@ -170,8 +170,8 @@ def test_various_regexes(selected_model: models.Model, prompt: str, pattern: str
 @pytest.mark.resource_intensive
 def test_long_prompt(selected_model: models.Model, selected_model_name: str):
     if selected_model_name in [
-        "hfllama7b",
-        "hfllama_7b_gpu",
+        "hfllama_llama2_7b_cpu",
+        "hfllama_llama2_7b_gpu",
         "hfllama_mistral_7b",
         "transformers_mistral_7b",
     ]:

--- a/tests/model_integration/library/test_gen.py
+++ b/tests/model_integration/library/test_gen.py
@@ -172,8 +172,8 @@ def test_long_prompt(selected_model: models.Model, selected_model_name: str):
     if selected_model_name in [
         "hfllama_llama2_7b_cpu",
         "hfllama_llama2_7b_gpu",
-        "hfllama_mistral_7b",
-        "transformers_mistral_7b",
+        "hfllama_mistral_7b_cpu",
+        "transformers_mistral_7b_cpu",
     ]:
         pytest.xfail("Insufficient context window in model")
     lm = selected_model

--- a/tests/model_specific/llama_cpp/test_chat_templates.py
+++ b/tests/model_specific/llama_cpp/test_chat_templates.py
@@ -42,7 +42,7 @@ def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_mo
     with guidance.assistant():
         lm += "Hello!"
     # Only check substring due to BOS/EOS tokens
-    if selected_model_name == "hfllama_mistral_7b":
+    if selected_model_name == "hfllama_mistral_7b_cpu":
         # The templates extracted via Transformers and GGUF are somewhat
         # different for Mistral. This is showing up in slightly
         # different spacing (our template is putting in a few extra spaces)

--- a/tests/model_specific/llama_cpp/test_chat_templates.py
+++ b/tests/model_specific/llama_cpp/test_chat_templates.py
@@ -42,7 +42,7 @@ def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_mo
     with guidance.assistant():
         lm += "Hello!"
     # Only check substring due to BOS/EOS tokens
-    if selected_model_name == "hfllama_mistral_7b_cpu":
+    if selected_model_name == "llamacpp_mistral_7b_cpu":
         # The templates extracted via Transformers and GGUF are somewhat
         # different for Mistral. This is showing up in slightly
         # different spacing (our template is putting in a few extra spaces)

--- a/tests/model_specific/llama_cpp/test_llama_cpp.py
+++ b/tests/model_specific/llama_cpp/test_llama_cpp.py
@@ -56,10 +56,10 @@ def test_repeat_calls(llamacpp_model: guidance.models.Model, selected_model_name
     print(f"{sys.version_info=}")
 
     fail_combinations = [
-        ("hfllama7b", "3.9", "Windows", "AMD64"),
-        ("hfllama7b", "3.10", "Windows", "AMD64"),
-        ("hfllama7b", "3.11", "Windows", "AMD64"),
-        ("hfllama7b", "3.12", "Windows", "AMD64"),
+        ("hfllama_llama2_7b_cpu", "3.9", "Windows", "AMD64"),
+        ("hfllama_llama2_7b_cpu", "3.10", "Windows", "AMD64"),
+        ("hfllama_llama2_7b_cpu", "3.11", "Windows", "AMD64"),
+        ("hfllama_llama2_7b_cpu", "3.12", "Windows", "AMD64"),
         ("hfllama_phi3cpu_mini_4k_instruct", "3.9", "Darwin", "arm64"),
         ("hfllama_phi3cpu_mini_4k_instruct", "3.10", "Darwin", "arm64"),
         ("hfllama_phi3cpu_mini_4k_instruct", "3.11", "Darwin", "arm64"),

--- a/tests/model_specific/llama_cpp/test_llama_cpp.py
+++ b/tests/model_specific/llama_cpp/test_llama_cpp.py
@@ -60,14 +60,14 @@ def test_repeat_calls(llamacpp_model: guidance.models.Model, selected_model_name
         ("hfllama_llama2_7b_cpu", "3.10", "Windows", "AMD64"),
         ("hfllama_llama2_7b_cpu", "3.11", "Windows", "AMD64"),
         ("hfllama_llama2_7b_cpu", "3.12", "Windows", "AMD64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.9", "Darwin", "arm64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.10", "Darwin", "arm64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.11", "Darwin", "arm64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.12", "Darwin", "arm64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.9", "Linux", "x86_64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.10", "Linux", "x86_64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.11", "Linux", "x86_64"),
-        ("hfllama_phi3cpu_mini_4k_instruct", "3.12", "Linux", "x86_64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.9", "Darwin", "arm64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.10", "Darwin", "arm64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.11", "Darwin", "arm64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.12", "Darwin", "arm64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.9", "Linux", "x86_64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.10", "Linux", "x86_64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.11", "Linux", "x86_64"),
+        ("hfllama_phi3_mini_4k_instruct_cpu", "3.12", "Linux", "x86_64"),
     ]
     expect_failure = False
     python_maj_min = f"{sys.version_info[0]}.{sys.version_info[1]}"

--- a/tests/model_specific/llama_cpp/test_llama_cpp.py
+++ b/tests/model_specific/llama_cpp/test_llama_cpp.py
@@ -56,18 +56,18 @@ def test_repeat_calls(llamacpp_model: guidance.models.Model, selected_model_name
     print(f"{sys.version_info=}")
 
     fail_combinations = [
-        ("hfllama_llama2_7b_cpu", "3.9", "Windows", "AMD64"),
-        ("hfllama_llama2_7b_cpu", "3.10", "Windows", "AMD64"),
-        ("hfllama_llama2_7b_cpu", "3.11", "Windows", "AMD64"),
-        ("hfllama_llama2_7b_cpu", "3.12", "Windows", "AMD64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.9", "Darwin", "arm64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.10", "Darwin", "arm64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.11", "Darwin", "arm64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.12", "Darwin", "arm64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.9", "Linux", "x86_64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.10", "Linux", "x86_64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.11", "Linux", "x86_64"),
-        ("hfllama_phi3_mini_4k_instruct_cpu", "3.12", "Linux", "x86_64"),
+        ("llamacpp_llama2_7b_cpu", "3.9", "Windows", "AMD64"),
+        ("llamacpp_llama2_7b_cpu", "3.10", "Windows", "AMD64"),
+        ("llamacpp_llama2_7b_cpu", "3.11", "Windows", "AMD64"),
+        ("llamacpp_llama2_7b_cpu", "3.12", "Windows", "AMD64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.9", "Darwin", "arm64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.10", "Darwin", "arm64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.11", "Darwin", "arm64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.12", "Darwin", "arm64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.9", "Linux", "x86_64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.10", "Linux", "x86_64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.11", "Linux", "x86_64"),
+        ("llamacpp_phi3_mini_4k_instruct_cpu", "3.12", "Linux", "x86_64"),
     ]
     expect_failure = False
     python_maj_min = f"{sys.version_info[0]}.{sys.version_info[1]}"

--- a/tests/model_specific/test_transformers.py
+++ b/tests/model_specific/test_transformers.py
@@ -7,7 +7,7 @@ from ..utils import get_model
 
 @pytest.fixture(scope="module")
 def phi3_model(selected_model, selected_model_name):
-    if selected_model_name in ["transformers_phi3cpu_mini_4k_instruct"]:
+    if selected_model_name in ["transformers_phi3_mini_4k_instruct_cpu"]:
         return selected_model
     else:
         pytest.skip("Requires Phi3 model")

--- a/tests/model_specific/test_transformers.py
+++ b/tests/model_specific/test_transformers.py
@@ -15,7 +15,7 @@ def phi3_model(selected_model, selected_model_name):
 
 @pytest.fixture(scope="module")
 def llama3_model(selected_model, selected_model_name):
-    if selected_model_name in ["transformers_llama3cpu_8b"] and selected_model is not None:
+    if selected_model_name in ["transformers_llama3_8b_cpu"] and selected_model is not None:
         return selected_model
     else:
         pytest.skip("Requires Llama3 model (needs HF_TOKEN to be set)")

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -85,7 +85,7 @@ class TestArtOfPromptDesign:
         run_notebook(nb_path)
 
     def test_react(self, selected_model_name):
-        if selected_model_name in ["phi2gpu"]:
+        if selected_model_name in ["transformers_phi2gpu"]:
             # I don't know why; it doesn't make sense, but
             msg = (
                 f"react notebook disagrees with {selected_model_name}; reasons obscure"

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -85,7 +85,7 @@ class TestArtOfPromptDesign:
         run_notebook(nb_path)
 
     def test_react(self, selected_model_name):
-        if selected_model_name in ["transformers_phi2gpu"]:
+        if selected_model_name in ["transformers_phi2_gpu"]:
             # I don't know why; it doesn't make sense, but
             msg = (
                 f"react notebook disagrees with {selected_model_name}; reasons obscure"


### PR DESCRIPTION
The `AVAILABLE_MODELS` dictionary has been getting rather disorganised and unwieldly of late. This change:

- Separates the dictionary into its own file
- Groups similar models together, so it is easy to find all ways a particular LLM is configured
- Makes the naming convention for the dictionary keys consistent as `<loader>_<model>_<host>`