### PR TITLE
Fix subtle bug in OpenAI -- returning from a generator

### DIFF
--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -218,7 +218,7 @@ class OpenAIClient(Client[OpenAIState]):
                 is_append=node.list_append,
             )
         else:
-            return chunks
+            yield from chunks
 
     def regex(self, state: OpenAIState, node: RegexNode, **kwargs) -> Iterator[OutputAttr]:
         if node.regex is not None:


### PR DESCRIPTION
@Harsha-Nori merging because it's just a tiny hotfix, but I wanted to share the pain...

```
def foo():
    yield 42
```
```
def ok():
    yield from foo()
list(ok())
```
> [42]

ok
```
def yep():
    return foo()
list(yep())
```
> [42]

yep
```
def oh_no():
    if False:
        yield from foo()
    return foo()
list(oh_no())
```
> []

oh no