### PR TITLE
[Feature] Expand JSON `$ref` resolution

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -451,6 +451,8 @@ class GenJson:
         This will allow us to get a unique key for each reference and hit the _defs cache correctly.
         """
         if ref.startswith("#"):
+            # Special case for fragment-only references:
+            # for certain schemes (e.g. urn), urljoin may throw the base URI, but we need to keep them around
             uri, fragment = self._base_uri, ref[1:]
         else:
             uri, fragment = urldefrag(urljoin(self._base_uri, ref))

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -16,7 +16,7 @@ from typing import (
 import warnings
 import referencing
 import contextlib
-from urllib.parse import urljoin, urldefrag
+from urllib.parse import urljoin
 
 try:
     import jsonschema
@@ -453,12 +453,8 @@ class GenJson:
         if ref.startswith("#"):
             # Special case for fragment-only references:
             # for certain schemes (e.g. urn), urljoin may throw the base URI, but we need to keep them around
-            uri, fragment = self._base_uri, ref[1:]
-        else:
-            uri, fragment = urldefrag(urljoin(self._base_uri, ref))
-        if fragment:
-            return f"{uri}#{fragment}"
-        return uri
+            return f"{self._base_uri}{ref}"
+        return urljoin(self._base_uri, ref)
 
     @contextlib.contextmanager
     def _base_uri_context(self, base_uri: str):

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -416,6 +416,7 @@ class GenJson:
         self._resolver = registry.resolver()
         self._defs: dict[str, Callable[[], GrammarFunction]] = {}
 
+
     @guidance(stateless=True)
     def ref(
         self,
@@ -456,6 +457,7 @@ class GenJson:
             return f"{self._base_uri}{ref}"
         return urljoin(self._base_uri, ref)
 
+
     @contextlib.contextmanager
     def _base_uri_context(self, base_uri: str):
         """
@@ -476,6 +478,7 @@ class GenJson:
     @guidance(stateless=True)
     def root(self, lm):
         return lm + self.json(json_schema=self.schema)
+
 
     @classmethod
     @guidance(stateless=True)

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -423,23 +423,11 @@ class GenJson:
     ):
         if reference not in self._defs:
             schema = self._resolver.lookup(reference).contents
-            grammar_callable = self._def(schema)
-            self._defs[reference] = grammar_callable
-        return lm + self._defs[reference]()
-
-    def _def(
-        self,
-        schema: JSONSchema,
-    ) -> Callable[[], GrammarFunction]:
-
-        def build_definition(json_schema: JSONSchema) -> Callable[[], GrammarFunction]:
             @guidance(stateless=True, dedent=False, cache=True)
             def closure(lm):
-                return lm + self.json(json_schema=json_schema)
-
-            return closure
-
-        return build_definition(schema)
+                return lm + self.json(json_schema=schema)
+            self._defs[reference] = closure
+        return lm + self._defs[reference]()
 
     @guidance(stateless=True)
     def root(self, lm):

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -413,7 +413,7 @@ class GenJson:
             uri=self._base_uri,
             resource=resource
         )
-        self._resolver = registry.resolver_with_root(resource)
+        self._resolver = registry.resolver()
         self._defs: dict[str, Callable[[], GrammarFunction]] = {}
 
     @guidance(stateless=True)
@@ -430,16 +430,20 @@ class GenJson:
         add it to the _defs cache. This allows us to avoid re-resolving the reference every time
         and to handle recursive references correctly.
         """
-        key = self._get_abspath(reference)
-        if key not in self._defs:
-            resolved = self._resolver.lookup(reference)
+        abspath = self._get_abspath(reference)
+        if abspath not in self._defs:
+            resolved = self._resolver.lookup(abspath)
+            base_uri_of_resolved = resolved.resolver._base_uri
+
             @guidance(stateless=True, dedent=False, cache=True)
             def closure(lm):
-                with self._resolver_context(resolved.resolver):
+                with self._base_uri_context(base_uri_of_resolved):
                     grammar = self.json(json_schema=resolved.contents)
                 return lm + grammar
-            self._defs[key] = closure
-        return lm + self._defs[key]()
+
+            self._defs[abspath] = closure
+        return lm + self._defs[abspath]()
+
 
     def _get_abspath(self, ref):
         """
@@ -455,21 +459,20 @@ class GenJson:
         return uri
 
     @contextlib.contextmanager
-    def _resolver_context(self, resolver):
+    def _base_uri_context(self, base_uri: str):
         """
-        Temporarily replace the resolver for the duration of the context manager.
+        Temporarily replace the base_uri for the duration of the context manager.
         This allows refs with different base URIs to be resolved correctly without passing the resolver around.
 
         Note: very much not thread-safe, but I don't expect instances of this class to be shared between threads.
-        TODO: ensure that the instance's hash depends on the resolver (or more likely the resolver's base URI)
-            before adding more caching to this class.
+        TODO: ensure that the instance's hash depends on the base_uri before adding more caching to this class.
         """
-        old_resolver = self._resolver
-        self._resolver = resolver
+        old_base_uri = self._base_uri
+        self._base_uri = base_uri
         try:
             yield
         finally:
