### PR TITLE
[Feature] Allow `@guidance` to decorate methods

### DIFF
--- a/guidance/__init__.py
+++ b/guidance/__init__.py
@@ -4,7 +4,7 @@ import sys
 import types
 
 from . import models
-from ._guidance import guidance
+from ._guidance import guidance, guidance_method
 
 from ._grammar import (
     RawFunction,

--- a/guidance/__init__.py
+++ b/guidance/__init__.py
@@ -4,7 +4,7 @@ import sys
 import types
 
 from . import models
-from ._guidance import guidance, guidance_method
+from ._guidance import guidance
 
 from ._grammar import (
     RawFunction,

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -92,7 +92,7 @@ class GuidanceMethod:
             impl = _decorator(weak_method, stateless=guidance_function.stateless, cache=guidance_function.cache, model=guidance_function.model)
             cls.impl_cache[key] = impl
             # Clean up the cache when the instance is deleted
-            weakref.finalize(weak_method, cls.impl_cache.pop, key)
+            weakref.finalize(instance, cls.impl_cache.pop, key)
         return cls(impl, instance)
 
     def __call__(self, *args, **kwargs):

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -85,6 +85,9 @@ class GuidanceFunction:
                 instance=instance,
             )
             self._methods[key] = method
+            # Ensure the method is removed from the cache when the instance is deleted
+            weakref.finalize(instance, self._methods.pop, key)
+
         return self._methods[key]
 
     def __repr__(self):

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -57,7 +57,6 @@ class GuidanceFunction:
         self.model = model
         self._wrapper = None
         self._methods: weakref.WeakKeyDictionary[Any, GuidanceMethod] = weakref.WeakKeyDictionary()
-        self._method_hashes: weakref.WeakKeyDictionary[Any, int] = weakref.WeakKeyDictionary()
 
     def __call__(self, *args, **kwargs):
         # "Cache" the wrapped function (needed for recursive calls)
@@ -73,7 +72,7 @@ class GuidanceFunction:
             return self
 
         # On cache miss, create a new GuidanceMethod. Make sure that changing the hash of the instance invalidates the cache.
-        if instance not in self._methods or hash(instance) != self._method_hashes.get(instance):
+        if instance not in self._methods:
             method = GuidanceMethod(
                 # Don't cache twice (in particular, we need to cache a weak_bound_method version downstairs)
                 self.f if not self.cache else self.f.__wrapped__,
@@ -83,7 +82,6 @@ class GuidanceFunction:
                 instance=instance,
             )
             self._methods[instance] = method
-            self._method_hashes[instance] = hash(instance)
             # Why do I need this? Am I the only reference to the instance??
             return method
 

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -15,6 +15,13 @@ def guidance(
     model = Model,
 ):
     """Decorator used to define guidance grammars"""
+    # if we are not yet being used as a decorator, then save the args
+
+    if f is None:
+        return functools.partial(
+            _decorator, stateless=stateless, cache=cache, dedent=dedent, model=model
+        )
+
     return _decorator(f, stateless=stateless, cache=cache, dedent=dedent, model=model)
 
 def guidance_method(
@@ -74,74 +81,64 @@ _null_grammar = string("")
 
 
 def _decorator(f, *, stateless, cache, dedent, model):
+    # this strips out indentation in multiline strings that aligns with the current python indentation
+    if dedent is True or dedent == "python":
+        f = strip_multiline_string_indents(f)
 
-    # if we are not yet being used as a decorator, then save the args
-    if f is None:
-        return functools.partial(
-            _decorator, stateless=stateless, cache=cache, dedent=dedent, model=model
-        )
+    # we cache if requested
+    if cache:
+        f = functools.cache(f)
 
-    # if we are being used as a decorator then return the decorated function
-    else:
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
 
-        # this strips out indentation in multiline strings that aligns with the current python indentation
-        if dedent is True or dedent == "python":
-            f = strip_multiline_string_indents(f)
+        # make a stateless grammar if we can
+        if stateless is True or (
+            callable(stateless) and stateless(*args, **kwargs)
+        ):
 
-        # we cache if requested
-        if cache:
-            f = functools.cache(f)
+            # if we have a (deferred) reference set, then we must be in a recursive definition and so we return the reference
+            reference = getattr(f, "_self_call_reference_", None)
+            if reference is not None:
+                return reference
 
-        @functools.wraps(f)
-        def wrapped(*args, **kwargs):
-
-            # make a stateless grammar if we can
-            if stateless is True or (
-                callable(stateless) and stateless(*args, **kwargs)
-            ):
-
-                # if we have a (deferred) reference set, then we must be in a recursive definition and so we return the reference
-                reference = getattr(f, "_self_call_reference_", None)
-                if reference is not None:
-                    return reference
-
-                # otherwise we call the function to generate the grammar
-                else:
-
-                    # set a DeferredReference for recursive calls (only if we don't have arguments that might make caching a bad idea)
-                    no_args = len(args) + len(kwargs) == 0
-                    if no_args:
-                        f._self_call_reference_ = DeferredReference()
-
-                    try:
-                        # call the function to get the grammar node
-                        node = f(_null_grammar, *args, **kwargs)
-                    except:
-                        raise
-                    else:
-                        if not isinstance(node, (Terminal, str)):
-                            node.name = f.__name__
-                        # set the reference value with our generated node
-                        if no_args:
-                            f._self_call_reference_.value = node
-                    finally:
-                        if no_args:
-                            del f._self_call_reference_
-
-                    return node
-
-            # otherwise must be stateful (which means we can't be inside a select() call)
+            # otherwise we call the function to generate the grammar
             else:
-                return RawFunction(f, args, kwargs)
 
-        # Remove the first argument from the wrapped function
-        signature = inspect.signature(f)
-        params = list(signature.parameters.values())
-        params.pop(0)
-        wrapped.__signature__ = signature.replace(parameters=params)
+                # set a DeferredReference for recursive calls (only if we don't have arguments that might make caching a bad idea)
+                no_args = len(args) + len(kwargs) == 0
+                if no_args:
+                    f._self_call_reference_ = DeferredReference()
 
-        # attach this as a method of the model class (if given)
-        # if model is not None:
-        #     setattr(model, f.__name__, f)
+                try:
+                    # call the function to get the grammar node
+                    node = f(_null_grammar, *args, **kwargs)
+                except:
+                    raise
+                else:
+                    if not isinstance(node, (Terminal, str)):
+                        node.name = f.__name__
+                    # set the reference value with our generated node
+                    if no_args:
+                        f._self_call_reference_.value = node
+                finally:
+                    if no_args:
+                        del f._self_call_reference_
 
-        return wrapped
+                return node
+
+        # otherwise must be stateful (which means we can't be inside a select() call)
+        else:
+            return RawFunction(f, args, kwargs)
+
+    # Remove the first argument from the wrapped function
+    signature = inspect.signature(f)
+    params = list(signature.parameters.values())
+    params.pop(0)
+    wrapped.__signature__ = signature.replace(parameters=params)
+
+    # attach this as a method of the model class (if given)
+    # if model is not None:
+    #     setattr(model, f.__name__, f)
+
+    return wrapped

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -99,7 +99,7 @@ class GuidanceMethod(GuidanceFunction):
             cache=cache,
             model=model,
         )
-        # Save the instance and owner for introspection
+        # Save the instance for introspection
         self._instance = weakref.ref(instance)
 
     def __get__(self, instance, owner=None, /):

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -55,11 +55,13 @@ class GuidanceFunction:
         self._wrapper = None
 
     def __call__(self, *args, **kwargs):
-        # "Cache" the wrapped function
+        # "Cache" the wrapped function (needed for recursive calls)
         if self._wrapper is None:
             self._wrapper = _decorator(self.f, stateless=self.stateless, model=self.model)
         return self._wrapper(*args, **kwargs)
 
+    # Cache the bound method (needed for recursive calls)
+    @functools.cache
     def __get__(self, instance, owner=None, /):
         if instance is None:
             return self

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -82,6 +82,7 @@ class GuidanceMethod:
 
     @classmethod
     def from_guidance_function(cls, guidance_function: GuidanceFunction, instance: Any) -> "GuidanceMethod":
+        # Use instance hash in addition to identity to make sure we miss the cache if the instance is meaningfully mutated
         key = (guidance_function.f, hash(instance), id(instance))
         try:
             impl = cls.impl_cache[key]

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -98,7 +98,7 @@ class GuidanceMethod:
         return self.__func__(*args, **kwargs)
 
     def __repr__(self):
-        return f"<bound GuidanceMethod {self.__qualname__} of {self._instance()!r}>"
+        return f"<bound GuidanceMethod {self.__qualname__} of {self.__self__!r}>"
 
 
 _null_grammar = string("")

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -84,6 +84,8 @@ class GuidanceFunction:
             )
             self._methods[instance] = method
             self._method_hashes[instance] = hash(instance)
