### PR TITLE
added Marimo support for echo=True

### DIFF
--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -29,7 +29,11 @@ try:
     torch_is_imported = True
 except ImportError:
     torch_is_imported = False
-
+try:
+    import marimo
+    marimo_is_imported = True
+except ImportError:
+    marimo_is_imported = False
 
 logger = logging.getLogger(__name__)
 try:
@@ -1026,6 +1030,8 @@ class Model:
             if ipython_is_imported:
                 clear_output(wait=True)
                 display(HTML(self._html()))
+            elif marimo_is_imported:
+                marimo.output.replace(marimo.Html(self._html()))
             else:
                 pprint(self._state)
 


### PR DESCRIPTION
Marimo is an alternative to Jupyter Lab, it contains a reactive UI and self-executing cells. It's worth checking out. I encourage people to check it out: https://marimo.io

However, the output of Guidance in Marimo is very scrambled with HTML, I altered the debug streamer to take Marimo into account, and use Marimo's own format to display the HTML output.

You can see the difference in the old version (left) and after this PR (right)

<img width="2068" alt="Comparison of before and after the PR" src="https://github.com/user-attachments/assets/97375ac8-88cb-45bd-a756-735a2219ccee">

I also made sure that if someone has Jupyter installed + Marimo, that Jupyter printing will be preferred, this is to make sure that the original behaviour will not change and that current Jupyter users will not have any surprises.

## How to test

I created a test Marimo script:

```py
import marimo

__generated_with = "0.7.19"
app = marimo.App(width="medium")


@app.cell
def __():
    import marimo as mo
    from guidance import models, gen
    from guidance.chat import ChatTemplate
    from guidance import user, system, assistant
    from transformers import AutoTokenizer
    return (
        AutoTokenizer,
        ChatTemplate,
        assistant,
        gen,
        mo,
        models,
        system,
        user,
    )


@app.cell
def __(AutoTokenizer):
    model_id = "meta-llama/Meta-Llama-3.1-8B-Instruct"
    tokenizer = AutoTokenizer.from_pretrained(model_id)
    return model_id, tokenizer


@app.cell
def __(ChatTemplate, UnsupportedRoleException, models, tokenizer):
    # Workaround (see: https://github.com/guidance-ai/guidance/discussions/917)
    class Llama31ChatTemplate(ChatTemplate):
        template_str = tokenizer.chat_template

        def get_role_start(self, role_name):
            if role_name == "system":
                return "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n"
            elif role_name == "user":
                return "<|start_header_id|>user<|end_header_id|>\n\n"
            elif role_name == "assistant":
                return "<|start_header_id|>assistant<|end_header_id|>\n\n"
            else:
                raise UnsupportedRoleException(role_name, self)

        def get_role_end(self, role_name=None):
            return "<|eot_id|>"


    model = models.LlamaCpp(
        "/Users/peter/Downloads/models/llama3.1-instruct.gguf",
        n_ctx=8192,
        chat_template=Llama31ChatTemplate,
        echo=True,
    )
    return Llama31ChatTemplate, model


@app.cell
def __(assistant, gen, model, system, user):
    lm = model
    with system():
        lm += "You are someone that loves dragons and arts, you also are a big fan of the GitHub user hudson-ai."
    with user():
        lm += "What is love?"
    with assistant():
        lm += gen()
    return lm,


if __name__ == "__main__":
    app.run()
```

(I have no affiliation with Marimo, just wanted to use it with Guidance!)