### PR TITLE
[Build] CI Fix

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -75,10 +75,10 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           # Configure endpoints for Azure OpenAI
-          AZUREAI_CHAT_ENDPOINT: ${{ secrets.AZUREAI_CHAT_ENDPOINT }}
-          AZUREAI_CHAT_MODEL: ${{ secrets.AZUREAI_CHAT_MODEL }}
-          AZUREAI_COMPLETION_ENDPOINT: ${{ secrets.AZUREAI_COMPLETION_ENDPOINT }}
-          AZUREAI_COMPLETION_MODEL: ${{ secrets.AZUREAI_COMPLETION_MODEL }}
+          AZUREAI_CHAT_ENDPOINT: ${{ vars.AZUREAI_CHAT_ENDPOINT }}
+          AZUREAI_CHAT_MODEL: ${{ vars.AZUREAI_CHAT_MODEL }}
+          AZUREAI_COMPLETION_ENDPOINT: ${{ vars.AZUREAI_COMPLETION_ENDPOINT }}
+          AZUREAI_COMPLETION_MODEL: ${{ vars.AZUREAI_COMPLETION_MODEL }}
           # Configure endpoints for Azure AI Studio
           AZURE_AI_STUDIO_PHI3_ENDPOINT: ${{ vars.AZURE_AI_STUDIO_PHI3_ENDPOINT }}
           AZURE_AI_STUDIO_PHI3_DEPLOYMENT: ${{ vars.AZURE_AI_STUDIO_PHI3_DEPLOYMENT }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Show GPUs
         run: |
           nvidia-smi
-      - name: DNS Sanity check
-        run: |
-          nslookup guidance-models-for-build.openai.azure.com
       - name: Update Ubuntu
         run: |
           sudo apt-get update

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Show GPUs
         run: |
           nvidia-smi
+      - name: DNS Sanity check
+        run: |
+          nslookup guidance-models-for-build.openai.azure.com
       - name: Update Ubuntu
         run: |
           sudo apt-get update

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -78,10 +78,10 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           # Configure endpoints for Azure OpenAI
-          AZUREAI_CHAT_ENDPOINT: ${{ secrets.AZUREAI_CHAT_ENDPOINT }}
-          AZUREAI_CHAT_MODEL: ${{ secrets.AZUREAI_CHAT_MODEL }}
-          AZUREAI_COMPLETION_ENDPOINT: ${{ secrets.AZUREAI_COMPLETION_ENDPOINT }}
-          AZUREAI_COMPLETION_MODEL: ${{ secrets.AZUREAI_COMPLETION_MODEL }}
+          AZUREAI_CHAT_ENDPOINT: ${{ vars.AZUREAI_CHAT_ENDPOINT }}
+          AZUREAI_CHAT_MODEL: ${{ vars.AZUREAI_CHAT_MODEL }}
+          AZUREAI_COMPLETION_ENDPOINT: ${{ vars.AZUREAI_COMPLETION_ENDPOINT }}
+          AZUREAI_COMPLETION_MODEL: ${{ vars.AZUREAI_COMPLETION_MODEL }}
           # Configure endpoints for Azure AI Studio
           AZURE_AI_STUDIO_PHI3_ENDPOINT: ${{ vars.AZURE_AI_STUDIO_PHI3_ENDPOINT }}
           AZURE_AI_STUDIO_PHI3_DEPLOYMENT: ${{ vars.AZURE_AI_STUDIO_PHI3_DEPLOYMENT }}

--- a/guidance/models/_azure_openai.py
+++ b/guidance/models/_azure_openai.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from typing import Type
+from typing import Union
 from urllib.parse import parse_qs, urlparse
 
 import tiktoken
@@ -32,15 +32,15 @@ class AzureOpenAI(Grammarless):
         self,
         model: str,
         azure_endpoint: str,
-        azure_deployment: str = None,
+        azure_deployment: Union[str, None] = None,
         azure_ad_token_provider=None,
-        api_key: str = None,
+        api_key: Union[str, None] = None,
         tokenizer=None,
-        echo=True,
-        version: str = None,
-        max_streaming_tokens=1000,
-        timeout=0.5,
-        compute_log_probs=False,
+        echo: bool = True,
+        version: Union[str, None] = None,
+        max_streaming_tokens: int = 1000,
+        timeout: float = 0.5,
+        compute_log_probs: bool = False,
         **kwargs,
     ):
         """Build a new AzureOpenAI model object that represents a model in a given state.
@@ -66,19 +66,17 @@ class AzureOpenAI(Grammarless):
 
         if api_key is None and azure_ad_token_provider is None:
             raise ValueError("Please provide either api_key or azure_ad_token_provider")
-        
+
         parsed_url = urlparse(azure_endpoint)
 
         if azure_deployment is None:
             parts = pathlib.Path(parsed_url.path).parts
             if len(parts) > 2:
                 azure_deployment = parts[3]
-                
+
         parsed_query = parse_qs(parsed_url.query)
         api_version = (
-            version
-            if "api-version" not in parsed_query
-            else parsed_query["api-version"]
+            version if "api-version" not in parsed_query else parsed_query["api-version"][0]
         )
 
         if tokenizer is None:
@@ -90,7 +88,7 @@ class AzureOpenAI(Grammarless):
             timeout=timeout,
             compute_log_probs=compute_log_probs,
             model=model,
-            azure_endpoint=azure_endpoint,
+            azure_endpoint=f"{parsed_url.scheme}://{parsed_url.netloc}",
             api_key=api_key,
             azure_ad_token_provider=azure_ad_token_provider,
             api_version=api_version,

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -21,6 +21,9 @@ def azureai_chat_model(rate_limiter):
         DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
     )
 
+    print(f"azureai_endpoint {' '.join(azureai_endpoint)}")
+    print(f"model {' '.join(model)}")
+
     lm = models.AzureOpenAI(
         model=model, azure_endpoint=azureai_endpoint, azure_ad_token_provider=token_provider
     )

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -21,9 +21,6 @@ def azureai_chat_model(rate_limiter):
         DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
     )
 
-    print(f"azureai_endpoint {' '.join(azureai_endpoint)}")
-    print(f"model {' '.join(model)}")
-
     lm = models.AzureOpenAI(
         model=model, azure_endpoint=azureai_endpoint, azure_ad_token_provider=token_provider
     )

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -17,8 +17,8 @@ def azureai_chat_model(rate_limiter):
     azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
-    print(f"{azureai_endpoint=}____")
-    print(f"{model=}____")
+    print(f"{azureai_endpoint=}")
+    print(f"{model=}")
 
     token_provider = get_bearer_token_provider(
         DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -17,6 +17,9 @@ def azureai_chat_model(rate_limiter):
     azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
+    print(f"{azureai_endpoint=}____")
+    print(f"{model=}____")
+
     token_provider = get_bearer_token_provider(
         DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
     )

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -17,22 +17,15 @@ def azureai_chat_model(rate_limiter):
     azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
-    parsed_url = urlparse(azureai_endpoint)
-    parsed_query = parse_qs(parsed_url.query)
-    azureai_deployment = pathlib.Path(parsed_url.path).parts[3]
-    version = parsed_query["api-version"]
-    min_azureai_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    print(f"{azureai_endpoint=}")
+    print(f"{model=}")
 
     token_provider = get_bearer_token_provider(
         DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
     )
 
     lm = models.AzureOpenAI(
-        model=model,
-        azure_endpoint=min_azureai_endpoint,
-        version=version,
-        azure_ad_token_provider=token_provider,
-        azure_deployment=azureai_deployment,
+        model=model, azure_endpoint=azureai_endpoint, azure_ad_token_provider=token_provider
     )
     assert isinstance(lm, models.AzureOpenAI)
 

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -100,7 +100,7 @@ def test_azureai_openai_completion_alt_args(rate_limiter):
     parsed_url = urlparse(azureai_endpoint)
     parsed_query = parse_qs(parsed_url.query)
     azureai_deployment = pathlib.Path(parsed_url.path).parts[3]
-    version = parsed_query["api-version"]
+    version = parsed_query["api-version"][0]
     min_azureai_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
     token_provider = get_bearer_token_provider(

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -51,7 +51,7 @@ def test_azureai_openai_chat_alt_args(rate_limiter):
     parsed_url = urlparse(azureai_endpoint)
     parsed_query = parse_qs(parsed_url.query)
     azureai_deployment = pathlib.Path(parsed_url.path).parts[3]
-    version = parsed_query["api-version"]
+    version = parsed_query["api-version"][0]
     min_azureai_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
     token_provider = get_bearer_token_provider(

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -17,15 +17,22 @@ def azureai_chat_model(rate_limiter):
     azureai_endpoint = env_or_fail("AZUREAI_CHAT_ENDPOINT")
     model = env_or_fail("AZUREAI_CHAT_MODEL")
 
-    print(f"{azureai_endpoint=}")
-    print(f"{model=}")
+    parsed_url = urlparse(azureai_endpoint)
+    parsed_query = parse_qs(parsed_url.query)
+    azureai_deployment = pathlib.Path(parsed_url.path).parts[3]
+    version = parsed_query["api-version"]
+    min_azureai_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
     token_provider = get_bearer_token_provider(
         DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
     )
 
     lm = models.AzureOpenAI(
-        model=model, azure_endpoint=azureai_endpoint, azure_ad_token_provider=token_provider
+        model=model,
+        azure_endpoint=min_azureai_endpoint,
+        version=version,
+        azure_ad_token_provider=token_provider,
+        azure_deployment=azureai_deployment,
     )
     assert isinstance(lm, models.AzureOpenAI)
 


### PR DESCRIPTION
Get the CI build working again. The core problem appears to be that updates to the `openai` package mean that it does not accept a 1-element string list for the `version` argument anymore. Instead, this must be a string.

We have also moved to having the endpoint information in regular variables, rather than secrets.