### PR TITLE
Mark special tokens in tokenizers

### DIFF
--- a/guidance/models/_engine/_tokenizer.py
+++ b/guidance/models/_engine/_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Sequence, Union
+from typing import Any, Dict, Sequence, Union, Optional
 
 import numpy as np
 
@@ -16,8 +16,9 @@ class Tokenizer:
         self,
         tokens: Union[Sequence[bytes], np.ndarray],
         chat_template: Union[str, ChatTemplate, None],
-        bos_token_id: Union[int, None] = None,
-        eos_token_id: Union[int, None] = None,
+        bos_token_id: Optional[int] = None,
+        eos_token_id: Optional[int] = None,
+        special_token_ids: Optional[list[int]] = None,
     ):
 
         # a numpy array of token byte strings indexed by their token id
@@ -42,6 +43,8 @@ class Tokenizer:
         self._bos_token = None if self.bos_token_id is None else self.tokens[self.bos_token_id]
         self._eos_token_id = eos_token_id if eos_token_id is not None else bos_token_id
         self._eos_token = None if self.eos_token_id is None else self.tokens[self.eos_token_id]
+
+        self._special_token_ids = special_token_ids or []
 
         # track which tokens are duplicates
         self._duplicate_tokens = []
@@ -75,6 +78,10 @@ class Tokenizer:
     @property
     def chat_template(self) -> Union[Any, None]:
         return self._chat_template
+
+    @property
+    def special_token_ids(self) -> list[int]:
+        return self._special_token_ids
 
     def __call__(self, byte_string: bytes):
         return self.encode(byte_string)

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -22,8 +22,8 @@ except ImportError:
 
 
 class MockTokenizer(Tokenizer):
-    def __init__(self, tokens: Sequence[bytes]):
-        super().__init__(tokens, chat_template=None, bos_token_id=0, eos_token_id=0)
+    def __init__(self, tokens: Sequence[bytes], special_token_ids: Optional[list[int]] = None):
+        super().__init__(tokens, chat_template=None, bos_token_id=0, eos_token_id=0, special_token_ids=special_token_ids)
         self.byte_trie = cpp.ByteTrie(self.tokens, np.arange(len(self.tokens)))
 
     def encode(self, byte_string: bytes) -> list[int]:
@@ -238,7 +238,7 @@ class Mock(Model):
             all_bytes = [bytes([i]) for i in range(256)]
             tokens = [b"<s>"] + all_lc_pairs + all_bytes
 
-            tokenizer = MockTokenizer(tokens)
+            tokenizer = MockTokenizer(tokens, special_token_ids=[0])
             engine = MockEngine(tokenizer, byte_patterns, compute_log_probs, force)
 
         super().__init__(

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -76,11 +76,13 @@ class LlamaCppTokenizer(Tokenizer):
 
         # get the bytes strings for all the tokens
         tokens = []
+        special_token_ids = []
         for i in range(tokenizer.llama.n_vocab()):
             tok = tokenizer.llama.detokenize([i])  # note that detokenize returns bytes directly
             if tok == b"":
                 # get text rep of special tokens
                 tok = llama_cpp.llama_vocab_get_text(vocab, i)
+                special_token_ids.append(i)
             tokens.append(tok)
 
         # Chat Template logic
@@ -92,7 +94,7 @@ class LlamaCppTokenizer(Tokenizer):
                 chat_template = self._model_obj.metadata["tokenizer.chat_template"]
 
         super().__init__(
-            tokens, chat_template, tokenizer.llama.token_bos(), tokenizer.llama.token_eos()
+            tokens, chat_template, tokenizer.llama.token_bos(), tokenizer.llama.token_eos(), special_token_ids
         )
 
     def encode(self, byte_string: bytes) -> list[int]:

--- a/guidance/models/transformers/_engine.py
+++ b/guidance/models/transformers/_engine.py
@@ -83,6 +83,10 @@ class TransformersTokenizer(Tokenizer):
             chat_template,
             None if ignore_bos_token else transformers_tokenizer.bos_token_id,
             transformers_tokenizer.eos_token_id,
+            special_token_ids=[
+                token_id for (token_id, token) in transformers_tokenizer.added_tokens_decoder.items()
+                if token.special
+            ]
         )
 
     def _tokenizer(self, model: str, **kwargs) -> tuple[

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     "psutil",
     "tiktoken>=0.3",
     "guidance-stitch",
-    "llguidance==0.6.29",
+    "llguidance==0.6.30",
     "setuptools" # TODO - Remove before release, used for multimodal mocks in python 3.12
 ]
 


### PR DESCRIPTION
@mmoskal if we merge https://github.com/guidance-ai/llguidance/pull/131, this PR will ensure special tokens are properly merked in guidance tokenizers. Doing so ensures that no special tokens are generated inside of grammars like `gen()` and will only be generated when explicitly allowed.

Funny side note -- zero (additional) special handling is required to ensure that generating an end-of-message token causes a chat model to stop. We already have a condition (in guidance -- not llguidance) that takes care of this. Attempting to generate any token outside of the mask is allowed iff an EOS token is allowed and would terminate the grammar. Generating such a token is then interpreted as an EOS token. This condition may have to be revisited, but it's actually working really nicely for now..!