### PR TITLE
[BUG] Fix llamacpp token overflows

### DIFF
--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -77,11 +77,10 @@ class LlamaCppTokenizer(Tokenizer):
         tokens = []
         special_token_ids = []
         for i in range(tokenizer.llama.n_vocab()):
-            tok = tokenizer.llama.detokenize([i])  # note that detokenize returns bytes directly
-            if tok == b"":
-                # get text rep of special tokens
-                tok = llama_cpp.llama_vocab_get_text(vocab, i)
+            tok_attrs = tokenizer.llama.token_get_attr(i)
+            if tok_attrs & llama_cpp.LLAMA_TOKEN_ATTR_CONTROL:
                 special_token_ids.append(i)
+            tok = tokenizer.llama.detokenize([i], special=True)  # note that detokenize returns bytes directly
             tokens.append(tok)
 
         # Chat Template logic

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -70,7 +70,9 @@ def detokenize(tokenizer: "LlamaTokenizer", tokens: list[int], special: bool = F
             0,
             special
         )
-        assert abs(n) <= size
+        if n < 0:
+            raise ValueError(f"Error writing token {token} to buffer of size {size}. Error: {n}")
+        assert n <= size
         output += bytes(buffer[:n])
     # NOTE: Llama1 models automatically added a space at the start of the prompt
     # this line removes a leading space if the first token is a beginning of sentence token

--- a/guidance/models/llama_cpp/_llama_cpp.py
+++ b/guidance/models/llama_cpp/_llama_cpp.py
@@ -57,7 +57,7 @@ class _LlamaBatchContext:
                 self.batch = None
                 llama_batch_free(batch)
 
-def detokenize(tokenizer: "LlamaTokenizer", tokens: list[int], special: bool = False, size: int = 32) -> bytes:
+def detokenize(tokenizer: "LlamaTokenizer", tokens: list[int], special: bool, size: int) -> bytes:
     """Re-implementation of llama_cpp.LLamaTokenizer.detokenize that ditches the hard-coded size=32"""
     output = b""
     buffer = ctypes.create_string_buffer(size)
@@ -106,7 +106,7 @@ class LlamaCppTokenizer(Tokenizer):
             tok_attrs = tokenizer.llama.token_get_attr(i)
             if tok_attrs & llama_cpp.LLAMA_TOKEN_ATTR_CONTROL:
                 special_token_ids.append(i)
-            tok = detokenize(tokenizer, [i], special=True, size=128)
+            tok = detokenize(tokenizer, [i], special=True, size=256)
             tokens.append(tok)
 
         # Chat Template logic


### PR DESCRIPTION
Some *non-special* tokens return empty bytes when calling `tokenizer.llama.detokenize`. In all cases where this returned empty bytes, we called `llama_cpp.llama_vocab_get_text` and marked the token as special.

While this does return non-empty bytes, they are improperly encoded. E.g., for some models, this function returns `Ġ` (which is two bytes) in place of spaces (which are one byte). In some cases, tokens with 128 bytes were then incorrectly encoded with 256 bytes, overflowing an assertion in `llguidance`.

This PR includes a few fixes:
1. Detect special tokens by calling `tokenizer.llama.token_get_attr` instead of relying on `detokenize` returning empty bytes
2. Re-implement `detokenize`, replacing a hard-coded 32-byte buffer with a parameterized 128-byte buffer, fixing the issues with some non-special tokens returning empty bytes.
   - Side note, but the original implementation had an assertion that *should* have caught this error, but it fails to because it assumes that `llama_cpp` will never slice the buffer with negative indices. We should maybe submit a PR to `llama_cpp_python`.
3. Call `detokenize` with  `special=True` to get text for special tokens, avoiding calling `llama_vocab_get_text`.