### PR TITLE
"required" JSON keys are validated against "additionalProperties" if they are missing from "properties"

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -365,7 +365,7 @@ def _gen_json_object(
     if any(k not in properties for k in required) and additional_properties is False:
         raise ValueError(
             f"Required properties not in properties but additionalProperties is False."
-            f" Missing required properties: {set(required) - set(properties)}"
+            f" Missing required properties: {list(r for r in required if r not in properties)}"
         )
     items = list(chain(
         # First iterate over the properties in order

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -1,6 +1,5 @@
 from json import dumps as json_dumps
 from enum import Enum
-from itertools import chain
 from typing import (
     Any,
     Callable,
@@ -367,13 +366,13 @@ def _gen_json_object(
             f"Required properties not in properties but additionalProperties is False."
             f" Missing required properties: {list(r for r in required if r not in properties)}"
         )
-    items = list(chain(
+    items = [
         # First iterate over the properties in order
-        properties.items(),
+        *properties.items(),
         # If there are any keys in required that weren't specified by properties, add them in order at the end,
         # where we will validate against the additional_properties schema
-        ((key, additional_properties) for key in required if key not in properties),
-    ))
+        *((key, additional_properties) for key in required if key not in properties),
+    ]
     grammars = tuple(f'"{name}":' + _gen_json(json_schema=schema, definitions=definitions) for name, schema in items)
     required_items = tuple(name in required for name, _ in items)
 

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -641,7 +641,7 @@ class TestObjectWithMissingRequired:
         schema = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["b", "c"], "additionalProperties": False}
         with pytest.raises(ValueError) as ve:
             _ = gen_json(schema=schema)
-        assert ve.value.args[0] == "Required properties not in properties but additionalProperties is False. Missing required properties: {'b', 'c'}"
+        assert ve.value.args[0] == "Required properties not in properties but additionalProperties is False. Missing required properties: ['b', 'c']"
 
 
 class TestSimpleArray:

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -614,6 +614,36 @@ class TestSimpleObject:
         )
 
 
+class TestObjectWithMissingRequired:
+    def test_required_is_required(self):
+        schema = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["b"]}
+        generate_and_check({"b": 1}, schema)
+        generate_and_check({"a": 1, "b": "xyz"}, schema)
+        check_match_failure(
+            bad_string=_to_compact_json(
+                {"a": 1}
+            ),
+            schema_obj=schema,
+        )
+
+    def test_validated_against_additionalProperties(self):
+        schema = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["b"], "additionalProperties": {"type": "integer"}}
+        generate_and_check({"b": 1}, schema)
+        generate_and_check({"a": 1, "b": 42}, schema)
+        check_match_failure(
+            bad_string=_to_compact_json(
+                {"a": 1, "b": "string"}
+            ),
+            schema_obj=schema,
+        )
+
+    def test_false_additionalProperties_fails(self):
+        schema = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["b", "c"], "additionalProperties": False}
+        with pytest.raises(ValueError) as ve:
+            _ = gen_json(schema=schema)
+        assert ve.value.args[0] == "Required properties not in properties but additionalProperties is False. Missing required properties: {'b', 'c'}"
+
+
 class TestSimpleArray:
     # These are array without references
     @pytest.mark.parametrize("target_obj", [[], [0], [34, 56], [1, 2, 3], [9, 8, 7, 6]])


### PR DESCRIPTION
Rather than raising an exception when `required` properties don't have a schema in `properties`, validate against `additionalProperties` (consistent with Draft202012)

Somewhat arbitrarily set key order of resulting objects to:
1. `properties` in order
2. `required` properties mising from `properties` in order
3. any other `additionalProperties`