### PR TITLE
Support boolean JSON schemas

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -9,7 +9,6 @@ from typing import (
     Sequence,
     Union,
     Type,
-    TypeAlias,
     TYPE_CHECKING,
 )
 import warnings

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -28,7 +28,7 @@ from .._grammar import GrammarFunction, select, capture, with_temperature
 from ._pydantic import pydantic_to_json_schema
 from ._subgrammar import lexeme, subgrammar
 
-JSONSchema: TypeAlias = Union[bool, Mapping[str, Any]]
+JSONSchema = Union[bool, Mapping[str, Any]]
 
 def _to_compact_json(target: Any) -> str:
     # See 'Compact Encoding':

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -2244,7 +2244,7 @@ class TestBooleanSchema:
         "schema_obj",
         [
             False,
-            {"type": "object", "properties": {"a": False}},
+            {"type": "object", "properties": {"a": False}, "required": ["a"]},
         ]
     )
     def test_false_schema(self, schema_obj):

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -2218,3 +2218,36 @@ class TestRequiredPropertiesScaling:
         HITS_MAGIC_NUMBER = 1
         expected_hits = 0
         assert cache_info.hits <= expected_hits + HITS_MAGIC_NUMBER
+
+class TestBooleanSchema:
+    @pytest.mark.parametrize(
+        "target_obj",
+        [
+            123,
+            "hello",
+            [1, 2, 3],
+            {"a": 1},
+            None,
+            [{"a": 1}],
+            {"a": [1, 2, 3]},
+            {"a": {"b": 1}},
+            False,
+            True
+        ],
+    )
+    def test_true_schema(self, target_obj):
+        # should be the same as an empty schema
+        schema_obj = True
+        generate_and_check(target_obj, schema_obj)
+
+    @pytest.mark.parametrize(
+        "schema_obj",
+        [
+            False,
+            {"type": "object", "properties": {"a": False}},
+        ]
+    )
+    def test_false_schema(self, schema_obj):
+        with pytest.raises(ValueError) as ve:
+            gen_json(schema=schema_obj)
+        assert ve.value.args[0] == "No valid JSON can be generated from a schema of `False`"


### PR DESCRIPTION
We were previously supporting `True`/`False` schemas only when nested in certain places like `items` and `additionalProperties`. This expands our coverage to handle top-level boolean schemas as well.

Note that we will now raise a `ValueError` for `False` schemas, simply because there is nothing we can generate in this case. Alternatively, we return a null grammar... But this may have unforseen consequences.

Added some minimal tests, as we already have decent coverage for the nested cases in the `TestEmptySchema` class. 

Note: developed alongside #1014, which made it much easier to tell whether I had full coverage of every type we accept :)