### PR TITLE
[HOTFIX]: don't naively decode bytes with `ByteParser`

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ._schema import EngineOutput, GenData, EngineCallResponse, GenToken, LLInterpreterResponse
+from ._utils import to_utf8_or_bytes_string
 
 if TYPE_CHECKING:
     from .models._engine import Tokenizer
@@ -330,7 +331,7 @@ class ByteParser:
         fake_issued_token = GenToken(
             token_id=token_id,
             prob=1.0,
-            text=self.tokenizer.decode([token_id]).decode("utf-8"),
+            text=to_utf8_or_bytes_string(self.tokenizer.decode([token_id])),
             latency_ms=0,
             is_generated=True,
         )

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -306,7 +306,7 @@ class LlamaCppEngine(Engine):
         _bytes = self.tokenizer.decode([token_ids[0]])
         try:
             _text = _bytes.decode("utf-8")
-        except Exception as e:
+        except UnicodeDecodeError as e:
             _text = str(_bytes)
             print(f"Failed to decode token: {token_ids[0]}, error: {e}, _bytes: {str(_bytes)}")
         text_sequence.append(
@@ -332,7 +332,7 @@ class LlamaCppEngine(Engine):
                 _text = ""
                 try:
                     _text = self.tokenizer.decode([_token_id]).decode("utf-8")
-                except Exception as e:
+                except UnicodeDecodeError as e:
                     _bytes = self.tokenizer.decode([_token_id])
                     _text = str(_bytes)
                     print(


### PR DESCRIPTION
Mostly just affects experimental vLLM model that runs a tokenizer-naive parser client-side