### PR TITLE
[Test] Bump dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 llamacpp_requires = ["llama-cpp-python==0.3.9"]
-transformers_requires = ["transformers==4.48.2"]
+transformers_requires = ["transformers==4.51.3"]
 
 install_requires = [
     "numpy",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-llamacpp_requires = ["llama-cpp-python==0.3.7"]
+llamacpp_requires = ["llama-cpp-python==0.3.9"]
 transformers_requires = ["transformers==4.48.2"]
 
 install_requires = [


### PR DESCRIPTION
Now that we're in a new cycle, try bumping the versions of `transformers` and `llama-cpp-python` we use in testing.