### PR TITLE
[BUGFIX] Dynamically determine llamacpp sentinel token for stripping leading tokenizer whitespace

### DIFF
--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -105,10 +105,10 @@ class LlamaCppTokenizer(Tokenizer):
             tok = detokenize(tokenizer, [i], special=True, size=256)
             tokens.append(tok)
 
-        # Search for a byte string that doesn't prefix more than one token
+        # Search for a byte string that prefixes exactly one token
         first_byte_counts = Counter(tok[0:1] for tok in tokens)
         for candidate in (b"\x00", b"\x01", b"\x02", b"\x03"):
-            if first_byte_counts[candidate] <= 1:
+            if first_byte_counts[candidate] == 1:
                 self._sentinel_bytes = candidate
                 break
         else:

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -134,7 +134,10 @@ class LlamaCppTokenizer(Tokenizer):
         raw_tokens = self._model_obj.tokenize(
             self._sentinel_bytes + byte_string, add_bos=False, special=True
         )
-        assert raw_tokens[: len(self._sentinel_tokens)] == self._sentinel_tokens
+        if raw_tokens[: len(self._sentinel_tokens)] != self._sentinel_tokens:
+            raise ValueError(
+                f"Failed to tokenize {byte_string} using sentinel bytes {self._sentinel_bytes}."
+            )
         return raw_tokens[len(self._sentinel_tokens) :]
 
 

--- a/tests/unit/test_ll.py
+++ b/tests/unit/test_ll.py
@@ -20,7 +20,7 @@ from guidance.library._subgrammar import subgrammar, lexeme
 log_level = 10
 
 
-class PhiTokenizer:
+class PhiTokenizer(guidance.models.TransformersTokenizer):
     _ll_tokenizer = None
     _instance = None
 
@@ -38,34 +38,11 @@ class PhiTokenizer:
             )
         return PhiTokenizer._ll_tokenizer
 
-    def tokenize_str(self, s: str) -> List[int]:
-        return self.hf_tokenizer.encode(s).ids
-
     def __init__(self) -> None:
-        import tokenizers
-        self.hf_tokenizer: tokenizers.Tokenizer = tokenizers.Tokenizer.from_pretrained(
-            "microsoft/Phi-3-mini-128k-instruct"
-        )
-        empty = self.tokenize_str("")
-        if empty:
-            self.bos_token_id = empty[0]
-        else:
-            self.bos_token_id = None
-        eos = self.tokenize_str("</s>")
-        assert len(eos) == 1
-        self.eos_token_id = eos[0]
-        self.tokens = []
-        for i in range(self.hf_tokenizer.get_vocab_size()):
-            t: str = self.hf_tokenizer.id_to_token(i)
-            if t.startswith("<0x"):
-                self.tokens.append(bytes([int(t[3:5], 16)]))
-            else:
-                t = t.replace("▁", " ")
-                self.tokens.append(t.encode("utf-8"))
-        assert len(self.tokens) == self.hf_tokenizer.get_vocab_size()
+        super().__init__("microsoft/Phi-3-mini-128k-instruct", None)
 
-    def __call__(self, s):
-        return self.tokenize_str(s)
+    def tokenize_str(self, s: str) -> List[int]:
+        return self.encode(s.encode("utf-8"))
 
 
 def check_eq(label: str, tokens: List[int], expected_tokens: str):


### PR DESCRIPTION
The tokenizer for gemma 3 has several tokens that are prefixed by `\x02`, causing our hard-coded `\x02` sentinel byte to fail. Just trying a few more candidates