### PR TITLE
[Feature] Support `required` properties in JSON schemas

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -175,14 +175,19 @@ def _gen_list(lm, *, elements: tuple[GrammarFunction, ...], required: tuple[bool
     e, elements = elements[0], elements[1:]
     r, required = required[0], required[1:]
 
-    if r:
-        if prefixed:
-            return lm + (',' + e + _gen_list(elements=elements, required=required, prefixed=True))
-        return lm + (e + _gen_list(elements=elements, required=required, prefixed=True))
-
     if prefixed:
+        if r:
+            # If we know we have preceeding elements, we can safely just add a (',' + e)
+            return lm + (',' + e + _gen_list(elements=elements, required=required, prefixed=True))
         # If we know we have preceeding elements, we can safely just add an optional(',' + e)
         return lm + (optional(',' + e) + _gen_list(elements=elements, required=required, prefixed=True))
+    if r:
+        # No preceding elements, and our element is required, so we just add the element
+        return lm + (e + _gen_list(elements=elements, required=required, prefixed=True))
+
+    # No preceding elements, and our element is optional, so we add a select between the two options.
+    # The first option is the recursive call with no preceding elements, the second is the recursive call
+    # with the current element as a prefix.
     return lm + select([
         _gen_list(elements=elements, required=required, prefixed=False),
         e + _gen_list(elements=elements, required=required, prefixed=True)

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -181,10 +181,8 @@ def _gen_list(lm, *, elements: tuple[GrammarFunction, ...], required: tuple[bool
         return lm + (e + _gen_list(elements=elements, required=required, prefixed=True))
 
     if prefixed:
-        return lm + select([
-            _gen_list(elements=elements, required=required, prefixed=True),
-            ',' + e + _gen_list(elements=elements, required=required, prefixed=True)
-        ])
+        # If we know we have preceeding elements, we can safely just add an optional(',' + e)
+        return lm + (optional(',' + e) + _gen_list(elements=elements, required=required, prefixed=True))
     return lm + select([
         _gen_list(elements=elements, required=required, prefixed=False),
         e + _gen_list(elements=elements, required=required, prefixed=True)

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -172,25 +172,25 @@ def _gen_list(lm, *, elements: tuple[GrammarFunction, ...], required: tuple[bool
     if not elements:
         return lm
 
-    e, elements = elements[0], elements[1:]
-    r, required = required[0], required[1:]
+    elem, elements = elements[0], elements[1:]
+    is_required, required = required[0], required[1:]
 
     if prefixed:
-        if r:
+        if is_required:
             # If we know we have preceeding elements, we can safely just add a (',' + e)
-            return lm + (',' + e + _gen_list(elements=elements, required=required, prefixed=True))
+            return lm + (',' + elem + _gen_list(elements=elements, required=required, prefixed=True))
         # If we know we have preceeding elements, we can safely just add an optional(',' + e)
-        return lm + (optional(',' + e) + _gen_list(elements=elements, required=required, prefixed=True))
-    if r:
+        return lm + (optional(',' + elem) + _gen_list(elements=elements, required=required, prefixed=True))
+    if is_required:
         # No preceding elements, and our element is required, so we just add the element
-        return lm + (e + _gen_list(elements=elements, required=required, prefixed=True))
+        return lm + (elem + _gen_list(elements=elements, required=required, prefixed=True))
 
     # No preceding elements, and our element is optional, so we add a select between the two options.
     # The first option is the recursive call with no preceding elements, the second is the recursive call
     # with the current element as a prefix.
     return lm + select([
         _gen_list(elements=elements, required=required, prefixed=False),
-        e + _gen_list(elements=elements, required=required, prefixed=True)
+        elem + _gen_list(elements=elements, required=required, prefixed=True)
     ])
 
 

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1877,9 +1877,9 @@ class TestEmptySchemas:
         "schema_obj",
         [
             # Empty property
-            {"type": "object", "properties": {"a": {}}},
+            {"type": "object", "properties": {"a": {}}, "required": ["a"]},
             # Empty reference
-            {"type": "object", "properties": {"a": {"$ref": "#/$defs/A"}}, "$defs": {"A": {}}},
+            {"type": "object", "properties": {"a": {"$ref": "#/$defs/A"}}, "$defs": {"A": {}}, "required": ["a"]},
         ],
     )
     @pytest.mark.parametrize(

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1545,7 +1545,8 @@ class TestAdditionalProperties:
         },
     "additionalProperties": {
             "type": "integer"
-        }
+        },
+    "required": ["mystr"]
     }
     """
 
@@ -1767,6 +1768,7 @@ class TestEmptySchemas:
         "a": {},
         "b": {"type": "number"}
     },
+    "required" : ["a", "b"],
     "type" : "object"
     }"""
 

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -40,23 +40,27 @@ def generate_and_check(
 
 
 def check_match_failure(
+    *,
     bad_string: str,
-    good_bytes: bytes,
-    failure_byte: bytes,
-    allowed_bytes: Optional[Set[bytes]],
+    good_bytes: Optional[bytes] = None,
+    failure_byte: Optional[bytes] = None,
+    allowed_bytes: Optional[Set[bytes]] = None,
     schema_obj: Dict[str, Any],
-    maybe_whitespace: bool,
-    compact: bool,
+    maybe_whitespace: Optional[bool] = None,
+    compact: bool = True,
 ):
+    if (allowed_bytes is not None) and (maybe_whitespace is None):
+        raise ValueError("If allowed_bytes is provided, maybe_whitespace must also be provided")
+    if allowed_bytes is not None and maybe_whitespace and not compact:
+        allowed_bytes = allowed_bytes.union(WHITESPACE)
+
     grammar = gen_json(schema=schema_obj, compact=compact)
+
     _check_match_failure(
         bad_string=bad_string,
         good_bytes=good_bytes,
         failure_byte=failure_byte,
-        allowed_bytes=(
-            allowed_bytes.union(WHITESPACE) if (maybe_whitespace and not compact and allowed_bytes is not None)
-            else allowed_bytes
-        ),
+        allowed_bytes=allowed_bytes,
         grammar=grammar,
     )
 

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -478,7 +478,8 @@ class TestSimpleObject:
             "type": "object",
             "properties": {
                 "a" : {"type": "integer"}
-            }
+            },
+            "required": ["a"]
         }
     """
         target_obj = dict(a=1)
@@ -502,7 +503,8 @@ class TestSimpleObject:
                 "f" : {"type": "integer"},
                 "g" : {"type": "integer"},
                 "h" : {"type": "integer"}
-            }
+            },
+            "required": ["a", "b", "c", "d", "e", "f", "g", "h"]
         }
     """
         target_obj = dict(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8)
@@ -533,7 +535,8 @@ class TestSimpleObject:
                         }
                     }
                 }
-            }
+            },
+            "required": ["name", "info"]
         }
     """
         target_obj = dict(name="my product", info=dict(a=1, b=2))
@@ -588,6 +591,7 @@ class TestSimpleObject:
             "properties": {
                 "a" : {"type": "integer"}
             },
+            "required": ["a"],
             "additionalProperties": false
         }
     """
