### PR TITLE
[JSON] Raise exceptions when "sibling" keywords are unhandled

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -165,17 +165,17 @@ TYPE_SPECIFIC_KEYWORDS = {
     JSONType.OBJECT: ObjectKeywords,
 }
 
-DEFS_KEYS = {"$defs", "definitions"}
-
 IGNORED_KEYS = {
     "$anchor",
+    "$defs",
     "$schema",
     "$id",
     "id",
     "$comment",
     "title",
-    "description",
     "default",
+    "definitions",
+    "description",
     "examples",
 }
 
@@ -188,7 +188,7 @@ IGNORED_KEYS = {
 IGNORED_KEYS.add("discriminator")
 
 WHITESPACE = {b" ", b"\t", b"\n", b"\r"}
-VALID_KEYS = set(Keyword) | IGNORED_KEYS | DEFS_KEYS | set(NumberKeywords) | set(StringKeywords) | set(ArrayKeywords) | set(ObjectKeywords)
+VALID_KEYS = set(Keyword) | set(NumberKeywords) | set(StringKeywords) | set(ArrayKeywords) | set(ObjectKeywords) | IGNORED_KEYS
 
 FORMAT_PATTERNS: dict[str, Optional[str]] = {
     # https://json-schema.org/understanding-json-schema/reference/string#built-in-formats

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -398,6 +398,11 @@ def validate_json_node_keys(node: Mapping[str, Any]):
         )
 
 
+def get_sibling_keys(node: Mapping[str, Any], key: str) -> set[str]:
+    # Get the set of functional (non-ignored) keys that are siblings of the given key
+    return set(node.keys()) & VALID_KEYS - set(IGNORED_KEYS) - {key}
+
+
 class GenJson:
     item_separator = ", "
     key_separator = ": "
@@ -811,15 +816,24 @@ class GenJson:
         validate_json_node_keys(json_schema)
 
         if Keyword.ANYOF in json_schema:
+            sibling_keys = get_sibling_keys(json_schema, Keyword.ANYOF)
+            if sibling_keys:
+                raise NotImplementedError(f"anyOf with sibling keys is not yet supported. Got {sibling_keys}")
             return lm + self.anyOf(anyof_list=json_schema[Keyword.ANYOF])
 
         if Keyword.ALLOF in json_schema:
+            sibling_keys = get_sibling_keys(json_schema, Keyword.ALLOF)
+            if sibling_keys:
+                raise NotImplementedError(f"allOf with sibling keys is not yet supported. Got {sibling_keys}")
             allof_list = json_schema[Keyword.ALLOF]
             if len(allof_list) != 1:
                 raise ValueError("Only support allOf with exactly one item")
             return lm + self.json(json_schema=allof_list[0])
 
         if Keyword.ONEOF in json_schema:
+            sibling_keys = get_sibling_keys(json_schema, Keyword.ONEOF)
+            if sibling_keys:
+                raise NotImplementedError(f"oneOf with sibling keys is not yet supported. Got {sibling_keys}")
             oneof_list = json_schema[Keyword.ONEOF]
             if len(oneof_list) == 1:
                 return lm + self.json(json_schema=oneof_list[0])
@@ -827,12 +841,21 @@ class GenJson:
             return lm + self.anyOf(anyof_list=oneof_list)
 
         if Keyword.REF in json_schema:
+            sibling_keys = get_sibling_keys(json_schema, Keyword.REF)
+            if sibling_keys:
+                raise NotImplementedError(f"$ref with sibling keys is not yet supported. Got {sibling_keys}")
             return lm + self.ref(reference=json_schema[Keyword.REF])
 
         if Keyword.CONST in json_schema:
+            sibling_keys = get_sibling_keys(json_schema, Keyword.CONST)
+            if sibling_keys:
+                raise NotImplementedError(f"const with sibling keys is not yet supported. Got {sibling_keys}")
             return lm + self.const(value=json_schema[Keyword.CONST])
 
         if Keyword.ENUM in json_schema:
+            sibling_keys = get_sibling_keys(json_schema, Keyword.ENUM)
+            if sibling_keys:
+                raise NotImplementedError(f"enum with sibling keys is not yet supported. Got {sibling_keys}")
             return lm + self.enum(options=json_schema[Keyword.ENUM])
 
         if Keyword.TYPE in json_schema:

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -2394,6 +2394,15 @@ class TestEnum:
                 validate(instance=obj, schema=schema_obj)
             check_match_failure(bad_string=json_dumps(obj), schema_obj=schema_obj)
 
+    def test_invalid_typed_enum(self):
+        schema_obj = {
+            "enum": [1, "2"],
+            "type": "boolean"
+        }
+        with pytest.raises(ValueError) as ve:
+            gen_json(schema=schema_obj)
+        assert ve.value.args[0] == "No valid options found for enum with type 'boolean': [1, '2']"
+
 class TestConst:
     def test_constant_int(self):
         # First sanity check what we're setting up

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -2348,6 +2348,51 @@ class TestEnum:
             schema_obj=schema_obj,
         )
 
