### PR TITLE
Strip anchors from JSON regexes

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -343,6 +343,12 @@ def _gen_json_string(
     if format is not None:
         regex = _get_format_pattern(format)
 
+    elif regex is not None:
+        # Sanitize the regex, removing unnecessary anchors that may cause problems later
+        # NOTE/TODO: this could potentially be pushed further down into the lexeme function,
+        # but it's not immediately clear whether anchors in other contexts are superfluous.
+        regex = regex.lstrip("^").rstrip("$")
+
     elif regex is None:
         range_expr = f"{{{min_length},{max_length}}}" if max_length is not None else f"{{{min_length},}}"
         regex = f"(?s:.{range_expr})"


### PR DESCRIPTION
What it says on the tin. Does `regex = regex.lstrip("^").rstrip("$")` for any user-passed regex under the json `pattern` keyword.

This strip is necessary in order to use `json` generation with the [big FHIR schema](https://build.fhir.org/fhir.schema.json) because of the odd double anchors they use. It "should" be safe to do this, but I'd like some feedback if there is any dissent.

Note that this could potentially be pulled further down into the `lexeme` code, but I'm not 100% confident that this is "safe" from the perspective of maintaining users' intended semantics.