### PR TITLE
[Hotfix] Only infer client_cls from model when it's a str

### DIFF
--- a/guidance/models/transformers/_engine.py
+++ b/guidance/models/transformers/_engine.py
@@ -386,8 +386,12 @@ class TransformersTokenizer(Tokenizer):
 class TransformersEngine(Engine):
     def __init__(
         self,
-        model,
-        tokenizer,
+        model: Union[str, "transformers_package.PreTrainedModel"],
+        tokenizer: Union[
+            "transformers_package.PreTrainedTokenizer",
+            "transformers_package.PreTrainedTokenizerFast",
+            None,
+        ],
         compute_log_probs: bool,
         chat_template=None,
         enable_backtrack=True,
@@ -409,8 +413,8 @@ class TransformersEngine(Engine):
 
         if not isinstance(model, str):
             try:
-                self.model = self.model_obj.config["_name_or_path"]
-            except KeyError:
+                self.model = self.model_obj.config._name_or_path
+            except AttributeError:
                 self.model = self.model_obj.__class__.__name__
         else:
             self.model = model
@@ -445,7 +449,7 @@ class TransformersEngine(Engine):
         super().__init__(my_tokenizer, compute_log_probs=compute_log_probs, enable_backtrack=enable_backtrack,
                          enable_ff_tokens=enable_ff_tokens, enable_monitoring=enable_monitoring, **kwargs)
 
-    def _model(self, model, **kwargs):
+    def _model(self, model, **kwargs) -> "transformers_package.PreTrainedModel":
         # intantiate the model if needed
         if isinstance(model, str):
 

--- a/guidance/models/transformers/_model.py
+++ b/guidance/models/transformers/_model.py
@@ -1,15 +1,24 @@
 import re
+from typing import Optional, TYPE_CHECKING, Union
 
 from .._base import Model
 from .._engine import EngineClient, EngineState, Llama3VisionClient, Phi3VisionClient
 from ._engine import TransformersEngine
 
 
+if TYPE_CHECKING:
+     from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast
+
 class Transformers(Model):
     def __init__(
         self,
-        model=None,
-        tokenizer=None,
+        model: Union[str, "PreTrainedModel"],
+        tokenizer: Union[
+            "PreTrainedTokenizer",
+            "PreTrainedTokenizerFast",
+            None,
+        ] = None,
+        client_cls: Optional[type[EngineClient]] = None,
         echo=True,
         compute_log_probs=False,
         chat_template=None,
@@ -19,12 +28,13 @@ class Transformers(Model):
         **kwargs,
     ):
         """Build a new Transformers model object that represents a model in a given state."""
-        if re.search("Llama-3.*-Vision", model):
-            client_cls = Llama3VisionClient
-        elif re.search("Phi-3-vision", model):
-            client_cls = Phi3VisionClient
-        else:
-            client_cls = EngineClient
+        if client_cls is None and isinstance(model, str):
+            if re.search("Llama-3.*-Vision", model):
+                client_cls = Llama3VisionClient
+            elif re.search("Phi-3-vision", model):
+                client_cls = Phi3VisionClient
+        if client_cls is None:
+                client_cls = EngineClient
 
         client = client_cls(
             TransformersEngine(


### PR DESCRIPTION
Currently, `main` does not support passing `AutoTokenizer`/`AutoModel` to the `Transformers` class (e.g. see https://github.com/guidance-ai/guidance/issues/1144).

This is because the `Client` class expected `model` to be passed as a string for the sake of inferring some capabilities of the model. Now there is an explicit `isinstance` check, as well as some additional type annotations to help prevent devs (me) from having the wrong mental model about types here.

For future: we should expand the capabilities check to be able to introspect on `AutoModel` classes / config files as well as looking at the raw string. Not in the scope of this PR though.

@paulbkoch ping for visibility as I know you're touching this part of the code too