-            self._resolver = old_resolver
+            self._base_uri = old_base_uri
 
 
     @guidance(stateless=True)

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -16,6 +16,7 @@ from typing import (
 import warnings
 import referencing
 import contextlib
+from urllib.parse import urljoin, urldefrag
 
 try:
     import jsonschema
@@ -445,7 +446,6 @@ class GenJson:
         Convert a reference to an absolute path, resolving it against the base URI if necessary.
         This will allow us to get a unique key for each reference and hit the _defs cache correctly.
         """
-        from urllib.parse import urljoin, urldefrag
         if ref.startswith("#"):
             uri, fragment = self._base_uri, ref[1:]
         else:

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     "ordered_set",
     "platformdirs",
     "pydantic",
+    "referencing",
     "requests",
     "tiktoken>=0.3",
     "llguidance>=0.1.7",

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1559,7 +1559,10 @@ class TestRefs:
             # invalid on outer field
             ({"foo": {"bar": "a"}, "bar": 1}, False),
             # valid on both fields
-            ({"foo": {"bar": "a"}, "bar": "a"}, True),
+            pytest.param(
+                *({"foo": {"bar": "a"}, "bar": "a"}, True),
+                marks=pytest.mark.xfail(reason="refs with sibling keywords are not yet supported; foo here is being seen as an additionalProperty before bar"),
+            ),
         ],
     )
     def test_refs_with_relative_uris_and_defs(self, test_object, valid):
@@ -1591,7 +1594,10 @@ class TestRefs:
             # invalid on outer field
             ({"foo": {"bar": "a"}, "bar": 1}, False),
             # valid on both fields
-            ({"foo": {"bar": "a"}, "bar": "a"}, True),
+            pytest.param(
+                *({"foo": {"bar": "a"}, "bar": "a"}, True),
+                marks=pytest.mark.xfail(reason="refs with sibling keywords are not yet supported; foo here is being seen as an additionalProperty before bar"),
+            ),
         ],
     )
     def test_relative_refs_with_absolute_uris_and_defs(self, test_object, valid):

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1250,7 +1250,10 @@ class TestRefs:
             # ref valid, maxItems valid
             ({'foo': []}, True),
             # ref valid, maxItems invalid
-            ({'foo': [1, 2, 3]}, False),
+            pytest.param(
+                *({'foo': [1, 2, 3]}, False),
+                marks=pytest.mark.xfail(reason="sibling keywords to ref are not yet supported")
+            ),
             # ref invalid
             ({'foo': 'string'}, False)
         ]
@@ -1277,6 +1280,7 @@ class TestRefs:
             ({'minLength': -1}, False)
         ]
     )
+    @pytest.mark.xfail(reason="Remote refs are not supported")
     def test_remote_ref_containing_refs_itself(self, test_object, valid):
         schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'https://json-schema.org/draft/2020-12/schema'}
         if valid:
@@ -1361,6 +1365,7 @@ class TestRefs:
             ('foo', False)
         ]
     )
+    @pytest.mark.xfail(reason="false schema is not implemented")
     def test_ref_to_boolean_schema_false(self, test_object, valid):
         schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': '#/$defs/bool', '$defs': {'bool': False}}
         if valid:
@@ -1425,6 +1430,7 @@ class TestRefs:
             ({'prop1': 'match'}, False)
         ]
     )
+    @pytest.mark.xfail(reason="unevaluatedProperties is not implemented")
     def test_ref_creates_new_scope_when_adjacent_to_keywords(self, test_object, valid):
         schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'A': {'unevaluatedProperties': False}}, 'properties': {'prop1': {'type': 'string'}}, '$ref': '#/$defs/A'}
         if valid:
@@ -1761,6 +1767,7 @@ class TestRefs:
             (12, True)
         ]
     )
+    @pytest.mark.xfail(reason="if not implemented")
     def test_ref_to_if(self, test_object, valid):
         schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/if', 'if': {'$id': 'http://example.com/ref/if', 'type': 'integer'}}
         if valid:
@@ -1783,6 +1790,7 @@ class TestRefs:
             (12, True)
         ]
     )
+    @pytest.mark.xfail(reason="then not implemented")
     def test_ref_to_then(self, test_object, valid):
         schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/then', 'then': {'$id': 'http://example.com/ref/then', 'type': 'integer'}}
         if valid:
@@ -1805,6 +1813,7 @@ class TestRefs:
             (12, True)
         ]
     )
+    @pytest.mark.xfail(reason="else not implemented")
     def test_ref_to_else(self, test_object, valid):
         schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/else', 'else': {'$id': 'http://example.com/ref/else', 'type': 'integer'}}
         if valid:

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1121,194 +1121,790 @@ class TestArrayWithLengthConstraints:
         )
 
 
-class TestWithReferences:
+class TestRefs:
     @pytest.mark.parametrize(
-        "target_obj",
+        ["test_object", "valid"],
         [
-            dict(all_cats=[]),
-            dict(all_cats=[dict(name="Kasha")]),
-            dict(all_cats=[dict(name="Dawon"), dict(name="Barong")]),
-        ],
+            # match
+            ({'foo': False}, True),
+            # recursive match
+            ({'foo': {'foo': False}}, True),
+            # mismatch
+            ({'bar': False}, False),
+            # recursive mismatch
+            ({'foo': {'bar': False}}, False)
+        ]
     )
-    def test_simple_ref(self, target_obj):
-        schema = """{
-        "$defs": {
-            "Cat": {
-            "properties": {
-                "name": {
-                "title": "Name",
-                "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "title": "Cat",
-            "type": "object"
-            }
-        },
-        "properties": {
-            "all_cats": {
-            "items": {
-                "$ref": "#/$defs/Cat"
-            },
-            "title": "All Cats",
-            "type": "array"
-            }
-        },
-        "required": [
-            "all_cats"
-        ],
-        "title": "CatList",
-        "type": "object"
-        }"""
-
-        # First sanity check what we're setting up
-        schema_obj = json.loads(schema)
-        validate(instance=target_obj, schema=schema_obj)
-
-        # The actual check
-        generate_and_check(target_obj, schema_obj)
+    def test_root_pointer_ref(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'foo': {'$ref': '#'}}, 'additionalProperties': False}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
     @pytest.mark.parametrize(
-        "target_obj",
+        ["test_object", "valid"],
         [
-            dict(all_cats=[]),
-            dict(all_cats=[dict(name="Kasha")]),
-            dict(all_cats=[dict(name="Dawon"), dict(name="Barong")]),
-        ],
+            # match
+            ({'bar': 3}, True),
+            # mismatch
+            ({'bar': True}, False)
+        ]
     )
-    def test_simple_ref_alt(self, target_obj):
-        # Uses 'definitions' rather than '$defs'
-        schema = """{
-        "definitions": {
-            "Cat": {
-            "properties": {
-                "name": {
-                "title": "Name",
-                "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "title": "Cat",
-            "type": "object"
-            }
-        },
-        "properties": {
-            "all_cats": {
-            "items": {
-                "$ref": "#/definitions/Cat"
-            },
-            "title": "All Cats",
-            "type": "array"
-            }
-        },
-        "required": [
-            "all_cats"
-        ],
-        "title": "CatList",
-        "type": "object"
-        }"""
+    def test_relative_pointer_ref_to_object(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'foo': {'type': 'integer'}, 'bar': {'$ref': '#/properties/foo'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        # First sanity check what we're setting up
-        schema_obj = json.loads(schema)
-        validate(instance=target_obj, schema=schema_obj)
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # match array
+            ([1, 2], True),
+            # mismatch array
+            ([1, 'foo'], False)
+        ]
+    )
+    def test_relative_pointer_ref_to_array(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'prefixItems': [{'type': 'integer'}, {'$ref': '#/prefixItems/0'}]}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        # The actual check
-        generate_and_check(target_obj, schema_obj)
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # slash invalid
+            ({'slash': 'aoeu'}, False),
+            # tilde invalid
+            ({'tilde': 'aoeu'}, False),
+            # percent invalid
+            ({'percent': 'aoeu'}, False),
+            # slash valid
+            ({'slash': 123}, True),
+            # tilde valid
+            ({'tilde': 123}, True),
+            # percent valid
+            ({'percent': 123}, True)
+        ]
+    )
+    def test_escaped_pointer_ref(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'tilde~field': {'type': 'integer'}, 'slash/field': {'type': 'integer'}, 'percent%field': {'type': 'integer'}}, 'properties': {'tilde': {'$ref': '#/$defs/tilde~0field'}, 'slash': {'$ref': '#/$defs/slash~1field'}, 'percent': {'$ref': '#/$defs/percent%25field'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-    @pytest.mark.parametrize("temperature", [None, 0.1, 1])
-    def test_nested_ref(self, temperature):
-        schema = """{
-        "$defs": {
-            "A": {
-            "properties": {
-                "name": {
-                "title": "Name",
-                "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "title": "A",
-            "type": "object"
-            },
-            "B": {
-            "properties": {
-                "other_str": {
-                "title": "Other Str",
-                "type": "string"
-                },
-                "my_A": {
-                "$ref": "#/$defs/A"
-                }
-            },
-            "required": [
-                "other_str",
-                "my_A"
-            ],
-            "title": "B",
-            "type": "object"
-            }
-        },
-        "properties": {
-            "my_B": {
-            "$ref": "#/$defs/B"
-            }
-        },
-        "required": [
-            "my_B"
-        ],
-        "title": "C",
-        "type": "object"
-        }"""
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # nested ref valid
+            (5, True),
+            # nested ref invalid
+            ('a', False)
+        ]
+    )
+    def test_nested_refs(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'a': {'type': 'integer'}, 'b': {'$ref': '#/$defs/a'}, 'c': {'$ref': '#/$defs/b'}}, '$ref': '#/$defs/c'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        target_obj = dict(my_B=dict(other_str="some string", my_A=dict(name="my name")))
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # ref valid, maxItems valid
+            ({'foo': []}, True),
+            # ref valid, maxItems invalid
+            ({'foo': [1, 2, 3]}, False),
+            # ref invalid
+            ({'foo': 'string'}, False)
+        ]
+    )
+    def test_ref_applies_alongside_sibling_keywords(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'reffed': {'type': 'array'}}, 'properties': {'foo': {'$ref': '#/$defs/reffed', 'maxItems': 2}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        # First sanity check what we're setting up
-        schema_obj = json.loads(schema)
-        validate(instance=target_obj, schema=schema_obj)
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # remote ref valid
+            ({'minLength': 1}, True),
+            # remote ref invalid
+            ({'minLength': -1}, False)
+        ]
+    )
+    def test_remote_ref_containing_refs_itself(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'https://json-schema.org/draft/2020-12/schema'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        # The actual check
-        generate_and_check(target_obj, schema_obj, desired_temperature=temperature)
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # property named $ref valid
+            ({'$ref': 'a'}, True),
+            # property named $ref invalid
+            ({'$ref': 2}, False)
+        ]
+    )
+    def test_property_named_ref_that_is_not_a_reference(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'$ref': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-    @pytest.mark.parametrize("temperature", [None, 0.1, 1])
-    def test_multiple_refs_to_same_def(self, temperature):
-        schema = """{
-        "$defs": {
-            "A": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name"],
-                "type": "object"
-            }
-        },
-        "properties": {
-            "A1": {
-                "$ref": "#/$defs/A"
-            },
-            "A2": {
-                "$ref": "#/$defs/A"
-            }
-        },
-        "required": ["A1", "A2"],
-        "type": "object"
-        }"""
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # property named $ref valid
+            ({'$ref': 'a'}, True),
+            # property named $ref invalid
+            ({'$ref': 2}, False)
+        ]
+    )
+    def test_property_named_ref_containing_an_actual_ref(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'$ref': {'$ref': '#/$defs/is-string'}}, '$defs': {'is-string': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        target_obj = dict(A1=dict(name="Romulus"), A2=dict(name="Remus"))
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # any value is valid
+            ('foo', True)
+        ]
+    )
+    def test_ref_to_boolean_schema_true(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': '#/$defs/bool', '$defs': {'bool': True}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        # First sanity check what we're setting up
-        schema_obj = json.loads(schema)
-        validate(instance=target_obj, schema=schema_obj)
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # any value is invalid
+            ('foo', False)
+        ]
+    )
+    def test_ref_to_boolean_schema_false(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': '#/$defs/bool', '$defs': {'bool': False}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
-        # The actual check
-        generate_and_check(target_obj, schema_obj, desired_temperature=temperature)
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # valid tree
+            ({'meta': 'root', 'nodes': [{'value': 1, 'subtree': {'meta': 'child', 'nodes': [{'value': 1.1}, {'value': 1.2}]}}, {'value': 2, 'subtree': {'meta': 'child', 'nodes': [{'value': 2.1}, {'value': 2.2}]}}]}, True),
+            # invalid tree
+            ({'meta': 'root', 'nodes': [{'value': 1, 'subtree': {'meta': 'child', 'nodes': [{'value': 'string is invalid'}, {'value': 1.2}]}}, {'value': 2, 'subtree': {'meta': 'child', 'nodes': [{'value': 2.1}, {'value': 2.2}]}}]}, False)
+        ]
+    )
+    def test_Recursive_references_between_schemas(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://localhost:1234/draft2020-12/tree', 'description': 'tree of nodes', 'type': 'object', 'properties': {'meta': {'type': 'string'}, 'nodes': {'type': 'array', 'items': {'$ref': 'node'}}}, 'required': ['meta', 'nodes'], '$defs': {'node': {'$id': 'http://localhost:1234/draft2020-12/node', 'description': 'node', 'type': 'object', 'properties': {'value': {'type': 'number'}, 'subtree': {'$ref': 'tree'}}, 'required': ['value']}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # object with numbers is valid
+            ({'foo"bar': 1}, True),
+            # object with strings is invalid
+            ({'foo"bar': '1'}, False)
+        ]
+    )
+    def test_refs_with_quote(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'foo"bar': {'$ref': '#/$defs/foo%22bar'}}, '$defs': {'foo"bar': {'type': 'number'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # referenced subschema doesn't see annotations from properties
+            ({'prop1': 'match'}, False)
+        ]
+    )
+    def test_ref_creates_new_scope_when_adjacent_to_keywords(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'A': {'unevaluatedProperties': False}}, 'properties': {'prop1': {'type': 'string'}}, '$ref': '#/$defs/A'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # do not evaluate the $ref inside the enum, matching any string
+            ('this is a string', False),
+            # do not evaluate the $ref inside the enum, definition exact match
+            ({'type': 'string'}, False),
+            # match the enum exactly
+            ({'$ref': '#/$defs/a_string'}, True)
+        ]
+    )
+    def test_naive_replacement_of_ref_with_its_destination_is_not_correct(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'a_string': {'type': 'string'}}, 'enum': [{'$ref': '#/$defs/a_string'}]}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # invalid on inner field
+            ({'foo': {'bar': 1}, 'bar': 'a'}, False),
+            # invalid on outer field
+            ({'foo': {'bar': 'a'}, 'bar': 1}, False),
+            # valid on both fields
+            ({'foo': {'bar': 'a'}, 'bar': 'a'}, True)
+        ]
+    )
+    def test_refs_with_relative_uris_and_defs(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/schema-relative-uri-defs1.json', 'properties': {'foo': {'$id': 'schema-relative-uri-defs2.json', '$defs': {'inner': {'properties': {'bar': {'type': 'string'}}}}, '$ref': '#/$defs/inner'}}, '$ref': 'schema-relative-uri-defs2.json'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # invalid on inner field
+            ({'foo': {'bar': 1}, 'bar': 'a'}, False),
+            # invalid on outer field
+            ({'foo': {'bar': 'a'}, 'bar': 1}, False),
+            # valid on both fields
+            ({'foo': {'bar': 'a'}, 'bar': 'a'}, True)
+        ]
+    )
+    def test_relative_refs_with_absolute_uris_and_defs(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/schema-refs-absolute-uris-defs1.json', 'properties': {'foo': {'$id': 'http://example.com/schema-refs-absolute-uris-defs2.json', '$defs': {'inner': {'properties': {'bar': {'type': 'string'}}}}, '$ref': '#/$defs/inner'}}, '$ref': 'schema-refs-absolute-uris-defs2.json'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # number is valid
+            (1, True),
+            # non-number is invalid
+            ('a', False)
+        ]
+    )
+    def test_id_must_be_resolved_against_nearest_parent_not_just_immediate_parent(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/a.json', '$defs': {'x': {'$id': 'http://example.com/b/c.json', 'not': {'$defs': {'y': {'$id': 'd.json', 'type': 'number'}}}}}, 'allOf': [{'$ref': 'http://example.com/b/d.json'}]}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # data is valid against first definition
+            (5, True),
+            # data is invalid against first definition
+            (50, False)
+        ]
+    )
+    def test_order_of_evaluation_id_and_ref(self, test_object, valid):
+        schema = {'$comment': '$id must be evaluated before $ref to get the proper $ref destination', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'https://example.com/draft2020-12/ref-and-id1/base.json', '$ref': 'int.json', '$defs': {'bigint': {'$comment': 'canonical uri: https://example.com/ref-and-id1/int.json', '$id': 'int.json', 'maximum': 10}, 'smallint': {'$comment': 'canonical uri: https://example.com/ref-and-id1-int.json', '$id': '/draft2020-12/ref-and-id1-int.json', 'maximum': 2}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # data is valid against first definition
+            (5, True),
+            # data is invalid against first definition
+            (50, False)
+        ]
+    )
+    def test_order_of_evaluation_id_and_anchor_and_ref(self, test_object, valid):
+        schema = {'$comment': '$id must be evaluated before $ref to get the proper $ref destination', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'https://example.com/draft2020-12/ref-and-id2/base.json', '$ref': '#bigint', '$defs': {'bigint': {'$comment': 'canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint', '$anchor': 'bigint', 'maximum': 10}, 'smallint': {'$comment': 'canonical uri: https://example.com/ref-and-id2#/$defs/smallint; another valid uri for this location: https://example.com/ref-and-id2/#bigint', '$id': 'https://example.com/draft2020-12/ref-and-id2/', '$anchor': 'bigint', 'maximum': 2}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # valid under the URN IDed schema
+            ({'foo': 37}, True),
+            # invalid under the URN IDed schema
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_simple_URN_base_URI_with_ref_via_the_URN(self, test_object, valid):
+        schema = {'$comment': 'URIs do not have to have HTTP(s) schemes', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed', 'minimum': 30, 'properties': {'foo': {'$ref': 'urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ({'foo': 'bar'}, True),
+            # a non-string is invalid
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_simple_URN_base_URI_with_JSON_pointer(self, test_object, valid):
+        schema = {'$comment': 'URIs do not have to have HTTP(s) schemes', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ({'foo': 'bar'}, True),
+            # a non-string is invalid
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_URN_base_URI_with_NSS(self, test_object, valid):
+        schema = {'$comment': 'RFC 8141 §2.2', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:example:1/406/47452/2', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ({'foo': 'bar'}, True),
+            # a non-string is invalid
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_URN_base_URI_with_r_component(self, test_object, valid):
+        schema = {'$comment': 'RFC 8141 §2.3.1', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:example:foo-bar-baz-qux?+CCResolve:cc=uk', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ({'foo': 'bar'}, True),
+            # a non-string is invalid
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_URN_base_URI_with_q_component(self, test_object, valid):
+        schema = {'$comment': 'RFC 8141 §2.3.2', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ({'foo': 'bar'}, True),
+            # a non-string is invalid
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_URN_base_URI_with_URN_and_JSON_pointer_ref(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-0000-0000-4321feebdaed', 'properties': {'foo': {'$ref': 'urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ({'foo': 'bar'}, True),
+            # a non-string is invalid
+            ({'foo': 12}, False)
+        ]
+    )
+    def test_URN_base_URI_with_URN_and_anchor_ref(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed', 'properties': {'foo': {'$ref': 'urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something'}}, '$defs': {'bar': {'$anchor': 'something', 'type': 'string'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ('bar', True),
+            # a non-string is invalid
+            (12, False)
+        ]
+    )
+    def test_URN_ref_with_nested_pointer_ref(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed', '$defs': {'foo': {'$id': 'urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed', '$defs': {'bar': {'type': 'string'}}, '$ref': '#/$defs/bar'}}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a non-integer is invalid due to the $ref
+            ('foo', False),
+            # an integer is valid
+            (12, True)
+        ]
+    )
+    def test_ref_to_if(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/if', 'if': {'$id': 'http://example.com/ref/if', 'type': 'integer'}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a non-integer is invalid due to the $ref
+            ('foo', False),
+            # an integer is valid
+            (12, True)
+        ]
+    )
+    def test_ref_to_then(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/then', 'then': {'$id': 'http://example.com/ref/then', 'type': 'integer'}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a non-integer is invalid due to the $ref
+            ('foo', False),
+            # an integer is valid
+            (12, True)
+        ]
+    )
+    def test_ref_to_else(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/else', 'else': {'$id': 'http://example.com/ref/else', 'type': 'integer'}}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # a string is valid
+            ('foo', True),
+            # an integer is invalid
+            (12, False)
+        ]
+    )
+    def test_ref_with_absolute_path_reference(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/ref/absref.json', '$defs': {'a': {'$id': 'http://example.com/ref/absref/foobar.json', 'type': 'number'}, 'b': {'$id': 'http://example.com/absref/foobar.json', 'type': 'string'}}, '$ref': '/absref/foobar.json'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # number is valid
+            (1, True),
+            # non-number is invalid
+            ('a', False)
+        ]
+    )
+    def test_id_with_file_URI_still_resolves_pointers___nix(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'file:///folder/file.json', '$defs': {'foo': {'type': 'number'}}, '$ref': '#/$defs/foo'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # number is valid
+            (1, True),
+            # non-number is invalid
+            ('a', False)
+        ]
+    )
+    def test_id_with_file_URI_still_resolves_pointers___windows(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'file:///c:/folder/file.json', '$defs': {'foo': {'type': 'number'}}, '$ref': '#/$defs/foo'}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
+
+    @pytest.mark.parametrize(
+        ["test_object", "valid"],
+        [
+            # number is valid
+            (1, True),
+            # non-number is invalid
+            ('a', False)
+        ]
+    )
+    def test_empty_tokens_in_ref_json_pointer(self, test_object, valid):
+        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'': {'$defs': {'': {'type': 'number'}}}}, 'allOf': [{'$ref': '#/$defs//$defs/'}]}
+        if valid:
+            validate(instance=test_object, schema=schema)
+            generate_and_check(test_object, schema)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=test_object, schema=schema)
+            check_match_failure(
+                bad_string=json_dumps(test_object),
+                schema_obj=schema
+            )
 
 
 class TestAnyOf:

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1126,49 +1126,50 @@ class TestRefs:
         ["test_object", "valid"],
         [
             # match
-            ({'foo': False}, True),
+            ({"foo": False}, True),
             # recursive match
-            ({'foo': {'foo': False}}, True),
+            ({"foo": {"foo": False}}, True),
             # mismatch
-            ({'bar': False}, False),
+            ({"bar": False}, False),
             # recursive mismatch
-            ({'foo': {'bar': False}}, False)
-        ]
+            ({"foo": {"bar": False}}, False),
+        ],
     )
     def test_root_pointer_ref(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'foo': {'$ref': '#'}}, 'additionalProperties': False}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {"$ref": "#"}},
+            "additionalProperties": False,
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # match
-            ({'bar': 3}, True),
+            ({"bar": 3}, True),
             # mismatch
-            ({'bar': True}, False)
-        ]
+            ({"bar": True}, False),
+        ],
     )
     def test_relative_pointer_ref_to_object(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'foo': {'type': 'integer'}, 'bar': {'$ref': '#/properties/foo'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {"type": "integer"}, "bar": {"$ref": "#/properties/foo"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1176,51 +1177,60 @@ class TestRefs:
             # match array
             ([1, 2], True),
             # mismatch array
-            ([1, 'foo'], False)
-        ]
+            ([1, "foo"], False),
+        ],
     )
     def test_relative_pointer_ref_to_array(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'prefixItems': [{'type': 'integer'}, {'$ref': '#/prefixItems/0'}]}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "integer"}, {"$ref": "#/prefixItems/0"}],
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # slash invalid
-            ({'slash': 'aoeu'}, False),
+            ({"slash": "aoeu"}, False),
             # tilde invalid
-            ({'tilde': 'aoeu'}, False),
+            ({"tilde": "aoeu"}, False),
             # percent invalid
-            ({'percent': 'aoeu'}, False),
+            ({"percent": "aoeu"}, False),
             # slash valid
-            ({'slash': 123}, True),
+            ({"slash": 123}, True),
             # tilde valid
-            ({'tilde': 123}, True),
+            ({"tilde": 123}, True),
             # percent valid
-            ({'percent': 123}, True)
-        ]
+            ({"percent": 123}, True),
+        ],
     )
     def test_escaped_pointer_ref(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'tilde~field': {'type': 'integer'}, 'slash/field': {'type': 'integer'}, 'percent%field': {'type': 'integer'}}, 'properties': {'tilde': {'$ref': '#/$defs/tilde~0field'}, 'slash': {'$ref': '#/$defs/slash~1field'}, 'percent': {'$ref': '#/$defs/percent%25field'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"},
+            },
+            "properties": {
+                "tilde": {"$ref": "#/$defs/tilde~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"},
+            },
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1228,178 +1238,245 @@ class TestRefs:
             # nested ref valid
             (5, True),
             # nested ref invalid
-            ('a', False)
-        ]
+            ("a", False),
+        ],
     )
     def test_nested_refs(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'a': {'type': 'integer'}, 'b': {'$ref': '#/$defs/a'}, 'c': {'$ref': '#/$defs/b'}}, '$ref': '#/$defs/c'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"},
+            },
+            "$ref": "#/$defs/c",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # ref valid, maxItems valid
-            ({'foo': []}, True),
+            ({"foo": []}, True),
             # ref valid, maxItems invalid
             pytest.param(
-                *({'foo': [1, 2, 3]}, False),
-                marks=pytest.mark.xfail(reason="sibling keywords to ref are not yet supported")
+                *({"foo": [1, 2, 3]}, False),
+                marks=pytest.mark.xfail(reason="sibling keywords to ref are not yet supported"),
             ),
             # ref invalid
-            ({'foo': 'string'}, False)
-        ]
+            ({"foo": "string"}, False),
+        ],
     )
     def test_ref_applies_alongside_sibling_keywords(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'reffed': {'type': 'array'}}, 'properties': {'foo': {'$ref': '#/$defs/reffed', 'maxItems': 2}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {"reffed": {"type": "array"}},
+            "properties": {"foo": {"$ref": "#/$defs/reffed", "maxItems": 2}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # remote ref valid
-            ({'minLength': 1}, True),
+            ({"minLength": 1}, True),
             # remote ref invalid
-            ({'minLength': -1}, False)
-        ]
+            ({"minLength": -1}, False),
+        ],
     )
     @pytest.mark.xfail(reason="Remote refs are not supported")
     def test_remote_ref_containing_refs_itself(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'https://json-schema.org/draft/2020-12/schema'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # property named $ref valid
-            ({'$ref': 'a'}, True),
+            ({"$ref": "a"}, True),
             # property named $ref invalid
-            ({'$ref': 2}, False)
-        ]
+            ({"$ref": 2}, False),
+        ],
     )
     def test_property_named_ref_that_is_not_a_reference(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'$ref': {'type': 'string'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"$ref": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # property named $ref valid
-            ({'$ref': 'a'}, True),
+            ({"$ref": "a"}, True),
             # property named $ref invalid
-            ({'$ref': 2}, False)
-        ]
+            ({"$ref": 2}, False),
+        ],
     )
     def test_property_named_ref_containing_an_actual_ref(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'$ref': {'$ref': '#/$defs/is-string'}}, '$defs': {'is-string': {'type': 'string'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"$ref": {"$ref": "#/$defs/is-string"}},
+            "$defs": {"is-string": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # any value is valid
-            ('foo', True)
-        ]
+            ("foo", True)
+        ],
     )
     def test_ref_to_boolean_schema_true(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': '#/$defs/bool', '$defs': {'bool': True}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {"bool": True},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # any value is invalid
-            ('foo', False)
-        ]
+            ("foo", False)
+        ],
     )
     @pytest.mark.xfail(reason="false schema is not implemented")
     def test_ref_to_boolean_schema_false(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': '#/$defs/bool', '$defs': {'bool': False}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {"bool": False},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # valid tree
-            ({'meta': 'root', 'nodes': [{'value': 1, 'subtree': {'meta': 'child', 'nodes': [{'value': 1.1}, {'value': 1.2}]}}, {'value': 2, 'subtree': {'meta': 'child', 'nodes': [{'value': 2.1}, {'value': 2.2}]}}]}, True),
+            (
+                {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [{"value": 1.1}, {"value": 1.2}],
+                            },
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [{"value": 2.1}, {"value": 2.2}],
+                            },
+                        },
+                    ],
+                },
+                True,
+            ),
             # invalid tree
-            ({'meta': 'root', 'nodes': [{'value': 1, 'subtree': {'meta': 'child', 'nodes': [{'value': 'string is invalid'}, {'value': 1.2}]}}, {'value': 2, 'subtree': {'meta': 'child', 'nodes': [{'value': 2.1}, {'value': 2.2}]}}]}, False)
-        ]
+            (
+                {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [{"value": "string is invalid"}, {"value": 1.2}],
+                            },
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [{"value": 2.1}, {"value": 2.2}],
+                            },
+                        },
+                    ],
+                },
+                False,
+            ),
+        ],
     )
     def test_Recursive_references_between_schemas(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://localhost:1234/draft2020-12/tree', 'description': 'tree of nodes', 'type': 'object', 'properties': {'meta': {'type': 'string'}, 'nodes': {'type': 'array', 'items': {'$ref': 'node'}}}, 'required': ['meta', 'nodes'], '$defs': {'node': {'$id': 'http://localhost:1234/draft2020-12/node', 'description': 'node', 'type': 'object', 'properties': {'value': {'type': 'number'}, 'subtree': {'$ref': 'tree'}}, 'required': ['value']}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {"type": "array", "items": {"$ref": "node"}},
+            },
+            "required": ["meta", "nodes"],
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft2020-12/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {"value": {"type": "number"}, "subtree": {"$ref": "tree"}},
+                    "required": ["value"],
+                }
+            },
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1407,114 +1484,136 @@ class TestRefs:
             # object with numbers is valid
             ({'foo"bar': 1}, True),
             # object with strings is invalid
-            ({'foo"bar': '1'}, False)
-        ]
+            ({'foo"bar': "1"}, False),
+        ],
     )
     def test_refs_with_quote(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', 'properties': {'foo"bar': {'$ref': '#/$defs/foo%22bar'}}, '$defs': {'foo"bar': {'type': 'number'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {'foo"bar': {"$ref": "#/$defs/foo%22bar"}},
+            "$defs": {'foo"bar': {"type": "number"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # referenced subschema doesn't see annotations from properties
-            ({'prop1': 'match'}, False)
-        ]
+            ({"prop1": "match"}, False)
+        ],
     )
     @pytest.mark.xfail(reason="unevaluatedProperties is not implemented")
     def test_ref_creates_new_scope_when_adjacent_to_keywords(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'A': {'unevaluatedProperties': False}}, 'properties': {'prop1': {'type': 'string'}}, '$ref': '#/$defs/A'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {"A": {"unevaluatedProperties": False}},
+            "properties": {"prop1": {"type": "string"}},
+            "$ref": "#/$defs/A",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # do not evaluate the $ref inside the enum, matching any string
-            ('this is a string', False),
+            ("this is a string", False),
             # do not evaluate the $ref inside the enum, definition exact match
-            ({'type': 'string'}, False),
+            ({"type": "string"}, False),
             # match the enum exactly
-            ({'$ref': '#/$defs/a_string'}, True)
-        ]
+            ({"$ref": "#/$defs/a_string"}, True),
+        ],
     )
-    def test_naive_replacement_of_ref_with_its_destination_is_not_correct(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'a_string': {'type': 'string'}}, 'enum': [{'$ref': '#/$defs/a_string'}]}
+    def test_naive_replacement_of_ref_with_its_destination_is_not_correct(
+        self, test_object, valid
+    ):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {"a_string": {"type": "string"}},
+            "enum": [{"$ref": "#/$defs/a_string"}],
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # invalid on inner field
-            ({'foo': {'bar': 1}, 'bar': 'a'}, False),
+            ({"foo": {"bar": 1}, "bar": "a"}, False),
             # invalid on outer field
-            ({'foo': {'bar': 'a'}, 'bar': 1}, False),
+            ({"foo": {"bar": "a"}, "bar": 1}, False),
             # valid on both fields
-            ({'foo': {'bar': 'a'}, 'bar': 'a'}, True)
-        ]
+            ({"foo": {"bar": "a"}, "bar": "a"}, True),
+        ],
     )
     def test_refs_with_relative_uris_and_defs(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/schema-relative-uri-defs1.json', 'properties': {'foo': {'$id': 'schema-relative-uri-defs2.json', '$defs': {'inner': {'properties': {'bar': {'type': 'string'}}}}, '$ref': '#/$defs/inner'}}, '$ref': 'schema-relative-uri-defs2.json'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$defs": {"inner": {"properties": {"bar": {"type": "string"}}}},
+                    "$ref": "#/$defs/inner",
+                }
+            },
+            "$ref": "schema-relative-uri-defs2.json",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # invalid on inner field
-            ({'foo': {'bar': 1}, 'bar': 'a'}, False),
+            ({"foo": {"bar": 1}, "bar": "a"}, False),
             # invalid on outer field
-            ({'foo': {'bar': 'a'}, 'bar': 1}, False),
+            ({"foo": {"bar": "a"}, "bar": 1}, False),
             # valid on both fields
-            ({'foo': {'bar': 'a'}, 'bar': 'a'}, True)
-        ]
+            ({"foo": {"bar": "a"}, "bar": "a"}, True),
+        ],
     )
     def test_relative_refs_with_absolute_uris_and_defs(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/schema-refs-absolute-uris-defs1.json', 'properties': {'foo': {'$id': 'http://example.com/schema-refs-absolute-uris-defs2.json', '$defs': {'inner': {'properties': {'bar': {'type': 'string'}}}}, '$ref': '#/$defs/inner'}}, '$ref': 'schema-refs-absolute-uris-defs2.json'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$defs": {"inner": {"properties": {"bar": {"type": "string"}}}},
+                    "$ref": "#/$defs/inner",
+                }
+            },
+            "$ref": "schema-refs-absolute-uris-defs2.json",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1522,21 +1621,30 @@ class TestRefs:
             # number is valid
             (1, True),
             # non-number is invalid
-            ('a', False)
-        ]
+            ("a", False),
+        ],
     )
-    def test_id_must_be_resolved_against_nearest_parent_not_just_immediate_parent(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/a.json', '$defs': {'x': {'$id': 'http://example.com/b/c.json', 'not': {'$defs': {'y': {'$id': 'd.json', 'type': 'number'}}}}}, 'allOf': [{'$ref': 'http://example.com/b/d.json'}]}
+    def test_id_must_be_resolved_against_nearest_parent_not_just_immediate_parent(
+        self, test_object, valid
+    ):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {"$defs": {"y": {"$id": "d.json", "type": "number"}}},
+                }
+            },
+            "allOf": [{"$ref": "http://example.com/b/d.json"}],
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1544,21 +1652,35 @@ class TestRefs:
             # data is valid against first definition
             (5, True),
             # data is invalid against first definition
-            (50, False)
-        ]
+            (50, False),
+        ],
     )
     def test_order_of_evaluation_id_and_ref(self, test_object, valid):
-        schema = {'$comment': '$id must be evaluated before $ref to get the proper $ref destination', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'https://example.com/draft2020-12/ref-and-id1/base.json', '$ref': 'int.json', '$defs': {'bigint': {'$comment': 'canonical uri: https://example.com/ref-and-id1/int.json', '$id': 'int.json', 'maximum': 10}, 'smallint': {'$comment': 'canonical uri: https://example.com/ref-and-id1-int.json', '$id': '/draft2020-12/ref-and-id1-int.json', 'maximum': 2}}}
+        schema = {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/draft2020-12/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: https://example.com/ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10,
+                },
+                "smallint": {
+                    "$comment": "canonical uri: https://example.com/ref-and-id1-int.json",
+                    "$id": "/draft2020-12/ref-and-id1-int.json",
+                    "maximum": 2,
+                },
+            },
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1566,288 +1688,341 @@ class TestRefs:
             # data is valid against first definition
             (5, True),
             # data is invalid against first definition
-            (50, False)
-        ]
+            (50, False),
+        ],
     )
     def test_order_of_evaluation_id_and_anchor_and_ref(self, test_object, valid):
-        schema = {'$comment': '$id must be evaluated before $ref to get the proper $ref destination', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'https://example.com/draft2020-12/ref-and-id2/base.json', '$ref': '#bigint', '$defs': {'bigint': {'$comment': 'canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint', '$anchor': 'bigint', 'maximum': 10}, 'smallint': {'$comment': 'canonical uri: https://example.com/ref-and-id2#/$defs/smallint; another valid uri for this location: https://example.com/ref-and-id2/#bigint', '$id': 'https://example.com/draft2020-12/ref-and-id2/', '$anchor': 'bigint', 'maximum': 2}}}
+        schema = {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/draft2020-12/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$anchor": "bigint",
+                    "maximum": 10,
+                },
+                "smallint": {
+                    "$comment": "canonical uri: https://example.com/ref-and-id2#/$defs/smallint; another valid uri for this location: https://example.com/ref-and-id2/#bigint",
+                    "$id": "https://example.com/draft2020-12/ref-and-id2/",
+                    "$anchor": "bigint",
+                    "maximum": 2,
+                },
+            },
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # valid under the URN IDed schema
-            ({'foo': 37}, True),
+            ({"foo": 37}, True),
             # invalid under the URN IDed schema
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_simple_URN_base_URI_with_ref_via_the_URN(self, test_object, valid):
-        schema = {'$comment': 'URIs do not have to have HTTP(s) schemes', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed', 'minimum': 30, 'properties': {'foo': {'$ref': 'urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed'}}}
+        schema = {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {"foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ({'foo': 'bar'}, True),
+            ({"foo": "bar"}, True),
             # a non-string is invalid
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_simple_URN_base_URI_with_JSON_pointer(self, test_object, valid):
-        schema = {'$comment': 'URIs do not have to have HTTP(s) schemes', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        schema = {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {"foo": {"$ref": "#/$defs/bar"}},
+            "$defs": {"bar": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ({'foo': 'bar'}, True),
+            ({"foo": "bar"}, True),
             # a non-string is invalid
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_URN_base_URI_with_NSS(self, test_object, valid):
-        schema = {'$comment': 'RFC 8141 §2.2', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:example:1/406/47452/2', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        schema = {
+            "$comment": "RFC 8141 §2.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {"foo": {"$ref": "#/$defs/bar"}},
+            "$defs": {"bar": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ({'foo': 'bar'}, True),
+            ({"foo": "bar"}, True),
             # a non-string is invalid
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_URN_base_URI_with_r_component(self, test_object, valid):
-        schema = {'$comment': 'RFC 8141 §2.3.1', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:example:foo-bar-baz-qux?+CCResolve:cc=uk', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        schema = {
+            "$comment": "RFC 8141 §2.3.1",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {"foo": {"$ref": "#/$defs/bar"}},
+            "$defs": {"bar": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ({'foo': 'bar'}, True),
+            ({"foo": "bar"}, True),
             # a non-string is invalid
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_URN_base_URI_with_q_component(self, test_object, valid):
-        schema = {'$comment': 'RFC 8141 §2.3.2', '$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z', 'properties': {'foo': {'$ref': '#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        schema = {
+            "$comment": "RFC 8141 §2.3.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {"foo": {"$ref": "#/$defs/bar"}},
+            "$defs": {"bar": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ({'foo': 'bar'}, True),
+            ({"foo": "bar"}, True),
             # a non-string is invalid
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_URN_base_URI_with_URN_and_JSON_pointer_ref(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-0000-0000-4321feebdaed', 'properties': {'foo': {'$ref': 'urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar'}}, '$defs': {'bar': {'type': 'string'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+            },
+            "$defs": {"bar": {"type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ({'foo': 'bar'}, True),
+            ({"foo": "bar"}, True),
             # a non-string is invalid
-            ({'foo': 12}, False)
-        ]
+            ({"foo": 12}, False),
+        ],
     )
     def test_URN_base_URI_with_URN_and_anchor_ref(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed', 'properties': {'foo': {'$ref': 'urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something'}}, '$defs': {'bar': {'$anchor': 'something', 'type': 'string'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "$defs": {"bar": {"$anchor": "something", "type": "string"}},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ('bar', True),
+            ("bar", True),
             # a non-string is invalid
-            (12, False)
-        ]
+            (12, False),
+        ],
     )
     def test_URN_ref_with_nested_pointer_ref(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed', '$defs': {'foo': {'$id': 'urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed', '$defs': {'bar': {'type': 'string'}}, '$ref': '#/$defs/bar'}}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar",
+                }
+            },
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a non-integer is invalid due to the $ref
-            ('foo', False),
+            ("foo", False),
             # an integer is valid
-            (12, True)
-        ]
+            (12, True),
+        ],
     )
     @pytest.mark.xfail(reason="if not implemented")
     def test_ref_to_if(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/if', 'if': {'$id': 'http://example.com/ref/if', 'type': 'integer'}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://example.com/ref/if",
+            "if": {"$id": "http://example.com/ref/if", "type": "integer"},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a non-integer is invalid due to the $ref
-            ('foo', False),
+            ("foo", False),
             # an integer is valid
-            (12, True)
-        ]
+            (12, True),
+        ],
     )
     @pytest.mark.xfail(reason="then not implemented")
     def test_ref_to_then(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/then', 'then': {'$id': 'http://example.com/ref/then', 'type': 'integer'}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://example.com/ref/then",
+            "then": {"$id": "http://example.com/ref/then", "type": "integer"},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a non-integer is invalid due to the $ref
-            ('foo', False),
+            ("foo", False),
             # an integer is valid
-            (12, True)
-        ]
+            (12, True),
+        ],
     )
     @pytest.mark.xfail(reason="else not implemented")
     def test_ref_to_else(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$ref': 'http://example.com/ref/else', 'else': {'$id': 'http://example.com/ref/else', 'type': 'integer'}}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://example.com/ref/else",
+            "else": {"$id": "http://example.com/ref/else", "type": "integer"},
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
         [
             # a string is valid
-            ('foo', True),
+            ("foo", True),
             # an integer is invalid
-            (12, False)
-        ]
+            (12, False),
+        ],
     )
     def test_ref_with_absolute_path_reference(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'http://example.com/ref/absref.json', '$defs': {'a': {'$id': 'http://example.com/ref/absref/foobar.json', 'type': 'number'}, 'b': {'$id': 'http://example.com/absref/foobar.json', 'type': 'string'}}, '$ref': '/absref/foobar.json'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/ref/absref.json",
+            "$defs": {
+                "a": {"$id": "http://example.com/ref/absref/foobar.json", "type": "number"},
+                "b": {"$id": "http://example.com/absref/foobar.json", "type": "string"},
+            },
+            "$ref": "/absref/foobar.json",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1855,21 +2030,23 @@ class TestRefs:
             # number is valid
             (1, True),
             # non-number is invalid
-            ('a', False)
-        ]
+            ("a", False),
+        ],
     )
     def test_id_with_file_URI_still_resolves_pointers___nix(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'file:///folder/file.json', '$defs': {'foo': {'type': 'number'}}, '$ref': '#/$defs/foo'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "file:///folder/file.json",
+            "$defs": {"foo": {"type": "number"}},
+            "$ref": "#/$defs/foo",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1877,21 +2054,23 @@ class TestRefs:
             # number is valid
             (1, True),
             # non-number is invalid
-            ('a', False)
-        ]
+            ("a", False),
+        ],
     )
     def test_id_with_file_URI_still_resolves_pointers___windows(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$id': 'file:///c:/folder/file.json', '$defs': {'foo': {'type': 'number'}}, '$ref': '#/$defs/foo'}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "file:///c:/folder/file.json",
+            "$defs": {"foo": {"type": "number"}},
+            "$ref": "#/$defs/foo",
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
     @pytest.mark.parametrize(
         ["test_object", "valid"],
@@ -1899,21 +2078,22 @@ class TestRefs:
             # number is valid
             (1, True),
             # non-number is invalid
-            ('a', False)
-        ]
+            ("a", False),
+        ],
     )
     def test_empty_tokens_in_ref_json_pointer(self, test_object, valid):
-        schema = {'$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'': {'$defs': {'': {'type': 'number'}}}}, 'allOf': [{'$ref': '#/$defs//$defs/'}]}
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {"": {"$defs": {"": {"type": "number"}}}},
+            "allOf": [{"$ref": "#/$defs//$defs/"}],
+        }
         if valid:
             validate(instance=test_object, schema=schema)
             generate_and_check(test_object, schema)
         else:
             with pytest.raises(ValidationError):
                 validate(instance=test_object, schema=schema)
-            check_match_failure(
-                bad_string=json_dumps(test_object),
-                schema_obj=schema
-            )
+            check_match_failure(bad_string=json_dumps(test_object), schema_obj=schema)
 
 
 class TestAnyOf:


### PR DESCRIPTION
1. Refs are now resolved in full generality, allowing anchors, relative refs, and absolute refs. 
2. Rather than pre-computing the grammars for schemas that happen to live in `$defs`, we now lazily compute grammars upon first reference.
3. Existing ref tests are replaced with the full set of tests from the JSON Schema test suite. Some are xfailed if they depend on other features that we do not (yet) support.
4. Keys in objects are now properly escaped in order to guarantee json.loads-ability (discovered this issue when running the new tests)

NOTE: this introduces a new dependency: `referencing`, which handles ref lookup for us (a fairly non-trivial task).