+            # Why do I need this? Am I the only reference to the instance??
+            return method
 
         return self._methods[instance]
 

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -50,7 +50,7 @@ class GuidanceFunction:
 
         # Update self with the wrapped function's metadata
         functools.update_wrapper(self, self._impl)
-        # Pretend to be one level of wrapping higher than we are
+        # Pretend to be one level of wrapping lower than we are
         self.__wrapped__ = self._impl.__wrapped__
 
     def __call__(self, *args, **kwargs):
@@ -77,7 +77,7 @@ class GuidanceMethod:
 
         # Update self with the wrapped function's metadata
         functools.update_wrapper(self, impl)
-        # Pretend to be one level of wrapping higher than we are
+        # Pretend to be one level of wrapping lower than we are
         self.__wrapped__ = impl.__wrapped__
 
     @classmethod

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -70,8 +70,8 @@ class GuidanceFunction:
 class GuidanceMethod:
     impl_cache = {}
     def __init__(self, impl, instance):
-        # Make object that looks like a method. Note we keep a hard reference to the instance
-        # to keep it (and therefore our cached impl) alive as long as we are alive
+        # Make object that looks like a method (__self__ and __func__) in order to be able to better support weak referencing via weakref.WeakMethod
+        # Note we keep a hard reference to the instance to keep it (and therefore our cached impl) alive as long as we are alive
         self.__self__ = instance
         self.__func__ = impl
 

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -42,7 +42,13 @@ class GuidanceFunction:
         model = Model,
     ):
         # Update self with the wrapped function's metadata
