### PR TITLE
[Optimization] Advance parser concurrently with model forward pass

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -131,8 +131,11 @@ class TokenParser:
             if not mask[token]:
                 # Note: we could punt this probem to ll_interpreter.post_process,
                 # but it's a bit clearer to handle it here
-                # TODO: send valid tokens rather than mask?
-                raise InvalidTokenException(token, mask, tokens)
+                raise InvalidTokenException(
+                    token=token,
+                    valid_tokens=[i for i in range(len(mask)) if mask[i]],
+                    prompt_tokens=tokens
+                )
 
             backtrack, ff_tokens = self.ll_interpreter.post_process(token)
             if backtrack:

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -168,6 +168,8 @@ class ByteParser:
         self.pos = 0
         self._variables: dict[str, Any] = {}
         self._variables_log_probs: dict[str, Any] = {}
+        # Prime the parser
+        self._advance(None)
         self.consume_bytes(prompt)
 
     def matched(self) -> bool:
@@ -212,11 +214,6 @@ class ByteParser:
         self.bytes += response.new_bytes
 
     def consume_bytes(self, bts: bytes) -> None:
-        # Run underlying ll_parser and fast-forward all of our bytes
-        # until we have a "choice" (generation step) to make
-        while self.gen_data is None and not self.token_parser.done():
-            self._advance(None)
-
         if not bts:
             return
 

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -139,6 +139,13 @@ class TokenParser:
             raise TokenParserException(f"Unexpected stop reason: {stop_reason}")
         self._done = True
 
+    def __del__(self):
+        # Silence exceptions from generator cleanup so users don't get any unraisable exceptions during GC
+        try:
+            self.cleanup()
+        except TokenParserException:
+            pass
+
 class ByteParserException(Exception):
     def __init__(self, *args, **kwargs):
         self.current_byte = kwargs.pop("current_byte", None)

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -193,7 +193,7 @@ class ByteParser:
             self.token_parser.cleanup()
             self.gen_data = None
         else:
