### PR TITLE
Refector `TransformersTokenizer` and change fallback behavior for `byte_tokens`

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -132,7 +132,7 @@ class TransformersTokenizer(Tokenizer):
         fallback_byte_decoder = self._fallback_byte_decoder()
         try:
             self._check_byte_decoder(
-                transformers_tokenizer.byte_decoder, transformers_tokenizer
+                fallback_byte_decoder, transformers_tokenizer
             )
         except ByteDecoderError as e:
             raise ValueError(

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -133,7 +133,10 @@ class TransformersTokenizer(Tokenizer):
                 self._check_byte_decoder(
                     transformers_tokenizer.byte_decoder, transformers_tokenizer
                 )
-            except ByteDecoderError:
+            except ByteDecoderError as e:
+                warnings.warn(
+                    f"Tokenizer has a byte_decoder, but it can't be used to construct byte_tokens: {e}"
+                )
                 pass
             else:
                 return self._byte_tokens_from_byte_decoder(transformers_tokenizer.byte_decoder, transformers_tokenizer)
@@ -143,7 +146,10 @@ class TransformersTokenizer(Tokenizer):
 
         try:
             return self._byte_tokens_by_encoding_token_strings(transformers_tokenizer)
-        except ValueError:
+        except ValueError as e:
+            warnings.warn(
+                f"Could not build_byte tokens from the tokenizer by encoding token strings: {e}"
+            )
             pass
 
         fallback_byte_decoder = self._fallback_byte_decoder()

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -129,7 +129,7 @@ class TransformersTokenizer(Tokenizer):
             return self._byte_tokens_from_sp_model(transformers_tokenizer)
 
         try:
-            return self._byte_tokens_from_vocab(transformers_tokenizer)
+            return self._byte_tokens_by_encoding_token_strings(transformers_tokenizer)
         except ValueError:
             pass
 
@@ -182,7 +182,7 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded.replace(space_prefix, b" ")
         return byte_tokens
 
-    def _byte_tokens_from_vocab(
+    def _byte_tokens_by_encoding_token_strings(
         self,
         transformers_tokenizer: Union[
             "transformers_package.PreTrainedTokenizer",

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -118,7 +118,6 @@ class TransformersTokenizer(Tokenizer):
             "transformers_package.PreTrainedTokenizerFast",
         ],
     ) -> list[bytes]:
-        vocab = transformers_tokenizer.get_vocab()
         byte_tokens = [b""] * len(transformers_tokenizer)
         special_tokens_map = {
             id: token for token, id in transformers_tokenizer.get_added_vocab().items()
@@ -136,7 +135,10 @@ class TransformersTokenizer(Tokenizer):
                 elif isinstance(token, str):
                     if hasattr(transformers_tokenizer, "convert_tokens_to_string"):
                         token_str = transformers_tokenizer.convert_tokens_to_string([token])
-                        roundtrip_id = transformers_tokenizer.encode(token_str)[0]
+                        encoded_str = transformers_tokenizer.encode(token_str)
+                        if len(encoded_str) != 1:
+                            raise ValueError(f"Round-trip encoding of tokens [{token}] failed! Got {encoded_str}")
+                        roundtrip_id = encoded_str[0]
                         if roundtrip_id == i:
                             byte_coded = token_str.encode()
                         else:

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -114,7 +114,7 @@ class TransformersTokenizer(Tokenizer):
         if hasattr(transformers_tokenizer, "byte_decoder"):
             try:
                 self._check_byte_decoder(
-                    transformers_tokenizer.byte_decoder, transformers_tokenizer.vocab
+                    transformers_tokenizer.byte_decoder, transformers_tokenizer
                 )
             except ByteDecoderError:
                 pass
@@ -132,7 +132,7 @@ class TransformersTokenizer(Tokenizer):
         fallback_byte_decoder = self._fallback_byte_decoder()
         try:
             self._check_byte_decoder(
-                transformers_tokenizer.byte_decoder, transformers_tokenizer.vocab
+                transformers_tokenizer.byte_decoder, transformers_tokenizer
             )
         except ByteDecoderError as e:
             raise ValueError(
@@ -245,7 +245,7 @@ class TransformersTokenizer(Tokenizer):
         def check_byte_decoder_has_all_bytes() -> None:
             # This is here because some tokenizers are bad and don't have all the bytes (I'm looking at you, microsoft/phi2)
             all_bytes = set()
-            for x in transformers_tokenizer.vocab.keys():
+            for x in transformers_tokenizer.get_vocab().keys():
                 for y in x:
                     all_bytes.add(y)
             if not set(byte_decoder.keys()) >= all_bytes:

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -88,7 +88,13 @@ class TransformersTokenizer(Tokenizer):
             tokenizer = transformers_package.AutoTokenizer.from_pretrained(
                 model, use_fast=False, **kwargs
             )
+        # except ImportError:
+        #     # HuggingFace needs us to install something (sentencepiece, protobuf, etc. for some non-fast tokenizers)
+        #     # TODO: decide whether to warn and fallback to fast tokenizer or to raise (should at least warn...)
+        #     raise
         except:
+            # Fall back for other exceptions
+            # TODO: (maybe warn?)
             tokenizer = transformers_package.AutoTokenizer.from_pretrained(
                 model, use_fast=True, **kwargs
             )  # fall back to the fast tokenizer

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -1,6 +1,7 @@
 import os
 import re
 import textwrap
+import warnings
 
 from typing import Sequence, Union
 
@@ -88,13 +89,14 @@ class TransformersTokenizer(Tokenizer):
             tokenizer = transformers_package.AutoTokenizer.from_pretrained(
                 model, use_fast=False, **kwargs
             )
-        # except ImportError:
-        #     # HuggingFace needs us to install something (sentencepiece, protobuf, etc. for some non-fast tokenizers)
-        #     # TODO: decide whether to warn and fallback to fast tokenizer or to raise (should at least warn...)
-        #     raise
-        except:
+        except ImportError as e:
+            # HuggingFace needs us to install something (sentencepiece, protobuf, etc. for some non-fast tokenizers)
+            raise RuntimeError(
+                f"Could not load tokenizer for model {model}. Please install the necessary dependencies for the tokenizer (see traceback for info)."
+            ) from e
+        except Exception as e:
             # Fall back for other exceptions
-            # TODO: (maybe warn?)
+            warnings.warn(f"Falling back to fast tokenizer. Could not load tokenizer for model {model} due to exception {e.__class__.__name__}: {e}")
             tokenizer = transformers_package.AutoTokenizer.from_pretrained(
                 model, use_fast=True, **kwargs
             )  # fall back to the fast tokenizer

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -83,7 +83,7 @@ class TransformersTokenizer(Tokenizer):
     ]:
         # make sure transformers is installed
         if not has_transformers:
-            raise Exception("Please install transformers with `pip install transformers`")
+            raise ImportError("Please install transformers with `pip install transformers`")
 
         try:
             tokenizer = transformers_package.AutoTokenizer.from_pretrained(

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -71,9 +71,15 @@ class TransformersTokenizer(Tokenizer):
             transformers_tokenizer.eos_token_id,
         )
 
-    def _byte_tokens_from_byte_decoder(self, transformers_tokenizer) -> list[bytes]:
+    def _byte_tokens_from_byte_decoder(
+        self,
+        transformers_tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+        ],
+    ) -> list[bytes]:
         byte_tokens = [b""] * len(transformers_tokenizer)
-        byte_decoder = transformers_tokenizer.byte_decoder
+        byte_decoder: dict[str, int] = transformers_tokenizer.byte_decoder
         for i in range(len(transformers_tokenizer)):
             byte_coded = bytes(
                 [byte_decoder[c] for c in transformers_tokenizer.convert_ids_to_tokens(i)]
@@ -81,7 +87,13 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
-    def _byte_tokens_from_sp_model(self, transformers_tokenizer) -> list[bytes]:
+    def _byte_tokens_from_sp_model(
+        self,
+        transformers_tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+        ],
+    ) -> list[bytes]:
         byte_tokens = [b""] * len(transformers_tokenizer)
         special_tokens_map = {
             id: token for token, id in transformers_tokenizer.get_added_vocab().items()
@@ -99,7 +111,13 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded.replace(space_prefix, b" ")
         return byte_tokens
 
-    def _byte_tokens_from_vocab(self, transformers_tokenizer) -> list[bytes]:
+    def _byte_tokens_from_vocab(
+        self,
+        transformers_tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+        ],
+    ) -> list[bytes]:
         vocab = transformers_tokenizer.get_vocab()
         byte_tokens = [b""] * len(transformers_tokenizer)
         special_tokens_map = {
@@ -130,9 +148,15 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
-    def _byte_tokens_fallback(self, transformers_tokenizer) -> list[bytes]:
+    def _byte_tokens_fallback(
+        self,
+        transformers_tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+        ],
+    ) -> list[bytes]:
         byte_tokens = [b""] * len(transformers_tokenizer)
-        byte_decoder = transformers_package.AutoTokenizer.from_pretrained(
+        byte_decoder: dict[str, int] = transformers_package.AutoTokenizer.from_pretrained(
             "gpt2", use_fast=False
         ).byte_decoder  # fall back to gpt2 mapping
 
@@ -182,7 +206,13 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
-    def _byte_tokens(self, transformers_tokenizer) -> list[bytes]:
+    def _byte_tokens(
+        self,
+        transformers_tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+        ],
+    ) -> list[bytes]:
 
         if hasattr(transformers_tokenizer, "byte_decoder"):
             return self._byte_tokens_from_byte_decoder(transformers_tokenizer)

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -119,7 +119,7 @@ class TransformersTokenizer(Tokenizer):
             )
         ):
             try:
