### PR TITLE
[HOTFIX] Resolve logger warnings

### DIFF
--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -183,7 +183,7 @@ class LlamaCppEngine(Engine):
             try:
                 sys.stdout.fileno()
             except:
-                logger.warn(
+                logger.warning(
                     "Cannot use verbose=True in this context (probably CoLab). See https://github.com/abetlen/llama-cpp-python/issues/729"
                 )
                 kwargs["verbose"] = True  # llama-cpp-python can't hide output in this case


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
