### PR TITLE
[Build] Move transformers exclusion to workflow

### DIFF
--- a/.github/workflows/action_gpu_basic_tests.yml
+++ b/.github/workflows/action_gpu_basic_tests.yml
@@ -54,9 +54,13 @@ jobs:
       - name: Other dependencies
         run: |
           pip install sentencepiece
+          echo "=============================="
+          pip uninstall -y transformers
+          pip install "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3" # Issue 965
       - name: GPU pip installs
         run: |
           pip install accelerate
+          echo "=============================="
           pip uninstall -y llama-cpp-python
           CMAKE_ARGS="-DGGML_CUDA=on" pip install "llama-cpp-python!=0.2.58,!=0.2.75,!=0.2.84"
       - name: Check GPU available

--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -42,7 +42,7 @@ jobs:
           pip uninstall -y llama-cpp-python
           pip install "llama-cpp-python!=0.2.58,!=0.2.79,!=0.2.84"
           echo "=============================="
-          pip uninstall transformers
+          pip uninstall -y transformers
           pip install "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3" # Issue 965
       - name: Run tests (except server)
         shell: bash

--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -38,8 +38,12 @@ jobs:
       - name: Install model-specific dependencies
         run: |
           pip install sentencepiece
+          echo "=============================="
           pip uninstall -y llama-cpp-python
           pip install "llama-cpp-python!=0.2.58,!=0.2.79,!=0.2.84"
+          echo "=============================="
+          pip uninstall transformers
+          pip install "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3" # Issue 965
       - name: Run tests (except server)
         shell: bash
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Other dependencies
         run: |
           pip install sentencepiece
+          echo "=============================="
+          pip uninstall -y transformers
+          pip install "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3" # Issue 965
       - name: GPU pip installs
         run: |
           pip install accelerate

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ test_requires = [
     "pytest",
     "pytest-cov",
     "torch",
-    "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3", # Exclusion due to trouble with GPT2 on MacOS ARM
+    "transformers",
     "mypy==1.9.0",
     "types-protobuf",
     "types-regex",


### PR DESCRIPTION
Trying to work around #965 by excluding `transformers` versions in `setup.py` wasn't the best approach (the problem only appears for GPT2 on MacOS-ARM). Move the exclusions into the workflow files, as we do for `llama-cpp-python`