### PR TITLE
[HOTFIX] Refactor `ByteParser.consume_bytes` to use a sequential loop

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -234,26 +234,14 @@ class ByteParser:
         self.bytes += response.new_bytes
 
     def consume_bytes(self, bts: bytes) -> None:
-        if not bts:
-            return
+        for b in bts:
+            self.consume_byte(b)
 
-        b = bts[0]
+    def consume_byte(self, b: int) -> None:
         # If the current position is less than the length of the bytes, then we are in fast_forward mode
         # and we need to make sure that the byte we are consuming is the same as the byte at the current
         # position
-        if self.pos < len(self.bytes):
-            if b != self.bytes[self.pos]:
-                next_byte = self.bytes[self.pos : self.pos + 1]
-                raise ByteParserException(
-                    f"Expected byte {next_byte!r} (fast_forward), got {bytes([b])!r}",
-                    current_byte=bytes([b]),
-                    allowed_bytes={next_byte},
-                    consumed_bytes=self.bytes[: self.pos],
-                )
-            # Byte was good, move to the next byte
-            self.pos += 1
-            self.consume_bytes(bts[1:])
-        else:
+        if self.pos >= len(self.bytes):
             # If we are here, then we are either in generation mode or we are done.
             if self.gen_data is None:
                 # TODO: may run into trouble here if we need to backtrack
@@ -278,8 +266,17 @@ class ByteParser:
             fake_engine_output = self.fake_engine_output(b)
             self._advance(fake_engine_output)
 
-            # Run consume_bytes to advance ll_parser and consume the next byte
-            self.consume_bytes(bts)
+        assert self.pos < len(self.bytes)
+        if b != self.bytes[self.pos]:
+            next_byte = self.bytes[self.pos : self.pos + 1]
+            raise ByteParserException(
+                f"Expected byte {next_byte!r} (fast_forward), got {bytes([b])!r}",
+                current_byte=bytes([b]),
+                allowed_bytes={next_byte},
+                consumed_bytes=self.bytes[: self.pos],
+            )
+        # Byte was good, move to the next byte
+        self.pos += 1
 
     def force_done(self):
         if not self.matched():

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,4 +1,4 @@
-from guidance import one_or_more, select, string, zero_or_more, regex
+from guidance import one_or_more, select, string, zero_or_more, regex, string
 from guidance._parser import ByteParser
 
 
@@ -130,3 +130,9 @@ def test_string_utf8():
     parser.consume_bytes(b[:1])
     assert parser.valid_next_bytes() == set([b[1:]])
     parser.consume_bytes(b[1:])
+
+
+def test_long_fast_forward():
+    s = "x"*10_000
+    g = string(s)
+    assert g.match(s) is not None


### PR DESCRIPTION
Replaces the previous recursive implementation of `consume_bytes` with an iterative approach, preventing deep recursion for long fast-forwards. This improves performance and safety