+    @pytest.mark.parametrize(
+        "obj, valid",
+        [
+            (1, True),
+            (2, False),
+            ("2", False),
+            ("1", False),
+            (True, False),
+        ]
+    )
+    def test_typed_enum_single_type(self, obj, valid):
+        schema_obj = {
+            "enum": [1, "2", True],
+            "type": "integer"
+        }
+        if valid:
+            validate(instance=obj, schema=schema_obj)
+            generate_and_check(obj, schema_obj)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=obj, schema=schema_obj)
+            check_match_failure(bad_string=json_dumps(obj), schema_obj=schema_obj)
+
+    @pytest.mark.parametrize(
+        "obj, valid",
+        [
+            (1, True),
+            (2, False),
+            ("2", True),
+            ("1", False),
+            (True, False),
+        ]
+    )
+    def test_typed_enum_multiple_types(self, obj, valid):
+        schema_obj = {
+            "enum": [1, "2", True],
+            "type": ["integer", "string"]
+        }
+        if valid:
+            validate(instance=obj, schema=schema_obj)
+            generate_and_check(obj, schema_obj)
+        else:
+            with pytest.raises(ValidationError):
+                validate(instance=obj, schema=schema_obj)
+            check_match_failure(bad_string=json_dumps(obj), schema_obj=schema_obj)
 
 class TestConst:
     def test_constant_int(self):

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -2461,6 +2461,67 @@ class TestConst:
             schema_obj=schema_obj,
         )
 
+    def test_valid_typed_const(self):
+        schema_obj = {
+            "const": 1,
+            "type": "integer"
+        }
+        target_obj = 1
+        validate(instance=target_obj, schema=schema_obj)
+        generate_and_check(target_obj, schema_obj)
+
+    def test_invalid_typed_const(self):
+        schema_obj = {
+            "const": 1,
+            "type": "boolean"
+        }
+        with pytest.raises(ValidationError):
+            gen_json(schema=schema_obj)
+
+    def test_valid_enum_const(self):
+        schema_obj = {
+            "const": 1,
+            "enum": [1, 2, 3]
+        }
+        target_obj = 1
+        validate(instance=target_obj, schema=schema_obj)
+        generate_and_check(target_obj, schema_obj)
+
+    def test_invalid_enum_const(self):
+        schema_obj = {
+            "const": 1,
+            "enum": [2, 3]
+        }
+        with pytest.raises(ValidationError):
+            gen_json(schema=schema_obj)
+
+    def test_valid_typed_enum_const(self):
+        schema_obj = {
+            "const": 1,
+            "enum": [1, "2", 3],
+            "type": "integer"
+        }
+        target_obj = 1
+        validate(instance=target_obj, schema=schema_obj)
+        generate_and_check(target_obj, schema_obj)
+
+    @pytest.mark.parametrize(
+        "const",
+        [
+            "2", # right enum, wrong type
+            2, # wrong enum, right type
+            "3", # wrong enum, wrong type
+        ]
+    )
+    def test_invalid_typed_enum_const(self, const):
+        schema_obj = {
+            "const": const,
+            "enum": [1, "2", 3],
+            "type": "integer"
+        }
+        with pytest.raises(ValidationError):
+            gen_json(schema=schema_obj)
+
 
 class TestAdditionalProperties:
 

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -1265,14 +1265,12 @@ class TestRefs:
             # ref valid, maxItems valid
             ({"foo": []}, True),
             # ref valid, maxItems invalid
-            pytest.param(
-                *({"foo": [1, 2, 3]}, False),
-                marks=pytest.mark.xfail(reason="sibling keywords to ref are not yet supported"),
-            ),
+            ({"foo": [1, 2, 3]}, False),
             # ref invalid
             ({"foo": "string"}, False),
         ],
     )
+    @pytest.mark.xfail(reason="sibling keywords to ref are not yet supported")
     def test_ref_applies_alongside_sibling_keywords(self, test_object, valid):
         schema = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1559,12 +1557,10 @@ class TestRefs:
             # invalid on outer field
             ({"foo": {"bar": "a"}, "bar": 1}, False),
             # valid on both fields
-            pytest.param(
-                *({"foo": {"bar": "a"}, "bar": "a"}, True),
-                marks=pytest.mark.xfail(reason="refs with sibling keywords are not yet supported; foo here is being seen as an additionalProperty before bar"),
-            ),
+            ({"foo": {"bar": "a"}, "bar": "a"}, True),
         ],
     )
+    @pytest.mark.xfail(reason="refs with sibling keywords are not yet supported")
     def test_refs_with_relative_uris_and_defs(self, test_object, valid):
         schema = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1594,12 +1590,10 @@ class TestRefs:
             # invalid on outer field
             ({"foo": {"bar": "a"}, "bar": 1}, False),
             # valid on both fields
-            pytest.param(
-                *({"foo": {"bar": "a"}, "bar": "a"}, True),
-                marks=pytest.mark.xfail(reason="refs with sibling keywords are not yet supported; foo here is being seen as an additionalProperty before bar"),
-            ),
+            ({"foo": {"bar": "a"}, "bar": "a"}, True),
         ],
     )
+    @pytest.mark.xfail(reason="refs with sibling keywords are not yet supported")
     def test_relative_refs_with_absolute_uris_and_defs(self, test_object, valid):
         schema = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
WIP BECAUSE THIS DEPENDS ON STILL-OPEN PR #1061 

When an [applicator](https://json-schema.org/draft/2020-12/json-schema-core#name-applicators) has sibling keywords, JSON schema mandates that both sets of keywords are respected, e.g.

```json
{
   "$defs": {"foo": {"type": "integer"}},
   "$ref": "#/$defs/foo",
   "minimum": 5
}
```
In this schema, "minimum" is a "sibling" to the "$ref", and we need to enforce BOTH the schema in the definition AND the "minimum" keyword.

There are some trivial examples of this general problem, and we can provide implementations for them (in this PR, I also include an implementation for combinations of the "type", "const", and "enum" keywords, which addresses the enum part of #1038). But when no implementation is provided, we need to raise an exception to prevent "type 1 errors" (the LLM is happy to generate an instance that might not validate against the full schema).

There are a number of tests in the `TestRefs` class that have to be xfailed due to this stricter behavior. In time, we can add more implementations that handle siblings, reducing the number of xfails.