-                self.check_byte_decoder(transformers_tokenizer.byte_decoder, transformers_tokenizer)
+                self._check_byte_decoder_complex_round_trip(transformers_tokenizer.byte_decoder, transformers_tokenizer)
             except ByteDecoderError:
                 pass
             else:
@@ -135,7 +135,7 @@ class TransformersTokenizer(Tokenizer):
 
         fallback_byte_decoder = self._fallback_byte_decoder()
         try:
-            self.check_byte_decoder(fallback_byte_decoder, transformers_tokenizer)
+            self._check_byte_decoder_complex_round_trip(fallback_byte_decoder, transformers_tokenizer)
         except ByteDecoderError as e:
             raise ValueError(
                 "Could not build byte tokens from the tokenizer, and falling back to a standard gpt2 byte_decoder failed"
@@ -221,7 +221,7 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
-    def check_byte_decoder(
+    def _check_byte_decoder_complex_round_trip(
         self,
         byte_decoder: dict[str, int],
         transformers_tokenizer: Union[

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -221,7 +221,14 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
-    def check_byte_decoder(self, byte_decoder, transformers_tokenizer):
+    def check_byte_decoder(
+        self,
+        byte_decoder: dict[str, int],
+        transformers_tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+        ],
+    ):
         # run a quick spot check to verify we can rebuild complex multi-token unicode symbols
         s = "’•¶∂ƒ˙∆£Ħ爨ൠᅘ∰፨"
         reconstructed = b""
@@ -256,7 +263,7 @@ class TransformersTokenizer(Tokenizer):
                 f"Failed to reconstruct the string {s} from the tokenizer's byte_decoder: {reconstructed.decode()!r} != {s!r}"
             )
 
-    def _fallback_byte_decoder(self):
+    def _fallback_byte_decoder(self) -> dict[str, int]:
         byte_decoder = transformers_package.AutoTokenizer.from_pretrained(
             "gpt2", use_fast=False
         ).byte_decoder # fall back to gpt2 mapping

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -89,11 +89,8 @@ class TransformersTokenizer(Tokenizer):
             tokenizer = transformers_package.AutoTokenizer.from_pretrained(
                 model, use_fast=False, **kwargs
             )
-        except ImportError as e:
-            # HuggingFace needs us to install something (sentencepiece, protobuf, etc. for some non-fast tokenizers)
-            raise RuntimeError(
-                f"Could not load tokenizer for model {model}. Please install the necessary dependencies for the tokenizer (see traceback for info)."
-            ) from e
+        except ImportError:
+            raise
         except Exception as e:
             # Fall back for other exceptions
             warnings.warn(f"Falling back to fast tokenizer. Could not load tokenizer for model {model} due to exception {e.__class__.__name__}: {e}")

--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -228,8 +228,10 @@ class TransformersTokenizer(Tokenizer):
         if hasattr(transformers_tokenizer, "sp_model"):
             return self._byte_tokens_from_sp_model(transformers_tokenizer)
 
-        if hasattr(transformers_tokenizer, "get_vocab"):
+        try:
             return self._byte_tokens_from_vocab(transformers_tokenizer)
+        except ValueError:
+            pass
 
         return self._byte_tokens_fallback(transformers_tokenizer)
 


### PR DESCRIPTION
- Break logic for getting `byte_tokens` from the original huggingface tokenizer out of `__init__` and into separate method
- Break that method down into various different methods, one per approach (using `byte_decoder`, `sp_model`, etc.)
- Don't fall back to fast tokenizer if `byte_decoder` doesn't have all bytes. Instead, just make having all bytes part of the conditional the decides whether to use the `byte_decoder` to get `byte_tokens`
- Remove `hasattr(tokenizer, "get_vocab")` check, as this is always true (@riedgar-ms is this only in new `transformers` versions?)
- Wrap `_byte_tokens_from_vocab` (@ambisinister's code, my name) in a try-except. Since the tokenizer always has a `get_vocab` method, hitting the except is the only path to the gpt-2 fallback byte decoder (@Harsha-Nori it's also the only path to the `sentencepiece` exception that https://github.com/guidance-ai/guidance/issues/971 complains is missing...)

Fixes https://github.com/guidance-ai/guidance/issues/958 (well, at least it makes the `sentencepiece` exception get raised correctly)