### PR TITLE
[Build] Gate fix (MacOS-ARM/GPT2)

### DIFF
--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -49,13 +49,7 @@ jobs:
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ inputs.model }} \
-            ./tests/unit
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
-            --selected_model ${{ inputs.model }} \
-            ./tests/model_integration
-          pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
-            --selected_model ${{ inputs.model }} \
-            ./tests/model_specific
+            ./tests/unit ./tests/model_integration ./tests/model_specific
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -48,8 +48,14 @@ jobs:
         shell: bash
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
-          --selected_model ${{ inputs.model }} \
-          ./tests/unit ./tests/model_integration ./tests/model_specific
+            --selected_model ${{ inputs.model }} \
+            ./tests/unit
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
+            --selected_model ${{ inputs.model }} \
+            ./tests/model_integration
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
+            --selected_model ${{ inputs.model }} \
+            ./tests/model_specific
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -170,11 +170,11 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           # - "transformers_gpt2_cpu" See #965
-          - "transformers_phi2_cpu"
-          - "transformers_mistral_7b_cpu"
-          - "llamacpp_llama2_7b_cpu"
-          - "llamacpp_mistral_7b_cpu"
-          - "transformers_phi3_mini_4k_instruct_cpu"
+          # - "transformers_phi2_cpu" Seems to get stuck
+          # - "transformers_mistral_7b_cpu" See Issue 713
+          # - "llamacpp_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
+          # - "llamacpp_mistral_7b_cpu"
+          # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
           - "llamacpp_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -169,7 +169,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
-          - "transformers_gpt2_cpu"
+          # - "transformers_gpt2_cpu" See #965
           # - "transformers_phi2_cpu" Seems to get stuck
           # - "transformers_mistral_7b_cpu" See Issue 713
           # - "llamacpp_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77

--- a/.github/workflows/workflow-pr-gate.yml
+++ b/.github/workflows/workflow-pr-gate.yml
@@ -170,11 +170,11 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           # - "transformers_gpt2_cpu" See #965
-          # - "transformers_phi2_cpu" Seems to get stuck
-          # - "transformers_mistral_7b_cpu" See Issue 713
-          # - "llamacpp_llama2_7b_cpu" Getting stuck with llama-cpp-python 0.2.77
-          # - "llamacpp_mistral_7b_cpu"
-          # - "transformers_phi3_mini_4k_instruct_cpu" Gives trouble on MacOS
+          - "transformers_phi2_cpu"
+          - "transformers_mistral_7b_cpu"
+          - "llamacpp_llama2_7b_cpu"
+          - "llamacpp_mistral_7b_cpu"
+          - "transformers_phi3_mini_4k_instruct_cpu"
           - "llamacpp_phi3_mini_4k_instruct_cpu"
     uses: ./.github/workflows/action_plain_basic_tests.yml
     with:


### PR DESCRIPTION
Attempting to deal with #965 . This is not a fix; it just disables GPT2 for the MacOS-ARM tests, which is decidedly less than ideal. Unfortunately, we don't seem able to reproduce this on our own ARM-based Macs.