-        functools.wraps(f)(self)
+        functools.update_wrapper(self, f)
+        # Remove the first argument from the wrapped function
+        signature = inspect.signature(f)
+        params = list(signature.parameters.values())
+        params.pop(0)
+        self.__signature__ = signature.replace(parameters=params)
+
         self.f = f
         self.stateless = stateless
         self.model = model
@@ -127,12 +133,6 @@ def _decorator(f, *, stateless, model):
         # otherwise must be stateful (which means we can't be inside a select() call)
         else:
             return RawFunction(f, args, kwargs)
-
-    # Remove the first argument from the wrapped function
-    signature = inspect.signature(f)
-    params = list(signature.parameters.values())
-    params.pop(0)
-    wrapped.__signature__ = signature.replace(parameters=params)
 
     # attach this as a method of the model class (if given)
     # if model is not None:

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -72,6 +72,9 @@ class GuidanceFunction:
             owner=owner,
         )
 
+    def __repr__(self):
+        return f"<GuidanceFunction {self.__module__}.{self.__qualname__}{self.__signature__}>"
+
 
 class GuidanceMethod(GuidanceFunction):
     def __init__(self, f, *, stateless=False, model=Model, instance, owner):
@@ -86,6 +89,9 @@ class GuidanceMethod(GuidanceFunction):
 
     def __get__(self, instance, owner=None, /):
         raise AttributeError("GuidanceMethod is already bound to an instance")
+
+    def __repr__(self):
+        return f"<bound GuidanceMethod {self.__qualname__} of {self._instance!r}>"
 
 
 _null_grammar = string("")

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -75,7 +75,6 @@ class GuidanceFunction:
                 stateless=self.stateless,
                 model=self.model,
                 instance=instance,
-                owner=owner,
             )
             self._methods[instance] = method
 
@@ -86,7 +85,7 @@ class GuidanceFunction:
 
 
 class GuidanceMethod(GuidanceFunction):
-    def __init__(self, f, *, stateless=False, model=Model, instance, owner):
+    def __init__(self, f, *, stateless=False, model=Model, instance):
         super().__init__(
             make_weak_bound_method(f, instance),
             stateless=stateless,
@@ -94,7 +93,6 @@ class GuidanceMethod(GuidanceFunction):
         )
         # Save the instance and owner for introspection
         self._instance = weakref.ref(instance)
-        self._owner = weakref.ref(owner)
 
     def __get__(self, instance, owner=None, /):
         raise AttributeError("GuidanceMethod is already bound to an instance")

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -5,7 +5,7 @@ from typing import Any
 import weakref
 
 from ._grammar import DeferredReference, RawFunction, Terminal, string
-from ._utils import strip_multiline_string_indents, make_weak_bound_method
+from ._utils import strip_multiline_string_indents, make_weak_bound_method, signature_pop
 from .models import Model
 
 
