### PR TITLE
Clean up the __slots__ and overall inheritance structure in `_grammar.py`

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -1125,7 +1125,7 @@ class LLSerializer:
                     "Gen": {
                         "body_rx": self.regex(node.grammar),
                         "stop_rx": "",
-                        "lazy": True,
+                        "lazy": False, # TODO: false needed to support substring, but it should maybe be true?
                         "capture_name": node.capture_name,
                         "max_tokens": node.max_tokens,
                         "temperature": node.temperature,

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -174,7 +174,7 @@ def gen(
                     break
         return lm
 
-    pattern = Gen(body_regex=regex, stop_regex=gen_stop, save_stop_text=save_stop_text, name=tagged_name, max_tokens=max_tokens)
+    pattern = Gen(body_regex=regex, stop_regex=gen_stop, save_stop_text=save_stop_text, capture_name=tagged_name, max_tokens=max_tokens)
 
     # define any capture group for non-tool calls
     if name is not None and tools is None:

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -16,7 +16,7 @@ def gen(
     lm,
     name=None,
     *,
-    max_tokens=1e10,
+    max_tokens=None,
     list_append=False,
     regex=None,
     tools=None,

--- a/guidance/library/_subgrammar.py
+++ b/guidance/library/_subgrammar.py
@@ -21,7 +21,7 @@ def lexeme(
         For example, /[a-z"]+/ will be quoted as /([a-z]|\\")+/.
         Defaults to False.
     """
-    return Lexeme(body_regex=body_regex, contextual=contextual, json_string=json_string)
+    return Lexeme(rx=body_regex, contextual=contextual, json_string=json_string)
 
 
 def subgrammar(


### PR DESCRIPTION
This PR primarily serves to align the attributes of our grammar classes with the arguments they are able to pass to the llguidance api.

The most notable change is that `max_tokens` is only allowed on classes that will serialize to `Gen`, `Lexeme`, or `GenGrammar`, where `token_limit` is reimplemented by wrapping a grammar in a `GenGrammar` pre-image (`Subgrammar`).