### PR TITLE
Cache computation of JSON nodes to improve performance

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -1,6 +1,7 @@
 from json import dumps as json_dumps
 from enum import Enum
 from frozendict import frozendict, deepfreeze
+from functools import cache
 from typing import (
     Any,
     Callable,
@@ -476,13 +477,13 @@ def json(
         temperature=temperature,
     )
 
-
+@cache
 def _build_definitions(
-    raw_definitions: Mapping[str, Any]
+    raw_definitions: frozendict[str, Any]
 ) -> frozendict[str, Callable[[], GrammarFunction]]:
     definitions: frozendict[str, Callable[[], GrammarFunction]]
 
-    def build_definition(json_schema: Mapping[str, Any]) -> Callable[[], GrammarFunction]:
+    def build_definition(json_schema: frozendict[str, Any]) -> Callable[[], GrammarFunction]:
         @guidance(stateless=True, dedent=False, cache=True)
         def closure(lm):
             return lm + _gen_json(json_schema=json_schema, definitions=definitions)

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -198,7 +198,7 @@ def _gen_list(lm, *, elements: tuple[GrammarFunction, ...], required: tuple[bool
 def _gen_json_array(
     lm,
     *,
-    prefix_items_schema: tuple[frozendict[str, Any]],
+    prefix_items_schema: tuple[frozendict[str, Any], ...],
     item_schema: Union[bool, frozendict[str, Any]],
     min_items: int,
     max_items: Optional[int],
@@ -274,7 +274,7 @@ def _gen_json_array(
 def _process_anyOf(
     lm,
     *,
-    anyof_list: tuple[frozendict[str, Any]],
+    anyof_list: tuple[frozendict[str, Any], ...],
     definitions: frozendict[str, Callable[[], GrammarFunction]],
 ):
     options = [_gen_json(json_schema=item, definitions=definitions) for item in anyof_list]
@@ -282,7 +282,7 @@ def _process_anyOf(
 
 
 @guidance(stateless=True, cache=True)
-def _process_enum(lm, *, options: tuple[frozendict[str, Any]]):
+def _process_enum(lm, *, options: tuple[frozendict[str, Any], ...]):
     # TODO: can we support a whitespace-flexible version of this?
     all_opts = []
     for opt in options:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 install_requires = [
     "diskcache",
+    "frozendict",
     "numpy",
     "ordered_set",
     "platformdirs",

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1395,6 +1395,10 @@ class TestOneOf:
         validate(instance=target_obj, schema=schema_obj)
 
         # The actual check; we expect a warning here because oneOf is not fully supported
+        from guidance.library._json import _process_oneOf, _gen_json
+        # Reset the caches to ensure we get the warning
+        _gen_json.__wrapped__.cache_clear()
+        _process_oneOf.__wrapped__.cache_clear()
         with pytest.warns() as record:
             generate_and_check(target_obj, schema_obj)
         assert len(record) == 1


### PR DESCRIPTION
WIP. Seeing 4x speedup on [large nested schema](https://build.fhir.org/fhir.schema.json) after adding caching, but we can probably squeeze more performance out of this. Not sure if the `frozendict` dep is strictly necessary; just trying out a quick idea.