### PR TITLE
[Bug] Ensure `grammar.match` raises appropriately on incomplete input

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -177,6 +177,8 @@ class GrammarFunction(Function):
 
         try:
             parser.consume_bytes(byte_string)
+            if not allow_partial:
+                parser.force_done()
         except _parser.ByteParserException:
             if raise_exceptions:
                 raise

--- a/tests/unit/test_grammar.py
+++ b/tests/unit/test_grammar.py
@@ -1,6 +1,7 @@
 import pytest
 import guidance
 from guidance import gen, models, optional, select, string
+from guidance._parser import ByteParserException
 
 
 def test_select_reset_pos():
@@ -133,3 +134,11 @@ class TestMatch:
         assert match is not None
         assert match.partial
         assert match.captures["mycap"] == string
+
+    def test_raises_on_incomplete_input(self):
+        g = "123" + gen(regex=r"\d+x?", name="mycap")
+        # Ok since we allow partial
+        assert g.match(b"123", raise_exceptions=True, allow_partial=True) is not None
+        # Shold raise since we don't allow partial
+        with pytest.raises(ByteParserException):
+            g.match(b"123", raise_exceptions=True)


### PR DESCRIPTION
Force-feed `ByteParser` an EOS token if it's not done by the time all input has been consumed. This lets us raise an exception when a string fails to complete a grammar