@@ -1175,6 +1179,7 @@ class TestWithReferences:
                         "type": "string"
                     }
                 },
+                "required": ["name"],
                 "type": "object"
             }
         },
@@ -1186,6 +1191,7 @@ class TestWithReferences:
                 "$ref": "#/$defs/A"
             }
         },
+        "required": ["A1", "A2"],
         "type": "object"
         }"""
 
@@ -1240,6 +1246,7 @@ class TestAnyOf:
             "type": "string"
             }
         },
+        "required": ["my_str"],
         "title": "A",
         "type": "object"
         },
@@ -1251,6 +1258,7 @@ class TestAnyOf:
             "type": "integer"
             }
         },
+        "required": ["my_int"],
         "title": "B",
         "type": "object"
         }
@@ -1268,6 +1276,7 @@ class TestAnyOf:
         "title": "My Val"
         }
     },
+    "required": ["my_val"],
     "title": "C",
     "type": "object"
     }
@@ -1323,7 +1332,8 @@ class TestAllOf:
                         }
                     ]
                 }
-            }
+            },
+            "required": ["my_cat"]
         }
         """
 
@@ -1495,7 +1505,7 @@ class TestConst:
 
     def test_nested_constant(self):
         # First sanity check what we're setting up
-        schema_obj = {"type": "object", "properties": {"a": {"const": 1}}}
+        schema_obj = {"type": "object", "properties": {"a": {"const": 1}}, "required": ["a"]}
         target_obj = {"a": 1}
         validate(instance=target_obj, schema=schema_obj)
 
