### PR TITLE
[HOTFIX] Revert #1197

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -234,14 +234,26 @@ class ByteParser:
         self.bytes += response.new_bytes
 
     def consume_bytes(self, bts: bytes) -> None:
-        for b in bts:
-            self.consume_byte(b)
+        if not bts:
+            return
 
-    def consume_byte(self, b: int) -> None:
+        b = bts[0]
         # If the current position is less than the length of the bytes, then we are in fast_forward mode
         # and we need to make sure that the byte we are consuming is the same as the byte at the current
         # position
-        if self.pos >= len(self.bytes):
+        if self.pos < len(self.bytes):
+            if b != self.bytes[self.pos]:
+                next_byte = self.bytes[self.pos : self.pos + 1]
+                raise ByteParserException(
+                    f"Expected byte {next_byte!r} (fast_forward), got {bytes([b])!r}",
+                    current_byte=bytes([b]),
+                    allowed_bytes={next_byte},
+                    consumed_bytes=self.bytes[: self.pos],
+                )
+            # Byte was good, move to the next byte
+            self.pos += 1
+            self.consume_bytes(bts[1:])
+        else:
             # If we are here, then we are either in generation mode or we are done.
             if self.gen_data is None:
                 # TODO: may run into trouble here if we need to backtrack
@@ -266,17 +278,8 @@ class ByteParser:
             fake_engine_output = self.fake_engine_output(b)
             self._advance(fake_engine_output)
 
-        assert self.pos < len(self.bytes)
-        if b != self.bytes[self.pos]:
-            next_byte = self.bytes[self.pos : self.pos + 1]
-            raise ByteParserException(
-                f"Expected byte {next_byte!r} (fast_forward), got {bytes([b])!r}",
-                current_byte=bytes([b]),
-                allowed_bytes={next_byte},
-                consumed_bytes=self.bytes[: self.pos],
-            )
-        # Byte was good, move to the next byte
-        self.pos += 1
+            # Run consume_bytes to advance ll_parser and consume the next byte
+            self.consume_bytes(bts)
 
     def force_done(self):
         if not self.matched():

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,4 +1,5 @@
-from guidance import one_or_more, select, string, zero_or_more, regex
+import pytest
+from guidance import one_or_more, select, string, zero_or_more, regex, string
 from guidance._parser import ByteParser
 
 
@@ -130,3 +131,12 @@ def test_string_utf8():
     parser.consume_bytes(b[:1])
     assert parser.valid_next_bytes() == set([b[1:]])
     parser.consume_bytes(b[1:])
+
+
+@pytest.mark.xfail(
+    reason="This test is expected to fail because the parser's recursive implementation does not handle long strings well."
+)
+def test_long_fast_forward():
+    s = "x"*10_000
+    g = string(s)
+    assert g.match(s) is not None

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,4 +1,4 @@
-from guidance import one_or_more, select, string, zero_or_more, regex, string
+from guidance import one_or_more, select, string, zero_or_more, regex
 from guidance._parser import ByteParser
 
 
@@ -130,9 +130,3 @@ def test_string_utf8():
     parser.consume_bytes(b[:1])
     assert parser.valid_next_bytes() == set([b[1:]])
     parser.consume_bytes(b[1:])
-
-
-def test_long_fast_forward():
-    s = "x"*10_000
-    g = string(s)
-    assert g.match(s) is not None

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from guidance import one_or_more, select, string, zero_or_more, regex, string
 from guidance._parser import ByteParser
@@ -137,6 +138,8 @@ def test_string_utf8():
     reason="This test is expected to fail because the parser's recursive implementation does not handle long strings well."
 )
 def test_long_fast_forward():
+    if sys.platform == "win32":
+        pytest.skip("Skipping long fast forward test on Windows to avoid stack overflow")
     s = "x"*10_000
     g = string(s)
     assert g.match(s) is not None


### PR DESCRIPTION
This reverts commit 0d7f55c11917242a8319d1ec11b35c16243efeb2. The sequential loop introduced an exception when matching grammars with backtracks. A proper solution will be a bit bigger than a hotfix, so punting on that for now and opening a tracking issue, #1198