### PR TITLE
JSON reserved keywords

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -38,6 +38,8 @@ def _to_compact_json(target: Any) -> str:
     # and whitespace
     return json_dumps(target, separators=(",", ":"))
 
+DRAFT202012_RESERVED_KEYWORDS = {'description', 'propertyNames', 'maxItems', 'then', 'minLength', 'minItems', 'oneOf', 'default', 'anyOf', 'maxContains', '$dynamicAnchor', 'else', 'readOnly', 'definitions', 'unevaluatedProperties', '$anchor', '$schema', 'minProperties', 'patternProperties', 'dependentRequired', 'items', 'maxLength', 'contentSchema', '$defs', 'minimum', '$comment', 'dependencies', 'allOf', 'examples', 'if', 'contentEncoding', 'const', 'dependentSchemas', 'prefixItems', '$ref', '$id', 'required', 'contentMediaType', 'type', '$recursiveAnchor', 'format', '$recursiveRef', 'maxProperties', 'uniqueItems', 'maximum', 'not', 'deprecated', 'multipleOf', '$dynamicRef', '$vocabulary', 'contains', 'additionalProperties', 'properties', 'enum', 'unevaluatedItems', 'writeOnly', 'minContains', 'exclusiveMaximum', 'exclusiveMinimum', 'title', 'pattern'}
+
 class JSONType(str, Enum):
     NULL = "null"
     BOOLEAN = "boolean"
@@ -303,7 +305,8 @@ def _get_format_pattern(format: str) -> str:
 
 def validate_json_node_keys(node: Mapping[str, Any]):
     keys = set(node.keys())
