### PR TITLE
Force Transformers engine to return float logits

### DIFF
--- a/guidance/models/transformers/_transformers.py
+++ b/guidance/models/transformers/_transformers.py
@@ -510,7 +510,7 @@ class TransformersEngine(Engine):
             cache_token_ids.extend(new_token_ids)
             # Need to add special truncating logic here for weird models that have a different output size than tokenizer vocab
             self._cached_logits = (
-                model_out.logits[0, -1, : len(self.tokenizer.tokens)].cpu().numpy()
+                model_out.logits[0, -1, : len(self.tokenizer.tokens)].float().cpu().numpy()
             )
             self.metrics.engine_input_tokens += len(new_token_ids)
             self.metrics.engine_output_tokens += 1


### PR DESCRIPTION
Problem: Logits cannot be converted directly to CPU numpy if its type is in BFloat16
```
File "/home/jc1da/repos/ML/guidance_loc/guidance/models/transformers/_transformers.py", line 513, in get_logits
    model_out.logits[0, -1, : len(self.tokenizer.tokens)].cpu().numpy()
TypeError: Got unsupported ScalarType BFloat16
```

Example Code:
```python
model = "Qwen/Qwen2-0.5B-Instruct"
lm = guidance.models.Transformers(
    model,
    device_map="auto",
    trust_remote_code=True,
    chat_template=QWen2_ChatTemplate,
    torch_dtype=torch.bfloat16,
)

lm += """1 + 1 = add(1, 1) = 2
3 + 5 = add(3, 5) = 8
11 + 9 = add"""
```

@hudson-ai 