### PR TITLE
[Build] Exclude llama-cpp-python version

### DIFF
--- a/.github/workflows/action_gpu_basic_tests.yml
+++ b/.github/workflows/action_gpu_basic_tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           pip install accelerate
           pip uninstall -y llama-cpp-python
-          CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.84"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install sentencepiece
           pip uninstall -y llama-cpp-python
-          pip install "llama-cpp-python!=0.2.58,!=0.2.79"
+          pip install "llama-cpp-python!=0.2.58,!=0.2.79,!=0.2.84"
       - name: Run tests (except server)
         shell: bash
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.84"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: GPU pip installs
         run: |
           pip install accelerate
-          CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75"
+          CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.84"
       - name: Check GPU available
         run: |
           python -c "import torch; assert torch.cuda.is_available()"

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ doc_requires = [
     "sphinx",
     "ipykernel",
     "huggingface_hub",
-    "llama-cpp-python!=0.2.84",
+    "llama-cpp-python",
 ]
 test_requires = [
     "azure-identity",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ doc_requires = [
     "sphinx",
     "ipykernel",
     "huggingface_hub",
-    "llama-cpp-python",
+    "llama-cpp-python!=0.2.84",
 ]
 test_requires = [
     "azure-identity",


### PR DESCRIPTION
The latest release of llama-cpp-python is causing trouble with Phi3. Exclude it, and [file a bug](https://github.com/abetlen/llama-cpp-python/issues/1638)