### PR TITLE
[Test] Move Azure Guidance in CI

### DIFF
--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -12,14 +12,6 @@ on:
       model:
         required: true
         type: string
-      AZUREAI_GUIDANCE_ENABLED_URL:
-        required: true
-        type: string
-        default: NOT_A_VALUE
-      AZUREAI_GUIDANCE_ENABLED_URL_KEY:
-        required: true
-        type: string
-        default: NOT_A_KEY
 
 
 jobs:
@@ -54,9 +46,6 @@ jobs:
           pip install "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3" # Issue 965
       - name: Run tests (except server)
         shell: bash
-        env:
-          AZUREAI_GUIDANCE_ENABLED_URL: ${{ inputs.AZUREAI_GUIDANCE_ENABLED_URL }}
-          AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ inputs.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ inputs.model }} \

--- a/.github/workflows/action_plain_basic_tests.yml
+++ b/.github/workflows/action_plain_basic_tests.yml
@@ -12,6 +12,14 @@ on:
       model:
         required: true
         type: string
+      AZUREAI_GUIDANCE_ENABLED_URL:
+        required: true
+        type: string
+        default: NOT_A_VALUE
+      AZUREAI_GUIDANCE_ENABLED_URL_KEY:
+        required: true
+        type: string
+        default: NOT_A_KEY
 
 
 jobs:
@@ -46,6 +54,9 @@ jobs:
           pip install "transformers!=4.43.0,!=4.43.1,!=4.43.2,!=4.43.3" # Issue 965
       - name: Run tests (except server)
         shell: bash
+        env:
+          AZUREAI_GUIDANCE_ENABLED_URL: ${{ inputs.AZUREAI_GUIDANCE_ENABLED_URL }}
+          AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ inputs.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ inputs.model }} \

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -173,3 +173,22 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+
+
+  basic-tests-linux-python:
+    env:
+      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
+      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
+    needs: end-stage-1
+    strategy:
+      fail-fast: false # Don't cancel all on first failure
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        model:
+          - "azure_guidance"
+    uses: ./.github/workflows/action_plain_basic_tests.yml
+    with:
+      os: Large_Linux
+      python-version: ${{ matrix.python-version }}
+      model: ${{ matrix.model }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -109,7 +109,6 @@ jobs:
           - transformers_gemma2_9b_cpu
           - transformers_gemma2_9b_gpu
           - transformers_llama3_8b_cpu
-          - azure_guidance
           # - transformers_llama3_8b_gpu Does not reliably work on GPU build machines
 
     steps:
@@ -162,8 +161,6 @@ jobs:
       - name: Run minimal tests for ${{ matrix.model }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
-          AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
         run: |
           pytest -vv --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ matrix.model }} \

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -177,9 +177,6 @@ jobs:
 
 
   basic-tests-linux-python:
-    env:
-      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
-      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
@@ -191,3 +188,5 @@ jobs:
       os: Large_Linux
       python-version: ${{ matrix.python-version }}
       model: ${{ matrix.model }}
+      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
+      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -183,10 +183,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           - "azure_guidance"
-      runs-on: Large_Linux
-      steps:
-        - uses: actions/checkout@v4
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v5
-          with:
-            python-version: ${{ matrix.python-version }}
+    runs-on: Large_Linux
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -159,9 +159,6 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
       # Note that we run a minimal set of tests here
       - name: Run minimal tests for ${{ matrix.model }}
-        env:
-          AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
-          AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
         run: |
           pytest -vv --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ matrix.model }} \
@@ -197,6 +194,9 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run tests (except server)
         shell: bash
+        env:
+          AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
+          AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ matrix.model }} \

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -176,7 +176,7 @@ jobs:
 
 
 
-  basic-tests-linux-python:
+  remote-endpoint-tests-linux-python:
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
@@ -190,3 +190,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -e .[test]
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests (except server)
+        shell: bash
+        run: |
+          pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
+            --selected_model ${{ inputs.model }} \
+            ./tests/unit ./tests/model_integration ./tests/model_specific
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -160,7 +160,8 @@ jobs:
       # Note that we run a minimal set of tests here
       - name: Run minimal tests for ${{ matrix.model }}
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
+          AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
         run: |
           pytest -vv --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ matrix.model }} \

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -183,10 +183,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         model:
           - "azure_guidance"
-    uses: ./.github/workflows/action_plain_basic_tests.yml
-    with:
-      os: Large_Linux
-      python-version: ${{ matrix.python-version }}
-      model: ${{ matrix.model }}
-      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
-      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
+      runs-on: Large_Linux
+      steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -177,6 +177,9 @@ jobs:
 
 
   basic-tests-linux-python:
+    env:
+      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
+      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
@@ -188,6 +191,3 @@ jobs:
       os: Large_Linux
       python-version: ${{ matrix.python-version }}
       model: ${{ matrix.model }}
-    env:
-      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
-      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -198,7 +198,7 @@ jobs:
         shell: bash
         run: |
           pytest --cov=guidance --cov-report=xml --cov-report=term-missing \
-            --selected_model ${{ inputs.model }} \
+            --selected_model ${{ matrix.model }} \
             ./tests/unit ./tests/model_integration ./tests/model_specific
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -177,10 +177,6 @@ jobs:
 
 
   basic-tests-linux-python:
-    env:
-      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
-      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}
-    needs: end-stage-1
     strategy:
       fail-fast: false # Don't cancel all on first failure
       matrix:
@@ -192,3 +188,6 @@ jobs:
       os: Large_Linux
       python-version: ${{ matrix.python-version }}
       model: ${{ matrix.model }}
+    env:
+      AZUREAI_GUIDANCE_ENABLED_URL: ${{ vars.AZUREAI_GUIDANCE_ENABLED_URL }}
+      AZUREAI_GUIDANCE_ENABLED_URL_KEY: ${{ secrets.AZUREAI_GUIDANCE_ENABLED_URL_KEY }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -159,6 +159,8 @@ jobs:
           python -c "import torch; assert torch.cuda.is_available()"
       # Note that we run a minimal set of tests here
       - name: Run minimal tests for ${{ matrix.model }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           pytest -vv --cov=guidance --cov-report=xml --cov-report=term-missing \
             --selected_model ${{ matrix.model }} \

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -185,8 +185,8 @@ jobs:
           - "azure_guidance"
       runs-on: Large_Linux
       steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+        - uses: actions/checkout@v4
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v5
+          with:
+            python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Move the Azure Guidance endpoint test to its own portion of the CI build. This spawns off another variant of the test workflow YAML (since it need variable and secret access). On the flip side, it does at least run all of the `model_integration` tests.