### PR TITLE
remove gpt2 autotokenizer dependency from failsafe in _transformers.py

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -113,9 +113,9 @@ class TransformersTokenizer(Tokenizer):
                 byte_tokens[i] = byte_coded
 
         else:
-            byte_decoder = transformers_package.AutoTokenizer.from_pretrained(
-                "gpt2", use_fast=False
-            ).byte_decoder  # fall back to gpt2 mapping
+            # fall back to gpt2 mapping
+            byte_encoder = self._bytes_to_unicode()
+            byte_decoder = {v: k for k, v in byte_encoder.items()}
 
             # some special tokens may not have their whitespace encoded...
             byte_decoder[" "] = 32


### PR DESCRIPTION
I think the gpt2 autotokenizer piece here is using something very similar to what was added for the phi-3-small commit so it's probably no longer necessary to use this imported byte decoder. Admittedly I'm not sure what models fall into this block so it's difficult for me to test -- happy to close if I'm mistaken about this