### PR TITLE
[Bug] [Feature] Fix issue #1039 by exposing `And`, `Not` regex operators from `llguidance`

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -581,7 +581,7 @@ class And(Terminal):
         name: Union[str, None] = None,
     ):
         super().__init__(temperature=-1, capture_name=None)
-        self.values = values
+        self.values = list(values)
         self.name = name if name is not None else GrammarFunction._new_name()
 
 class Not(Terminal):
@@ -917,13 +917,13 @@ class LLSerializer:
     def _add_regex(self, key: str, val):
         return self._add_regex_json({key: val})
 
-    def _regex_or(self, nodes: list[GrammarFunction]):
+    def _regex_or(self, nodes: Sequence[GrammarFunction]):
         if len(nodes) == 1:
             return self.regex_id_cache[nodes[0]]
         else:
             return self._add_regex("Or", [self.regex_id_cache[v] for v in nodes])
 
-    def _regex_and(self, nodes: list[GrammarFunction]):
+    def _regex_and(self, nodes: Sequence[GrammarFunction]):
         if len(nodes) == 1:
             return self.regex_id_cache[nodes[0]]
         else:

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -906,6 +906,15 @@ class LLSerializer:
         else:
             return self._add_regex("Or", [self.regex_id_cache[v] for v in nodes])
 
+    def _regex_and(self, nodes: list[GrammarFunction]):
+        if len(nodes) == 1:
+            return self.regex_id_cache[nodes[0]]
+        else:
+            return self._add_regex("And", [self.regex_id_cache[v] for v in nodes])
+
+    def _regex_not(self, node: GrammarFunction):
+        return self._add_regex("Not", self.regex_id_cache[node])
+
     def regex(self, node: GrammarFunction):
         """
         Serialize node as regex. Throws if impossible.

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -495,6 +495,7 @@ def _gen_json_object(
     grammars = tuple(f'"{name}":' + _gen_json(json_schema=schema, definitions=definitions) for name, schema in items)
     required_items = tuple(name in required for name, _ in items)
     names = set(properties.keys()) | set(required)
+    key_grammar: GrammarFunction
     if len(names) > 0:
         # If there are any properties, we need to disallow them as additionalProperties
         key_grammar = as_regular_grammar(

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -26,9 +26,9 @@ from .._guidance import guidance
 from ..library import char_range, gen, one_or_more, optional, sequence
 from ..library._regex_utils import rx_int_range, rx_float_range
 
-from .._grammar import GrammarFunction, select, capture, with_temperature, Not, And, as_regular_grammar, quote_regex
+from .._grammar import GrammarFunction, select, capture, with_temperature, Not, And, quote_regex
 from ._pydantic import pydantic_to_json_schema
-from ._subgrammar import lexeme, subgrammar
+from ._subgrammar import as_regular_grammar, lexeme, subgrammar
 
 JSONSchema = Union[bool, Mapping[str, Any]]
 
@@ -501,7 +501,8 @@ def _gen_json_object(
             And([
                 lexeme(r'"([^"\\]|\\["\\/bfnrt]|\\u[0-9a-fA-F]{4})*"'),
                 Not(lexeme('"(' + '|'.join(quote_regex(name) for name in names) + ')"')),
-            ])
+            ]),
+            lexeme = True,
         )
     else:
         key_grammar = _gen_json_string()

--- a/guidance/library/_subgrammar.py
+++ b/guidance/library/_subgrammar.py
@@ -1,3 +1,4 @@
+from guidance._grammar import LLSerializer, RegularGrammar, string
 from .._grammar import Subgrammar, Lexeme, GrammarFunction, capture
 from typing import Optional
 
@@ -40,3 +41,12 @@ def subgrammar(
     if name:
         r = capture(r, name)
     return r
+
+
+def as_regular_grammar(value, lexeme=False) -> RegularGrammar:
+    # TODO: assert that value is not empty since we don't yet support that
+    if isinstance(value, str):
+        value = string(value)
+    # check if it serializes
+    _ignore = LLSerializer().regex(value)
+    return RegularGrammar(value, lexeme=lexeme)

--- a/guidance/library/_substring.py
+++ b/guidance/library/_substring.py
@@ -1,9 +1,11 @@
 from typing import Optional, Dict, Union
 
+from ._subgrammar import as_regular_grammar
+
 from .._guidance import guidance
 
 # from ._prefix_tree import prefix_tree
-from .._grammar import string, select, capture, as_regular_grammar, Terminal, GrammarFunction
+from .._grammar import string, select, capture, Terminal, GrammarFunction
 from ._optional import optional
 
 

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1882,6 +1882,16 @@ class TestAdditionalProperties:
             compact=compact,
         )
 
+    def test_out_of_order_non_required_properties_not_validated_as_additionalProperties(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"const": "foo"}, "b": {"const": "bar"}},
+            "required": ["b"],
+        }
+        test_string = '{"b": "bar", "a": "BAD"}'
+        grammar = gen_json(schema=schema)
+        assert grammar.match(test_string) is None
+
 
 class TestRecursiveStructures:
     @pytest.mark.parametrize(

--- a/tests/unit/test_ll.py
+++ b/tests/unit/test_ll.py
@@ -15,7 +15,7 @@ from guidance import (
     string,
     capture,
 )
-from guidance._grammar import as_regular_grammar
+from guidance.library._subgrammar import as_regular_grammar
 from guidance.library._subgrammar import subgrammar, lexeme
 
 log_level = 10


### PR DESCRIPTION
Fixes issue #1039 by ensuring that the keys for JSON properties validated against `additionalProperties` aren't allowed to match any of the keys for the properties themselves.

I'm still a bit unsure about the API of `And` and `Not`, as well as what the right type hierarchy is (e.g. should they be subclasses of `RegularGrammar`?), but I am comfortable with punting on those questions a bit as they are very much not part of the "public" API yet.