### PR TITLE
Use `json_string` kwarg from `llguidance 0.1.7`to properly escape json string patterns

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -547,17 +547,20 @@ class Gen(Terminal):
 
 
 class Lexeme(Gen):
-    __slots__ = ("contextual",)
+    __slots__ = ("contextual", "json_string")
 
     def __init__(
         self,
+        *,
         body_regex: str,
         contextual: bool = False,
+        json_string: bool = False,
         name: Union[str, None] = None,
         max_tokens=100000000,
     ) -> None:
         super().__init__(body_regex, "", name=name, max_tokens=max_tokens)
         self.contextual = contextual
+        self.json_string = json_string
 
     def __repr__(self, indent="", done=None):
         return super().__repr__(indent, done, "Lex")
@@ -1019,6 +1022,8 @@ class LLSerializer:
             elif isinstance(node, Null):
                 res = self._add_regex_json("EmptyString")
             elif isinstance(node, Lexeme):
+                if node.json_string:
+                    raise ValueError("Cannot serialize lexeme with `json_string=True` as regex: " + node.__repr__())
                 res = self._add_regex("Regex", node.body_regex)
             else:
                 raise ValueError("Cannot serialize as regex: " + node.__repr__())
@@ -1080,6 +1085,7 @@ class LLSerializer:
                 "Lexeme": {
                     "rx": node.body_regex,
                     "contextual": node.contextual,
+                    "json_string": node.json_string,
                 }
             }
         elif isinstance(node, Subgrammar):

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -124,7 +124,10 @@ def _gen_json_string(
     max_length: Union[int, None] = None,
     regex: Union[str, None] = None,
 ):
-    if regex is not None:
+    if regex is None:
+        range_expr = f"{{{min_length},{max_length}}}" if max_length is not None else f"{{{min_length},}}"
+        regex = f"(?s:.{range_expr})"
+    else:
         if min_length > 0 or max_length is not None:
             msg = (
                 "If a pattern is specified for a JSON "
@@ -132,12 +135,7 @@ def _gen_json_string(
                 "left unspecified."
             )
             raise ValueError(msg)
-        return '"' + gen(regex=regex) + '"'
-
-    char_expr = r'(\\([\"\\\/bfnrt]|u[a-fA-F0-9]{4})|[^\"\\\x00-\x1F\x7F])'
-    range_expr = f"{{{min_length},{max_length}}}" if max_length is not None else f"{{{min_length},}}"
-    string_expr = f'"{char_expr}{range_expr}"'
-    return lm + lexeme(string_expr, contextual=True)
+    return lm + lexeme(regex, contextual=True, json_string=True)
 
 
 @guidance(stateless=True)

--- a/guidance/library/_subgrammar.py
+++ b/guidance/library/_subgrammar.py
@@ -17,7 +17,7 @@ def lexeme(
         Set to true for eg. a JSON schema with both `/"type"/` and `/"[^"]*"/` as lexemes,
         or for "get"/"set" contextual keywords in C#.
     json_string (bool): Specifies if the lexeme should be quoted as a JSON string.
-        For example, /[a-z"]+/ will be quoted as /([a-z]|\\")+.
+        For example, /[a-z"]+/ will be quoted as /([a-z]|\\")+/.
         Defaults to False.
     """
     return Lexeme(body_regex=body_regex, contextual=contextual, json_string=json_string)

--- a/guidance/library/_subgrammar.py
+++ b/guidance/library/_subgrammar.py
@@ -5,8 +5,22 @@ from typing import Optional
 def lexeme(
     body_regex: str,
     contextual: bool = False,
-):
-    return Lexeme(body_regex=body_regex, contextual=contextual)
+    json_string: bool = False,
+) -> Lexeme:
+    """
+    Constructs a Lexeme based on a given regular expression.
+
+    Parameters:
+    body_regex (str): The regular expression that will greedily match the input.
+    contextual (bool): If false, all other lexemes are excluded when this lexeme is recognized.
+        This is normal behavior for keywords in programming languages.
+        Set to true for eg. a JSON schema with both `/"type"/` and `/"[^"]*"/` as lexemes,
+        or for "get"/"set" contextual keywords in C#.
+    json_string (bool): Specifies if the lexeme should be quoted as a JSON string.
+        For example, /[a-z"]+/ will be quoted as /([a-z]|\\")+.
+        Defaults to False.
+    """
+    return Lexeme(body_regex=body_regex, contextual=contextual, json_string=json_string)
 
 
 def subgrammar(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "pydantic",
     "requests",
     "tiktoken>=0.3",
-    "llguidance",
+    "llguidance>=0.1.7",
 ]
 
 # Our basic list of 'extras'


### PR DESCRIPTION
- Pass `json_string` down into Lexeme/llguidance
- Rewrite json_string definition in `library/_json.py`
- Add some tests to ensure that user specified patterns like `.*` can only produce valid json strings