@@ -1735,6 +1745,7 @@ class TestRecursiveStructures:
                     ]
                 }
             },
+            "required": ["my_str", "next"],
             "type": "object"
         }
     },
@@ -1750,7 +1761,8 @@ class TestRecursiveStructures:
                 }
             ]
         }
-    }
+    },
+    "required": ["my_list"]
 }
         """
         # First sanity check what we're setting up
@@ -1846,9 +1858,9 @@ class TestEmptySchemas:
         "schema_obj",
         [
             # Empty property
-            {"type": "object", "properties": {"a": {}}},
+            {"type": "object", "properties": {"a": {}}, "required": ["a"]},
             # Empty reference
-            {"type": "object", "properties": {"a": {"$ref": "#/$defs/A"}}, "$defs": {"A": {}}},
+            {"type": "object", "properties": {"a": {"$ref": "#/$defs/A"}}, "$defs": {"A": {}}, "required": ["a"]},
         ],
     )
     @pytest.mark.parametrize(
@@ -2025,7 +2037,8 @@ def test_ignored_keys_allowed_as_properties():
         "type": "object",
         "properties": {
             key: {"type": "string"} for key in IGNORED_KEYS
-        }
+        },
+        "required": list(IGNORED_KEYS),
     }
     target_obj = {key: "value" for key in IGNORED_KEYS}
     generate_and_check(target_obj, schema_obj)

--- a/tests/unit/library/test_sequences.py
+++ b/tests/unit/library/test_sequences.py
@@ -31,10 +31,10 @@ class TestExactlynRepeats:
         SUFFIX = "BBB"
         grammar = Join([PREFIX, exactly_n_repeats("b", 4), SUFFIX])
         check_match_failure(
-            PREFIX + bad_string + SUFFIX,
-            PREFIX.encode() + good_bytes,
-            failure_byte,
-            allowed_bytes,
+            bad_string=PREFIX + bad_string + SUFFIX,
+            good_bytes=PREFIX.encode() + good_bytes,
+            failure_byte=failure_byte,
+            allowed_bytes=allowed_bytes,
             grammar=grammar,
         )
 
@@ -68,10 +68,10 @@ class TestAtMostnRepeats:
         SUFFIX = "BBB"
         grammar = Join([PREFIX, at_most_n_repeats("b", 4), SUFFIX])
         check_match_failure(
-            PREFIX + bad_string + SUFFIX,
-            PREFIX.encode() + good_bytes,
-            failure_byte,
-            allowed_bytes,
+            bad_string=PREFIX + bad_string + SUFFIX,
+            good_bytes=PREFIX.encode() + good_bytes,
+            failure_byte=failure_byte,
+            allowed_bytes=allowed_bytes,
             grammar=grammar,
         )
 
@@ -116,10 +116,10 @@ class TestSequence:
         SUFFIX = "BBB"
         grammar = Join([PREFIX, sequence("b"), SUFFIX])
         check_match_failure(
-            PREFIX + bad_string + SUFFIX,
-            PREFIX.encode() + good_bytes,
-            failure_byte,
-            allowed_bytes,
+            bad_string=PREFIX + bad_string + SUFFIX,
+            good_bytes=PREFIX.encode() + good_bytes,
+            failure_byte=failure_byte,
+            allowed_bytes=allowed_bytes,
             grammar=grammar,
         )
 
@@ -149,10 +149,10 @@ class TestSequence:
         SUFFIX = "BBB"
         grammar = Join([PREFIX, sequence("b", min_length=4), SUFFIX])
         check_match_failure(
-            PREFIX + bad_string + SUFFIX,
-            PREFIX.encode() + good_bytes,
-            failure_byte,
-            allowed_bytes,
+            bad_string=PREFIX + bad_string + SUFFIX,
+            good_bytes=PREFIX.encode() + good_bytes,
+            failure_byte=failure_byte,
+            allowed_bytes=allowed_bytes,
             grammar=grammar,
         )
 
@@ -181,10 +181,10 @@ class TestSequence:
         SUFFIX = "BBB"
         grammar = Join([PREFIX, sequence("b", max_length=2), SUFFIX])
         check_match_failure(
-            PREFIX + bad_string + SUFFIX,
-            PREFIX.encode() + good_bytes,
-            failure_byte,
-            allowed_bytes,
+            bad_string=PREFIX + bad_string + SUFFIX,
+            good_bytes=PREFIX.encode() + good_bytes,
+            failure_byte=failure_byte,
+            allowed_bytes=allowed_bytes,
             grammar=grammar,
         )
 
@@ -249,9 +249,9 @@ class TestSequence:
         SUFFIX = "BBB"
         grammar = Join([PREFIX, sequence("b", min_length=1, max_length=2), SUFFIX])
         check_match_failure(
-            PREFIX + bad_string + SUFFIX,
-            PREFIX.encode() + good_bytes,
-            failure_byte,
-            allowed_bytes,
+            bad_string=PREFIX + bad_string + SUFFIX,
+            good_bytes=PREFIX.encode() + good_bytes,
+            failure_byte=failure_byte,
+            allowed_bytes=allowed_bytes,
             grammar=grammar,
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -147,10 +147,11 @@ def check_match_success_with_guards(grammar, test_string: str):
 
 
 def check_match_failure(
+    *,
     bad_string: str,
-    good_bytes: bytes,
-    failure_byte: bytes,
-    allowed_bytes: Optional[Set[bytes]],
+    good_bytes: Optional[bytes] = None,
+    failure_byte: Optional[bytes] = None,
+    allowed_bytes: Optional[Set[bytes]] = None,
     grammar: GrammarFunction,
 ):
     """
@@ -162,8 +163,10 @@ def check_match_failure(
     """
     with pytest.raises(ByteParserException) as pe:
         grammar.match(bad_string, raise_exceptions=True)
-    assert pe.value.consumed_bytes == good_bytes
-    assert pe.value.current_byte == failure_byte
+    if good_bytes is not None:
+        assert pe.value.consumed_bytes == good_bytes
+    if failure_byte is not None:
+        assert pe.value.current_byte == failure_byte
     if allowed_bytes is not None:
         assert pe.value.allowed_bytes == allowed_bytes
 


### PR DESCRIPTION
We currently treat all properties as required, whether or not they are actually in the `required` list.

Implementing a grammar that allows an arbitrary list of grammars to be comma-joined where any subset of the grammars are allowed to be omitted based on a provided sequence of booleans wasn't very trivial... leading and trailing commas were hard to avoid without a recursive definition that's O(2^N) in the worst case (where all properties are optional). This is obviously a bad naive behavior.

Caching brings the O(2^N) to something that I think is closer to O(N) (need to verify).

Need to add some extensive tests too.