### PR TITLE
Upgrade llguidance to `0.5.1rc0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     "referencing",
     "requests",
     "tiktoken>=0.3",
-    "llguidance==0.5.0",
+    "llguidance==0.5.1rc0",
 ]
 
 # Our basic list of 'extras'


### PR DESCRIPTION
- Allow intersection of `pattern`, `format`, and `minLength`/`maxLength` on strings
- Support for pre-Draft2019-09 `additionalItems`
- Reduce cases where we give a warning for `oneOf` (we can infer cases where coercion is guaranteed to be safe)
- Correction to JSON `pattern`'s regex anchoring semantics (patterns not assumed to be anchored by default)
- Minor changes to JSON string generation with `minLength`/`maxLength`: UTF-16 surrogate pairs are no longer allowed