-    invalid_keys = keys - VALID_KEYS
+    # Any key that is a valid JSON schema keyword but not one that we have explicit support for is "invalid"
+    invalid_keys = (keys - VALID_KEYS).intersection(DRAFT202012_RESERVED_KEYWORDS)
     if invalid_keys:
         raise ValueError(
             f"JSON schema had keys that could not be processed: {invalid_keys}" f"\nSchema: {node}"

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -38,7 +38,86 @@ def _to_compact_json(target: Any) -> str:
     # and whitespace
     return json_dumps(target, separators=(",", ":"))
 
-DRAFT202012_RESERVED_KEYWORDS = {'description', 'propertyNames', 'maxItems', 'then', 'minLength', 'minItems', 'oneOf', 'default', 'anyOf', 'maxContains', '$dynamicAnchor', 'else', 'readOnly', 'definitions', 'unevaluatedProperties', '$anchor', '$schema', 'minProperties', 'patternProperties', 'dependentRequired', 'items', 'maxLength', 'contentSchema', '$defs', 'minimum', '$comment', 'dependencies', 'allOf', 'examples', 'if', 'contentEncoding', 'const', 'dependentSchemas', 'prefixItems', '$ref', '$id', 'required', 'contentMediaType', 'type', '$recursiveAnchor', 'format', '$recursiveRef', 'maxProperties', 'uniqueItems', 'maximum', 'not', 'deprecated', 'multipleOf', '$dynamicRef', '$vocabulary', 'contains', 'additionalProperties', 'properties', 'enum', 'unevaluatedItems', 'writeOnly', 'minContains', 'exclusiveMaximum', 'exclusiveMinimum', 'title', 'pattern'}
+DRAFT202012_RESERVED_KEYWORDS = {
+    # Anchors and References
+    '$anchor',
+    '$dynamicAnchor',
+    '$dynamicRef',
+    '$id',
+    '$recursiveAnchor',
+    '$recursiveRef',
+    '$ref',
+    '$schema',
+    '$vocabulary',
+
+    # Schema Structure and Combining Schemas
+    '$defs',
+    'definitions',
+    'dependencies',
+    'dependentRequired',
+    'dependentSchemas',
+    'allOf',
+    'anyOf',
+    'oneOf',
+    'not',
+    'if',
+    'then',
+    'else',
+
+    # Validation Keywords for Any Instance Type
+    'const',
+    'enum',
+    'type',
+
+    # Validation Keywords for Numeric Instances
+    'multipleOf',
+    'maximum',
+    'exclusiveMaximum',
+    'minimum',
+    'exclusiveMinimum',
+
+    # Validation Keywords for Strings
+    'maxLength',
+    'minLength',
+    'pattern',
+    'format',
+
+    # Validation Keywords for Arrays
+    'items',
+    'prefixItems',
+    'maxItems',
+    'minItems',
+    'uniqueItems',
+    'contains',
+    'maxContains',
+    'minContains',
+
+    # Validation Keywords for Objects
+    'properties',
+    'patternProperties',
+    'additionalProperties',
+    'propertyNames',
+    'required',
+    'maxProperties',
+    'minProperties',
+    'unevaluatedProperties',
+    'unevaluatedItems',
+
+    # Metadata Keywords
+    '$comment',
+    'description',
+    'title',
+    'default',
+    'deprecated',
+    'readOnly',
+    'writeOnly',
+    'examples',
+
+    # Content Validation
+    'contentEncoding',
+    'contentMediaType',
+    'contentSchema',
+}
 
 class JSONType(str, Enum):
     NULL = "null"

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -52,17 +52,17 @@ DRAFT202012_RESERVED_KEYWORDS = {
 
     # Schema Structure and Combining Schemas
     '$defs',
+    'allOf',
+    'anyOf',
     'definitions',
     'dependencies',
     'dependentRequired',
     'dependentSchemas',
-    'allOf',
-    'anyOf',
-    'oneOf',
-    'not',
-    'if',
-    'then',
     'else',
+    'if',
+    'not',
+    'oneOf',
+    'then',
 
     # Validation Keywords for Any Instance Type
     'const',
@@ -70,48 +70,48 @@ DRAFT202012_RESERVED_KEYWORDS = {
     'type',
 
     # Validation Keywords for Numeric Instances
-    'multipleOf',
-    'maximum',
     'exclusiveMaximum',
-    'minimum',
     'exclusiveMinimum',
+    'maximum',
+    'minimum',
+    'multipleOf',
 
     # Validation Keywords for Strings
+    'format',
     'maxLength',
     'minLength',
     'pattern',
-    'format',
 
     # Validation Keywords for Arrays
-    'items',
-    'prefixItems',
-    'maxItems',
-    'minItems',
-    'uniqueItems',
     'contains',
+    'items',
     'maxContains',
+    'maxItems',
     'minContains',
+    'minItems',
+    'prefixItems',
+    'uniqueItems',
 
     # Validation Keywords for Objects
-    'properties',
-    'patternProperties',
     'additionalProperties',
-    'propertyNames',
-    'required',
     'maxProperties',
     'minProperties',
-    'unevaluatedProperties',
+    'patternProperties',
+    'properties',
+    'propertyNames',
+    'required',
     'unevaluatedItems',
+    'unevaluatedProperties',
 
     # Metadata Keywords
     '$comment',
-    'description',
-    'title',
     'default',
     'deprecated',
-    'readOnly',
-    'writeOnly',
+    'description',
     'examples',
+    'readOnly',
+    'title',
+    'writeOnly',
 
     # Content Validation
     'contentEncoding',


### PR DESCRIPTION
Add a set containing every single keyword reserved by JSON schema Draft 2020-12.

"Invalid" keywords (rather, unsupported/not-yet-supported keys) are now defined as "any keyword we don't explicitly provide an implementation for that is ALSO a reserved keyword.

This should prevent us from having to manually whitelist non-keywords. Note that I think that the sets/enums of "supported" keys probably needs a second refactor... Not part of this PR though.

For posterity, here's the code I wrote to get the set of all reserved keywords:

```python
from referencing import Registry
from referencing.retrieval import to_cached_resource
import httpx

@to_cached_resource()
def retrieve_with_httpx(url: str) -> str:
    response = httpx.get(url)
    response.raise_for_status()
    return response.text

registry = Registry(retrieve=retrieve_with_httpx)
resolved = registry.resolver().lookup("https://json-schema.org/draft/2020-12/schema")

def crawl(schema, resolver):
    props = {}
    todo = [schema]
    while todo:
        current = todo.pop()
        if "$ref" in current:
            resolved = resolver.lookup(current["$ref"])
            props.update(
                crawl(resolved.contents, resolved.resolver)
            )
        if "properties" in current:
            props.update(current["properties"])
        if "allOf" in current:
            todo.extend(current["allOf"])
        if "anyOf" in current:
            raise NotImplementedError("anyOf")
        if "oneOf" in current:
            raise NotImplementedError("oneOf")
        if "$dynamicRef" in current:
            raise NotImplementedError("$dynamicRef")

    return props

props = crawl(resolved.contents, resolved.resolver)
```