### PR TITLE
Raise exception when roles are used in stateless functions

### DIFF
--- a/guidance/_guidance.py
+++ b/guidance/_guidance.py
@@ -139,6 +139,7 @@ def _decorator(f, *, stateless, cache, model):
 
             # otherwise we call the function to generate the grammar
             else:
+                # set the stateless context variable so that others can detect that we're currently calling a stateless function
                 token = _in_stateless_context.set(True)
 
                 # set a RuleRefNode for recursive calls (only if we don't have arguments that might make caching a bad idea)
@@ -161,7 +162,9 @@ def _decorator(f, *, stateless, cache, model):
                     if no_args:
                         thread_local._self_call_reference_.set_target(rule)
                 finally:
+                    # Reset the stateless context back to the previous value
                     _in_stateless_context.reset(token)
+                    # Clean up the thread local reference
                     if no_args:
                         del thread_local._self_call_reference_
 

--- a/guidance/library/_block.py
+++ b/guidance/library/_block.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from typing import Optional, Union
 from .._ast import ASTNode, Function
 from ..models._base._model import _active_blocks
+from .._guidance import _in_stateless_context
 
 class Block:
     def __init__(self, name: Optional[str], opener: Union[str, Function, ASTNode], closer: Union[str, Function, ASTNode]):
@@ -12,6 +13,8 @@ class Block:
 
 @contextmanager
 def block(name=None, opener=None, closer=None):
+    if _in_stateless_context.get():
+        raise RuntimeError("Cannot use roles or other blocks when stateless=True")
     current_blocks = _active_blocks.get()
     new_block = Block(name=name, opener=opener, closer=closer)
     token = _active_blocks.set(current_blocks + (new_block,))

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -4,7 +4,7 @@ import gc
 import inspect
 
 import guidance
-from guidance import gen
+from guidance import gen, role
 
 def test_dedent_basic():
     """Test that dedent functionality in f-strings works across Python versions."""
@@ -465,3 +465,15 @@ class TestSignature:
                 pass
         obj = MyClass()
         assert inspect.signature(obj.guidance_method) == inspect.signature(obj.method)
+
+def test_roles_in_stateless():
+    """Test that roles are not allowed in stateless mode."""
+
+    @guidance(stateless=True)
+    def foo(lm):
+        with role("assistant"):
+            lm += gen()
+        return lm
+
+    with pytest.raises(RuntimeError, match="Cannot use roles or other blocks when stateless=True"):
+        foo()


### PR DESCRIPTION
@Harsha-Nori we currently do not respect role context managers inside of stateless guidance functions. Even worse, they fail silently! This PR introduces an exception that is raised if we detect that a role is being used in a stateless function.

In the future, we could actually stateless roles working properly, but for now, we should at least raise an exception to let the user know that they are doing something wrong.

Example traceback:
```
Cell In[2], line 3, in foo(lm)
      1 @guidance(stateless=True)
      2 def foo(lm):
----> 3     with assistant():
      4         lm += gen()
      5     return lm

File /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/contextlib.py:117, in _GeneratorContextManager.__enter__(self)
    115 del self.args, self.kwds, self.func
    116 try:
--> 117     return next(self.gen)
    118 except StopIteration:
    119     raise RuntimeError("generator didn't yield") from None

File ~/pkg/guidance-ai/guidance/library/_block.py:17, in block(name, opener, closer)
     14 @contextmanager
     15 def block(name=None, opener=None, closer=None):
     16     if _in_stateless_context.get():
---> 17         raise RuntimeError("Cannot use roles or other blocks when stateless=True")
     18     current_blocks = _active_blocks.get()
     19     new_block = Block(name=name, opener=opener, closer=closer)

RuntimeError: Cannot use roles or other blocks when stateless=True
```

Note that the `ContextVar` approach is both thread and async safe :)