### PR TITLE
[JSON] Modify test to stabilize property order

### DIFF
--- a/tests/unit/library/json/test_allOf.py
+++ b/tests/unit/library/json/test_allOf.py
@@ -380,10 +380,10 @@ class TestAllOf:
             },
             # additionalProperties in parent schema
             {
+                "properties": {"foo": {"maximum": 4}},
                 "allOf": [
                     {"properties": {"bar": {"maximum": 5}}, "additionalProperties": {"type": ["integer", "null"]}}
                 ],
-                "properties": {"foo": {"maximum": 4}},
                 "additionalProperties": {"minimum": 5},
             },
             # additionalProperties in allOf


### PR DESCRIPTION
Modifies a test to respect property order definition in https://github.com/guidance-ai/llguidance/pull/134

Previously, the "properties" keyword was given precedence over definitions in "allOf", but now we actually care about order. To give it precedence, it had to be moved earlier in the schema.