@@ -46,11 +46,8 @@ class GuidanceFunction:
     ):
         # Update self with the wrapped function's metadata
         functools.update_wrapper(self, f)
-        # Remove the first argument from the wrapped function
-        signature = inspect.signature(f)
-        params = list(signature.parameters.values())
-        params.pop(0)
-        self.__signature__ = signature.replace(parameters=params)
+        # Remove the first argument from the wrapped function since we're going to drop the `lm` argument
+        self.__signature__ = signature_pop(inspect.signature(f), 0)
 
         self.f = f
         self.stateless = stateless

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -19,7 +19,7 @@ def guidance(
 
     if f is None:
         return functools.partial(
-            _decorator, stateless=stateless, cache=cache, model=model
+            _decorator, stateless=stateless, model=model
         )
 
     # this strips out indentation in multiline strings that aligns with the current python indentation

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -19,7 +19,7 @@ def guidance(
 
     if f is None:
         return functools.partial(
-            _decorator, stateless=stateless, model=model
+            guidance, stateless=stateless, cache=cache, dedent=dedent, model=model,
         )
 
     # this strips out indentation in multiline strings that aligns with the current python indentation
@@ -43,7 +43,7 @@ def guidance_method(
     # if we are not yet being used as a decorator, then save the args
     if f is None:
         return functools.partial(
-            GuidanceMethod, stateless=stateless, model=model
+            guidance_method, stateless=stateless, cache=cache, dedent=dedent, model=model,
         )
 
     # this strips out indentation in multiline strings that aligns with the current python indentation

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -44,10 +44,13 @@ class GuidanceFunction:
         self.f = f
         self.stateless = stateless
         self.model = model
+        self._wrapper = None
 
     def __call__(self, *args, **kwargs):
-        decorated = _decorator(self.f, stateless=self.stateless, model=self.model)
-        return decorated(*args, **kwargs)
+        # "Cache" the wrapped function
+        if self._wrapper is None:
+            self._wrapper = _decorator(self.f, stateless=self.stateless, model=self.model)
+        return self._wrapper(*args, **kwargs)
 
     def __get__(self, instance, owner=None, /):
         if instance is None:

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -27,11 +27,7 @@ def guidance(
     if dedent is True or dedent == "python":
         f = strip_multiline_string_indents(f)
 
-    # we cache if requested
-    if cache:
-        f = functools.cache(f)
-
-    return GuidanceFunction(f, stateless=stateless, model=model)
+    return GuidanceFunction(f, stateless=stateless, cache=cache, model=model)
 
 
 class GuidanceFunction:
@@ -40,8 +36,13 @@ class GuidanceFunction:
         f,
         *,
         stateless = False,
+        cache = False,
         model = Model,
     ):
+        # we cache the function itself if requested
+        if cache:
+            f = functools.cache(f)
+
         # Update self with the wrapped function's metadata
         functools.update_wrapper(self, f)
         # Remove the first argument from the wrapped function
@@ -80,11 +81,12 @@ class GuidanceFunction:
 
 
 class GuidanceMethod(GuidanceFunction):
-    def __init__(self, f, *, stateless=False, model=Model, instance, owner):
+    def __init__(self, f, *, stateless=False, cache=False, model=Model, instance, owner):
         super().__init__(
             f.__get__(instance, owner),
             stateless=stateless,
-            model=model
+            cache=cache,
+            model=model,
         )
         # Save the instance and owner for introspection
         self._instance = instance

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -29,7 +29,11 @@ def guidance(
     if dedent is True or dedent == "python":
         f = strip_multiline_string_indents(f)
 
-    return GuidanceFunction(f, stateless=stateless, cache=cache, model=model)
+    # we cache the function itself if requested
+    if cache:
+        f = functools.cache(f)
+
+    return GuidanceFunction(f, stateless=stateless, model=model)
 
 
 class GuidanceFunction:
@@ -38,13 +42,8 @@ class GuidanceFunction:
         f,
         *,
         stateless = False,
-        cache = False,
         model = Model,
     ):
-        # we cache the function itself if requested
-        if cache:
-            f = functools.cache(f)
-
         # Update self with the wrapped function's metadata
         functools.update_wrapper(self, f)
         # Remove the first argument from the wrapped function
@@ -90,11 +89,10 @@ class GuidanceFunction:
 
 
 class GuidanceMethod(GuidanceFunction):
-    def __init__(self, f, *, stateless=False, cache=False, model=Model, instance, owner):
+    def __init__(self, f, *, stateless=False, model=Model, instance, owner):
         super().__init__(
             f.__get__(instance, owner),
             stateless=stateless,
-            cache=cache,
             model=model,
         )
         # Save the instance and owner for introspection

--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -41,6 +41,8 @@ class GuidanceFunction:
         stateless = False,
         model = Model,
     ):
+        # Update self with the wrapped function's metadata
+        functools.wraps(f)(self)
         self.f = f
         self.stateless = stateless
         self.model = model
@@ -85,7 +87,6 @@ _null_grammar = string("")
 
 def _decorator(f, *, stateless, model):
     reference = None
-    @functools.wraps(f)
     def wrapped(*args, **kwargs):
         nonlocal reference
 

--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -122,14 +122,14 @@ def strip_multiline_string_indents(f):
     return new_f
 
 def make_weak_bound_method(f, instance):
-    weak_method = weakref.WeakMethod(
-        types.MethodType(f, instance)
-    )
+    instance_ref = weakref.ref(instance)
+    instance_repr = repr(instance)
     @functools.wraps(f) # ish
     def weak_bound_f(*args, **kwargs):
-        method = weak_method()
-        if method is None:
-            raise ReferenceError(f"Weak reference to method is dead: {f}")
+        instance = instance_ref()
+        if instance is None:
+            raise ReferenceError(f"Lost reference to {instance_repr} and cannot bind {f} to it.")
+        method = types.MethodType(f, instance)
         return method(*args, **kwargs)
 
     # remove the first argument from the wrapped function since it is now bound

--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -113,6 +113,10 @@ def strip_multiline_string_indents(f):
         closure=f.__closure__,
     )
     new_f.__kwdefaults__ = f.__kwdefaults__
+    new_f.__qualname__ = f.__qualname__
+    new_f.__annotations__ = f.__annotations__
+    new_f.__doc__ = f.__doc__
+    new_f.__module__ = f.__module__
     return new_f
 
 class CaptureEvents:

--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -132,7 +132,14 @@ def make_weak_bound_method(f, instance):
         bound_f = types.MethodType(f, instance)
         return bound_f(*args, **kwargs)
 
+    # remove the first argument from the wrapped function since it is now bound
+    weak_bound_f.__signature__ = signature_pop(inspect.signature(f), 0)
     return weak_bound_f
+
+def signature_pop(signature, index):
+    params = list(signature.parameters.values())
+    params.pop(index)
+    return signature.replace(parameters=params)
 
 class CaptureEvents:
     """Creates a scope where all the events are captured in a queue.

--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -122,15 +122,15 @@ def strip_multiline_string_indents(f):
     return new_f
 
 def make_weak_bound_method(f, instance):
-    weak_instance = weakref.ref(instance)
-
+    weak_method = weakref.WeakMethod(
+        types.MethodType(f, instance)
+    )
     @functools.wraps(f) # ish
     def weak_bound_f(*args, **kwargs):
-        instance = weak_instance()
-        if instance is None:
-            raise ReferenceError("Weak reference to instance is dead")
-        bound_f = types.MethodType(f, instance)
-        return bound_f(*args, **kwargs)
+        method = weak_method()
+        if method is None:
+            raise ReferenceError(f"Weak reference to method is dead: {f}")
+        return method(*args, **kwargs)
 
     # remove the first argument from the wrapped function since it is now bound
     weak_bound_f.__signature__ = signature_pop(inspect.signature(f), 0)

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -452,6 +452,23 @@ class TestMethodGarbageCollection:
         assert obj_ref() is None
 
 
+    def test_deleting_instance_lets_method_be_garbage_collected(self):
+        obj = self.MyClass()
+        # Create a weak reference to the object
+        obj_ref = weakref.ref(obj)
+        # Create a weak reference to the cached method
+        meth_ref = weakref.ref(obj.cached_method)
+        # Quick sanity check (real methods need weakref.WeakMethod, but we're a bit different)
+        gc.collect()
+        assert meth_ref() is not None
+        # Delete the hard ref to the obj
+        del obj
+        # Run garbage collection
+        gc.collect()
+        # Check if the object was garbage collected
+        assert meth_ref() is None
+
+
 class TestSignature:
     def test_function_signature(self):
         def func(a, b=1, *, c, d=2):

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -397,3 +397,20 @@ class TestMethodGarbageCollection:
         gc.collect()
         # Check if the object was garbage collected
         assert obj_ref() is None
+
+
+class TestSignature:
+    @guidance(stateless=True)
+    def func(lm, a, b=1, *, c, d=2):
+        return lm
+
+    class MyClass:
+        @guidance(stateless=True)
+        def method(self, lm, a, b=1, *, c, d=2):
+            return lm
+
+    def test_function_signature(self):
+        assert list(self.func.__signature__.parameters.keys()) == ["a", "b", "c", "d"]
+
+    def test_method_signature(self):
+        assert list(self.MyClass().method.__signature__.parameters.keys()) == ["a", "b", "c", "d"]

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -154,7 +154,7 @@ class TestGuidanceMethod:
         def __init__(self, x):
             self.x = x
         
-        @guidance.guidance_method(stateless=True, cache=True, dedent=False)
+        @guidance(stateless=True, cache=True, dedent=False)
         def method(self, lm):
             lm += str(self.x)
             return lm
@@ -163,7 +163,7 @@ class TestGuidanceMethod:
         def __init__(self, x):
             self.x = x
         
-        @guidance.guidance_method(stateless=True, cache=True, dedent=False)
+        @guidance(stateless=True, cache=True, dedent=False)
         def method(self, lm):
             lm += str(self.x)
             return lm

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -1,6 +1,7 @@
 import pytest
 import weakref
 import gc
+import inspect
 
 import guidance
 from guidance import gen
@@ -400,17 +401,20 @@ class TestMethodGarbageCollection:
 
 
 class TestSignature:
-    @guidance(stateless=True)
-    def func(lm, a, b=1, *, c, d=2):
-        return lm
-
-    class MyClass:
-        @guidance(stateless=True)
-        def method(self, lm, a, b=1, *, c, d=2):
-            return lm
-
     def test_function_signature(self):
-        assert list(self.func.__signature__.parameters.keys()) == ["a", "b", "c", "d"]
+        def func(a, b=1, *, c, d=2):
+            pass
+        @guidance(stateless=True)
+        def guidance_func(lm, a, b=1, *, c, d=2):
+            return lm
+        assert inspect.signature(guidance_func) == inspect.signature(func)
 
     def test_method_signature(self):
-        assert list(self.MyClass().method.__signature__.parameters.keys()) == ["a", "b", "c", "d"]
+        class MyClass:
+            def method(self, a, b=1, *, c, d=2):
+                pass
+            @guidance(stateless=True)
+            def guidance_method(self, lm, a, b=1, *, c, d=2):
+                pass
+        obj = MyClass()
+        assert inspect.signature(obj.guidance_method) == inspect.signature(obj.method)

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -427,7 +427,7 @@ class TestMethodGarbageCollection:
         # Create a weak reference to the object
         obj_ref = weakref.ref(obj)
         # Create a weak reference to the cached method
-        meth_ref = weakref.ref(obj.cached_method)
+        meth_ref = weakref.WeakMethod(obj.cached_method)
         # Quick sanity check (real methods need weakref.WeakMethod, but we're a bit different)
         gc.collect()
         assert meth_ref() is not None
@@ -443,10 +443,8 @@ class TestMethodGarbageCollection:
         # Reference to method but not instance
         method = self.MyClass().cached_method
         gc.collect()
-        try:
-            method()
-        except ReferenceError:
-            pytest.xfail(reason="This test is expected to fail due to the way weakrefs are handled in Python.")
+        # Will raise a ReferenceError if the method is broken
+        method()
 
 
 class TestSignature:

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -178,6 +178,21 @@ class TestGuidanceMethodCache:
         grammar2 = obj.cached_method("Computer, tell me a joke.")
         assert grammar1 is grammar2
 
+    def test_miss_cache_when_args_change(self):
+        obj = self.MyClass("You are a helpful AI. Do what the user asks:", "Thank you.")
+        grammar1 = obj.cached_method("Computer, tell me a joke.")
+        grammar2 = obj.cached_method("Computer, tell me a riddle.")
+        assert grammar1 is not grammar2
+        lm = guidance.models.Mock()
+        assert (
+            str(lm + grammar1)
+            == "You are a helpful AI. Do what the user asks:\nComputer, tell me a joke.\nThank you."
+        )
+        assert (
+            str(lm + grammar2)
+            == "You are a helpful AI. Do what the user asks:\nComputer, tell me a riddle.\nThank you."
+        )
+
     def test_miss_cache_when_instance_hash_changes(self):
         obj = self.MyClass("You are a helpful AI. Do what the user asks:", "Thank you.")
         grammar1 = obj.cached_method("Computer, tell me a joke.")

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -386,11 +386,11 @@ class TestMethodGarbageCollection:
         def __hash__(self):
             return hash(self.thing)
 
-        @guidance(cache=True)
+        @guidance(stateless=True, cache=True)
         def cached_method(self, lm, *args):
             return lm + self.thing
 
-        @guidance(cache=False)
+        @guidance(stateless=True, cache=False)
         def uncached_method(self, lm, *args):
             return lm + self.thing
 
@@ -407,36 +407,6 @@ class TestMethodGarbageCollection:
         # Check if the object was garbage collected
         assert obj_ref() is None
 
-    def test_garbage_collection_cached_method_2(self):
-        # Not sure why I couldn't trigger the issue in the other tests...
-        class MyClass:
-            def __init__(self, prefix: str, suffix: str):
-                self.prefix = prefix
-                self.suffix = suffix
-                self.delimiter = "\n"
-
-            # def __hash__(self):
-            #     # Intentionally leave out self.delimiter so we can mess with it later
-            #     return hash((self.prefix, self.suffix))
-
-            @guidance(stateless=True, cache=True)
-            def cached_method(self, lm, middle: str):
-                return lm + self.delimiter.join([self.prefix, middle, self.suffix])
-        obj = MyClass("You are a helpful AI. Do what the user asks:", "Thank you.")
-
-        # Create a weak reference to the object
-        obj_ref = weakref.ref(obj)
-
-        # Call the cached method
-        grammar1 = obj.cached_method("Computer, tell me a joke.")
-        obj.suffix = "Thanks!"
-        grammar2 = obj.cached_method("Computer, tell me a joke.")
-        # Delete the hard ref to the obj
-        del obj
-        # Run garbage collection
-        gc.collect()
-        # Check if the object was garbage collected
-        assert obj_ref() is None
 
     def test_garbage_collection_uncached_method(self):
         obj = self.MyClass()

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -439,6 +439,16 @@ class TestMethodGarbageCollection:
         assert meth_ref() is None
 
 
+    def test_deleting_instance_does_not_break_method(self):
+        # Reference to method but not instance
+        method = self.MyClass().cached_method
+        gc.collect()
+        try:
+            method()
+        except ReferenceError:
+            pytest.xfail(reason="This test is expected to fail due to the way weakrefs are handled in Python.")
+
+
 class TestSignature:
     def test_function_signature(self):
         def func(a, b=1, *, c, d=2):

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -147,3 +147,46 @@ def test_exception_on_repeat_calls():
         # improper handling may not raise and may instead return
         # a Placeholder grammar node
         raises()
+
+
+class TestGuidanceMethod:
+    class MyClassWithoutHash:
+        def __init__(self, x):
+            self.x = x
+        
+        @guidance.guidance_method(stateless=True, cache=True, dedent=False)
+        def method(self, lm):
+            lm += str(self.x)
+            return lm
+
+    class MyClassWithHash:
+        def __init__(self, x):
+            self.x = x
+        
+        @guidance.guidance_method(stateless=True, cache=True, dedent=False)
+        def method(self, lm):
+            lm += str(self.x)
+            return lm
+        
+        def __hash__(self):
+            return hash(self.x)
+
+    def test_guidance_method_caches(self):
+        obj1 = self.MyClassWithoutHash(1)
+
+        lm = guidance.models.Mock()
+        result = lm + obj1.method()
+        assert str(result) == "1"
+        obj1.x = 2
+        result = lm + obj1.method()
+        assert str(result) == "1"
+
+    def test_guidance_method_caches_with_hash(self):
+        obj1 = self.MyClassWithHash(1)
+
+        lm = guidance.models.Mock()
+        result = lm + obj1.method()
+        assert str(result) == "1"
+        obj1.x = 2
+        result = lm + obj1.method()
+        assert str(result) == "2"

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -230,7 +230,7 @@ class TestGuidanceMethodCache:
             str(lm + grammar1)
             == "You are a helpful AI. Do what the user asks:\nComputer, tell me a joke.\nThank you."
         )
-        # Note that the delimiter is still the same as the first call since the hash didn't change
+        # Note that the delimiter actually changes because the instance changed and we're not calling the cached method
         assert (
             str(lm + grammar2)
             == "You are a helpful AI. Do what the user asks:\tComputer, tell me a joke.\tThank you."

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -428,7 +428,7 @@ class TestMethodGarbageCollection:
         obj_ref = weakref.ref(obj)
         # Create a weak reference to the cached method
         meth_ref = weakref.WeakMethod(obj.cached_method)
-        # Quick sanity check (real methods need weakref.WeakMethod, but we're a bit different)
+        # Quick sanity check that the weak reference is working
         gc.collect()
         assert meth_ref() is not None
         # Delete the hard ref to the obj

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -342,3 +342,19 @@ class TestGuidanceMethodDedent:
         lm = guidance.models.Mock()
         result = lm + grammar
         assert str(result) == '{\n"name": "harsha",\n  "age": "314",\n"weapon": "sword"\n}'
+
+class TestGuidanceRecursion:
+    class MyClass:
+        @guidance(stateless=True, dedent=False)
+        def recursive(self, lm):
+            return lm + guidance.select(["a", self.recursive()])
+
+    def test_method_recursion(self):
+        assert self.MyClass().recursive() is not None
+
+    def test_function_recursion(self):
+        @guidance(stateless=True, dedent=False)
+        def recursive(lm):
+            return lm + guidance.select(["a", recursive()])
+
+        assert recursive() is not None

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -380,13 +380,19 @@ class TestGuidanceRecursion:
 
 class TestMethodGarbageCollection:
     class MyClass:
+        def __init__(self, thing: str = "Hello"):
+            self.thing = thing
+
+        def __hash__(self):
+            return hash(self.thing)
+
         @guidance(cache=True)
-        def cached_method(self, lm):
-            return lm
+        def cached_method(self, lm, *args):
+            return lm + self.thing
 
         @guidance(cache=False)
-        def uncached_method(self, lm):
-            return lm
+        def uncached_method(self, lm, *args):
+            return lm + self.thing
 
     def test_garbage_collection_cached_method(self):
         obj = self.MyClass()
@@ -394,6 +400,37 @@ class TestMethodGarbageCollection:
         obj_ref = weakref.ref(obj)
         # Call the cached method
         _ = obj.cached_method()
+        # Delete the hard ref to the obj
+        del obj
+        # Run garbage collection
+        gc.collect()
+        # Check if the object was garbage collected
+        assert obj_ref() is None
+
+    def test_garbage_collection_cached_method_2(self):
+        # Not sure why I couldn't trigger the issue in the other tests...
+        class MyClass:
+            def __init__(self, prefix: str, suffix: str):
+                self.prefix = prefix
+                self.suffix = suffix
+                self.delimiter = "\n"
+
+            # def __hash__(self):
+            #     # Intentionally leave out self.delimiter so we can mess with it later
+            #     return hash((self.prefix, self.suffix))
+
+            @guidance(stateless=True, cache=True)
+            def cached_method(self, lm, middle: str):
+                return lm + self.delimiter.join([self.prefix, middle, self.suffix])
+        obj = MyClass("You are a helpful AI. Do what the user asks:", "Thank you.")
+
+        # Create a weak reference to the object
+        obj_ref = weakref.ref(obj)
+
+        # Call the cached method
+        grammar1 = obj.cached_method("Computer, tell me a joke.")
+        obj.suffix = "Thanks!"
+        grammar2 = obj.cached_method("Computer, tell me a joke.")
         # Delete the hard ref to the obj
         del obj
         # Run garbage collection


### PR DESCRIPTION
This PR extends the `@guidance` decorator to work with methods.

I believe this will be invaluable when defining grammars that are implemented as several guidance functions that call each other, particularly if they need to share common parameters. I think that [rewriting `json` as a class](https://github.com/hudson-ai/guidance/blob/json_class_seps/guidance/library/_json.py) will be a good test case for this, and I expect to be able to simplify the implementation with this new machinery as well as enable some otherwise-tricky shared parameters like `separators=(", ", ": ")`.

To achieve this:
- I introduce a `GuidanceFunction` type that is returned when the decorator is called on a function.
- `GuidanceFunction` uses `__get__` descriptor magic to ensure that the function is bound to an instance before being wrapped by the decorator's actual implementation (`_decorator`).
- Bound `GuidanceFunction`s are given a `GuidanceMethod` type

Side note/todo: `_guidance.pyi` is now not _strictly_ correct, but it still gives helpful type hints. It's most-wrong in the case where a user guidance-decorates a method but tries to call it from the class rather than an instance. This case **should** be broken anyway, but I need to think some more about how to give the user a good error message. IMO, that can wait for a follow-up PR.