### PR TITLE
[BUG] Reset role blocks when `model.reset` is called

### DIFF
--- a/guidance/models/_model.py
+++ b/guidance/models/_model.py
@@ -378,6 +378,7 @@ class Model:
             If we should clear all the model object's variables in addition to reseting the byte state.
         """
         self._state = self._state[:0]
+        self.opened_blocks = {}
         if clear_variables:
             self._variables = {}
             self._variables_log_probs = {}


### PR DESCRIPTION
Just empties the dict of open role blocks when `model.reset` is called. Should close #1071