### PR TITLE
[JSON] Add `strict_properties` kwarg to `guidance.json` to make JSON output terser by default

### DIFF
--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -990,6 +990,9 @@ def json(
         # Default schema is empty, "anything goes" schema
         # TODO: consider default being `{"type": "object"}`
         schema = {}
+        # In this case, we don't want to use strict_properties
+        # because we're not actually validating against a schema
+        strict_properties = False
     elif isinstance(schema, (Mapping, bool)):
         # Raises jsonschema.exceptions.SchemaError or ValueError
         # if schema is not valid

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -915,11 +915,11 @@ def json(
         Type["pydantic.BaseModel"],
         "pydantic.TypeAdapter",
     ] = None,
-    temperature: float = 0.0,
-    max_tokens: int = 100000000,
     separators: Optional[tuple[str, str]] = None,
     whitespace_flexible: bool = False,
     strict_properties: bool = True,
+    temperature: float = 0.0,
+    max_tokens: int = 100000000,
     **kwargs,
 ):
     """Generate valid JSON according to the supplied JSON schema or `pydantic` model.
@@ -963,6 +963,23 @@ def json(
             - A JSON schema object. This is a JSON schema string which has been passed to ``json.loads()``
             - A subclass of ``pydantic.BaseModel``
             - An instance of ``pydantic.TypeAdapter``
+    separators : Optional[Tuple[str, str]]
+        The (item, key) separators to use when generating the JSON. For maximal compactness/token savings, use `(",", ":")`.
+        Note that most JSON "in the wild" will include whitespace around these separators, and compact JSON may be out-of-distribution
+        for some models.
+        Default: (", ", ": ")
+    whitespace_flexible : bool
+        If True, allow for whitespace to be inserted between tokens in the JSON output. This gives maximal control to the model in terms of
+        formatting (and therefore might be more likely to be in-distribution for some models), but guidance will be able to accelerate fewer
+        tokens.
+    strict_properties : bool
+        If True, the generated JSON will only include additional properties if they are explicitly allowed in the schema. If False, additional
+        properties will be allowed unless they are explicitly disallowed.
+    max_tokens : int
+        The maximum number of tokens to generate.
+        Note setting this to a small number will likely result in an incomplete JSON object.
+    temperature : float
+        The temperature to use when generating the JSON.
     """
     if "compact" in kwargs:
         warnings.warn("The 'compact' argument is deprecated and has no effect. It will be removed in a future release.", category=DeprecationWarning)

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -406,7 +406,7 @@ def get_sibling_keys(node: Mapping[str, Any], key: str) -> set[str]:
 class GenJson:
     item_separator = ", "
     key_separator = ": "
-    def __init__(self, schema: JSONSchema, separators: Optional[tuple[str, str]] = None, strict_properties=True) -> None:
+    def __init__(self, schema: JSONSchema, separators: Optional[tuple[str, str]] = None, strict_properties: bool = True) -> None:
         self.schema = schema
         if separators is not None:
             self.item_separator, self.key_separator = separators

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -3130,7 +3130,7 @@ class TestWhitespace:
         seps,
     )
     def test_separators(self, separators, schema, obj):
-        grammar = gen_json(schema=schema, separators=separators)
+        grammar = gen_json(schema=schema, separators=separators, strict_properties=False)
         for seps in self.seps:
             prepared_json = json.dumps(obj, separators=seps)
             if separators == seps:
@@ -3160,7 +3160,7 @@ class TestWhitespace:
         [None, 0, 2, 4],
     )
     def test_whitespace_flexibility(self, indent, separators, schema, obj):
-        grammar = gen_json(schema=schema, whitespace_flexible=True)
+        grammar = gen_json(schema=schema, strict_properties=False, whitespace_flexible=True)
         prepared_json = json.dumps(obj, separators=separators, indent=indent)
 
         assert grammar.match(prepared_json, raise_exceptions=True) is not None

--- a/tests/unit/library/test_json.py
+++ b/tests/unit/library/test_json.py
@@ -17,7 +17,10 @@ from ...utils import generate_and_check as _generate_and_check
 
 
 def generate_and_check(
-    target_obj: Any, schema_obj, desired_temperature: Optional[float] = None
+    target_obj: Any,
+    schema_obj,
+    desired_temperature: Optional[float] = None,
+    strict_properties: bool = False,
 ):
     # Sanity check what we're being asked
     validate(instance=target_obj, schema=schema_obj)
@@ -28,16 +31,17 @@ def generate_and_check(
     # We partial in the grammar_callable
     if desired_temperature is not None:
         grammar_callable = partial(
-            gen_json, schema=schema_obj, temperature=desired_temperature
+            gen_json, schema=schema_obj, temperature=desired_temperature, strict_properties=strict_properties
         )
     else:
-        grammar_callable = partial(gen_json, schema=schema_obj)
+        grammar_callable = partial(gen_json, schema=schema_obj, strict_properties=strict_properties)
 
     lm = _generate_and_check(
         grammar_callable,
         test_string=prepared_json,
     )
-    check_run_with_temperature(lm, desired_temperature)
+    if desired_temperature is not None:
+        check_run_with_temperature(lm, desired_temperature)
 
 
 def check_match_failure(
@@ -47,8 +51,9 @@ def check_match_failure(
     failure_byte: Optional[bytes] = None,
     allowed_bytes: Optional[Set[bytes]] = None,
     schema_obj: Dict[str, Any],
+    strict_properties: bool = False,
 ):
-    grammar = gen_json(schema=schema_obj)
+    grammar = gen_json(schema=schema_obj, strict_properties=strict_properties)
 
     _check_match_failure(
         bad_string=bad_string,


### PR DESCRIPTION
Adds a `strict_properties` kwarg to `guidance.json` with a default value of `True`.

When `strict_properties` is `True`, then any JSON schema that leaves `additionalProperties` unset will be treated as if it were set to `False`. This means that the LLM will only generate properties that are explicitly requested by the schema. Explicitly setting `additionalProperties` with any non-False schema will override this behavior.

In the special case `guidance.json` is called without a schema (`None`), the value of `strict_properties` will be ignored and "any valid json" can be generated.

Note that this behavior isn't technically compliant with the official JSON Schema spec, and to enforce behavior in line with the spec, users should explicitly pass `strict_properties=False` when calling `guidance.json`. The `True` behavior will most likely be more in line with what users expect, however, and we adopt this as the default. Particularly when using the `pydantic` interface, this means that users don't have to monkey around with `ConfigDict`s.

Closes #1050