-            assert tokens is not None
+            assert mask is not None
             assert ll_response.temperature is not None
             self.gen_data = GenData(
                 tokens=tokens,

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -80,9 +80,9 @@ class MockEngine(Engine):
         # seed the random number generator
         self._rand_generator = np.random.default_rng(seed=42)
 
-    def get_next_token(self, token_ids: list[int], mask: Optional[bytes], temperature: float) -> int:
+    def sample_with_temperature(self, logits, mask, temperature):
         self.called_temperatures.append(temperature)
-        return super().get_next_token(token_ids, mask, temperature)
+        return super().sample_with_temperature(logits, mask, temperature)
 
     def get_logits(self, token_ids: list[int]) -> np.ndarray:
         """Pretends to compute the logits for the given token state."""

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -24,7 +24,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-from .._schema import EngineCallResponse, GuidanceEngineMetrics, LLInterpreterResponse
+from .._schema import EngineCallResponse, GuidanceEngineMetrics
 from .._utils import softmax, CaptureEvents
 from .._parser import TokenParser
 from .._grammar import (
@@ -153,8 +153,7 @@ class Engine:
 
             # Important: don't wait on this future until after getting the logits;
             # this allows the mask to be built concurrently with model inference
-            mask, ll_response_str = mid_process_fut.result()
-            ll_response = LLInterpreterResponse.model_validate_json(ll_response_str)
+            mask, ll_response = mid_process_fut.result()
 
             engine_response = ll_response.progress.to_engine_call_response()
             yield engine_response

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -136,23 +136,30 @@ class Engine:
             gen_data, response = parser.advance(token)
 
             if gen_data is not None:
-                if parser.is_accepting() and self.tokenizer.eos_token_id is not None:
+                can_finish_early = parser.is_accepting() and self.tokenizer.eos_token_id is not None
+
+                if can_finish_early:
+                    # Type checker needs some help
+                    assert self.tokenizer.eos_token_id is not None
+                    # Should be equivalent to parser.is_accepting()
+                    assert gen_data.mask[self.tokenizer.eos_token_id]
                     # Whenever we are in an accepting state, we will allow the model to generate whatever it wants
                     # but we will treat any "illegal" tokens as EOS, allowing the model to finish gracefully.
-                    assert gen_data.mask[self.tokenizer.eos_token_id]
-                    token = self.get_next_token(
-                        token_ids=gen_data.tokens,
-                        mask=None,
-                        temperature=gen_data.temperature
-                    )
-                    if not gen_data.mask[token]:
-                        token = self.tokenizer.eos_token_id
+                    # Hence, mask must be None
+                    mask_for_get_next_token = None
                 else:
-                    token = self.get_next_token(
-                        token_ids=gen_data.tokens,
-                        mask=gen_data.mask,
-                        temperature=gen_data.temperature
-                    )
+                    mask_for_get_next_token = gen_data.mask
+
+                token = self.get_next_token(
+                    token_ids=gen_data.tokens,
+                    mask=mask_for_get_next_token,
+                    temperature=gen_data.temperature
+                )
+
+                if can_finish_early and not gen_data.mask[token]:
+                    # Type checker needs some help
+                    assert self.tokenizer.eos_token_id is not None
+                    token = self.tokenizer.eos_token_id
             else:
                 token = None
 

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -135,7 +135,9 @@ class Engine:
         token = None
         while True:
             tokens, mid_process_fut = parser.advance(token)
-            if has_get_logits:
+            has_pending_stop = parser.has_pending_stop()
+
+            if has_get_logits and not has_pending_stop:
                 try:
                     logits = self.get_logits(token_ids=tokens)
                 except NotImplementedError:
@@ -159,6 +161,9 @@ class Engine:
                 parser.cleanup()
                 # Ensure we break AFTER yielding the final response
                 break
+
+            # If there was a pending stop, we should have broken out of the loop
+            assert not has_pending_stop
 
             # Help the type checker: assert that everything we need to get the next token is not None
             assert mask is not None

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -161,7 +161,6 @@ class Engine:
                 break
 
             # Help the type checker: assert that everything we need to get the next token is not None
-            assert logits is not None
             assert mask is not None
             assert ll_response.temperature is not None
 

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -135,6 +135,10 @@ class Engine:
         token = None
         while True:
             tokens, mid_process_fut = parser.advance(token)
+
+            # Note that has_pending_stop implies that the response is a stop response,
+            # but the converse is not true. We can therefore avoid some (but not all)
+            # unnecessary calls to get_logits on the final iteration.
             has_pending_stop = parser.has_pending_stop()
 
             if has_get_logits and not has_pending_stop:

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -148,8 +148,9 @@ class Engine:
             yield engine_response
 
             if ll_response.stop:
-                # assert logits is None
                 assert mask is None
+                # May raise an exception if the parser is in an bad state!
+                parser.cleanup()
                 # Ensure we break AFTER yielding the final response
                 break
 

--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -137,7 +137,7 @@ class Engine:
             tokens, mid_process_fut = parser.advance(token)
             if has_get_logits:
                 try:
-                    logits = self.get_logits(tokens)
+                    logits = self.get_logits(token_ids=tokens)
                 except NotImplementedError:
                     # Permanently fall-back to get_next_token if get_logits is not implemented
                     has_get_logits = False

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "pydantic",
     "requests",
     "tiktoken>=0.3",
-    "llguidance>=0.1.7",
+    "llguidance>=0.3.0",
 ]
 
 # Our basic list of 'extras'

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -81,11 +81,11 @@ def test_associativity(selected_model: models.Model):
 
     with patch.object(engine, "get_logits", side_effect=engine.get_logits) as get_logits_1:
         _ = selected_model + (prompt + grammar)
-    prompt_tokens_1 = get_logits_1.call_args.kwargs["token_ids"]
+    prompt_tokens_1 = get_logits_1.call_args_list[0].kwargs["token_ids"]
 
     with patch.object(engine, "get_logits", side_effect=engine.get_logits) as get_logits_2:
         _ = (selected_model + prompt) + grammar
-    prompt_tokens_2 = get_logits_2.call_args.kwargs["token_ids"]
+    prompt_tokens_2 = get_logits_2.call_args_list[0].kwargs["token_ids"]
 
     # Main assertion: the prompt tokens should be the same
     assert prompt_tokens_1 == prompt_tokens_2

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -74,18 +74,18 @@ def test_associativity(selected_model: models.Model):
     REMOTE_MODELS = [models.AzureGuidance]
     for rm in REMOTE_MODELS:
         if isinstance(selected_model, rm):
-            pytest.skip("Method get_next_token not available for remote models")
+            pytest.skip("Method get_logits not available for remote models")
     prompt = "pi = "
     grammar = gen("number", regex=r"\d")
     engine = selected_model.engine
 
-    with patch.object(engine, "get_next_token", side_effect=engine.get_next_token) as get_next_token_1:
+    with patch.object(engine, "get_logits", side_effect=engine.get_logits) as get_logits_1:
         _ = selected_model + (prompt + grammar)
-    prompt_tokens_1 = get_next_token_1.call_args.kwargs["token_ids"]
+    prompt_tokens_1 = get_logits_1.call_args.kwargs["token_ids"]
 
-    with patch.object(engine, "get_next_token", side_effect=engine.get_next_token) as get_next_token_2:
+    with patch.object(engine, "get_logits", side_effect=engine.get_logits) as get_logits_2:
         _ = (selected_model + prompt) + grammar
-    prompt_tokens_2 = get_next_token_2.call_args.kwargs["token_ids"]
+    prompt_tokens_2 = get_logits_2.call_args.kwargs["token_ids"]
 
     # Main assertion: the prompt tokens should be the same
     assert prompt_tokens_1 == prompt_tokens_2


### PR DESCRIPTION
Refactors `Engine.__call__` and `TokenParser._parse` coroutine/generator to yield a _future_ wrapping `LLInterpreter.mid_process` (running in a `ThreadPoolExecutor`) such that `mid_process` can run concurrently with the forward pass. This function comes directly from the rust extension, so it releases the GIL and threading *should* be sufficient to ensure true concurrency.

@lochuynh1412 I stole a bit of your code from the interactivity overhaul in order to simplify `Engine.__call__`. I'm definitely introducing a merge conflict for that PR -- happy to help resolve it :)