### PR TITLE
[Refactor] Use `llguidance`'s native wrapper for `transformers.PretrainedTokenizerFast` where possible

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -38,7 +38,7 @@ class TokenParser:
         enable_ff_tokens: bool = True,
     ):
         self.tokenizer = tokenizer
-        self.ll_tokenizer = llguidance.LLTokenizer(llguidance.TokenizerWrapper(tokenizer))
+        self.ll_tokenizer = tokenizer._ll_tokenizer
         self.ll_interpreter = llguidance.LLInterpreter(
             self.ll_tokenizer,
             grammar,

--- a/guidance/models/_byte_tokenizer.py
+++ b/guidance/models/_byte_tokenizer.py
@@ -1,5 +1,6 @@
 import numpy as np
 from ._engine import Tokenizer
+from ._engine._tokenizer import TokenizerWrappable
 from ..chat import load_template_class
 from typing import List
 
@@ -9,8 +10,20 @@ class ByteTokenizer(Tokenizer):
         all_bytes = [bytes([i]) for i in range(256)]
         bos = b"<s>"
         tokens = np.array(all_bytes + [bos], dtype="object")
-        chat_template = load_template_class(chat_template)
-        super().__init__(tokens, chat_template, bos_token_id=256)
+        ll_tokenizer = TokenizerWrappable(
+            eos_token_id=256,
+            bos_token_id=256,
+            tokens=tokens,
+            special_token_ids=[],
+            # ENCODE MUST BE OVERRIDDEN
+            encode_callable=self.encode,
+        ).as_ll_tokenizer()
+
+        super().__init__(
+            ll_tokenizer=ll_tokenizer,
+            chat_template=chat_template,
+            bos_token_id=256,
+        )
 
     def encode(self, byte_string: bytes) -> List[int]:
         """Returns a list of tokens that represent the given byte string."""

--- a/guidance/models/_engine/_tokenizer.py
+++ b/guidance/models/_engine/_tokenizer.py
@@ -1,12 +1,29 @@
-from typing import Any, Dict, Optional, Sequence, Union
-from abc import ABC, abstractmethod
+from typing import Any, Optional, Sequence, Union, Callable
+from dataclasses import dataclass
+from functools import cached_property
 
-import numpy as np
 
 from ...chat import ChatTemplate, load_template_class
+import llguidance
 
+@dataclass
+class TokenizerWrappable:
+    eos_token_id: int
+    bos_token_id: Optional[int]
+    tokens: list[bytes]
+    special_token_ids: list[int]
+    encode_callable: Callable[[bytes], list[int]]
 
-class Tokenizer(ABC):
+    def __call__(self, byte_string: bytes) -> list[int]:
+        return self.encode_callable(byte_string)
+
+    def as_ll_tokenizer(self) -> "llguidance.LLTokenizer":
+        """Returns an LLTokenizer that can be used by llguidance."""
+        return llguidance.LLTokenizer(
+            llguidance.TokenizerWrapper(self)
+        )
+
+class Tokenizer:
     """This is the standardized tokenizer interface used by guidance models.
 
     This class should be subclassed by specific implementations and then used as the
@@ -15,85 +32,50 @@ class Tokenizer(ABC):
 
     def __init__(
         self,
-        tokens: Union[Sequence[bytes], np.ndarray],
+        ll_tokenizer: llguidance.LLTokenizer,
         chat_template: Union[str, ChatTemplate, None],
         bos_token_id: Optional[int] = None,
-        eos_token_id: Optional[int] = None,
-        special_token_ids: Optional[list[int]] = None,
     ):
-
-        # a numpy array of token byte strings indexed by their token id
-        if isinstance(tokens, list):
-            # note that we need np.bytes_ so zero bytes are not treated as null terminations
-            self._tokens = np.array(tokens, dtype="object")
-
-        # a numpy array of token byte strings indexed by their token id
-        elif isinstance(tokens, np.ndarray):
-            self._tokens = tokens
-
-        else:
-            raise ValueError("Unknown tokenizer was passed!")
-
-        assert isinstance(self.tokens[0], bytes), "The tokens need to be provided as bytes!"
-
+        self._ll_tokenizer = ll_tokenizer
         # This method supports None, a huggingface style jinja2_template_str, or a ChatTemplate subclass
         # Defaults to ChatML if nothing is found
         self._chat_template = load_template_class(chat_template)
-
         self._bos_token_id = bos_token_id
-        self._bos_token = None if self.bos_token_id is None else self.tokens[self.bos_token_id]
-        self._eos_token_id = eos_token_id if eos_token_id is not None else bos_token_id
-        self._eos_token = None if self.eos_token_id is None else self.tokens[self.eos_token_id]
-
-        self._special_token_ids = special_token_ids or []
-
-        # track which tokens are duplicates
-        self._duplicate_tokens = []
-        found: Dict[bytes, int] = {}
-        for i, t in enumerate(self.tokens):
-            if t in found:
-                self._duplicate_tokens.append((i, found[t]))
-            else:
-                found[t] = i
-
-    @property
-    def tokens(self) -> np.ndarray:
-        return self._tokens
 
     @property
     def bos_token_id(self) -> Union[int, None]:
+        # Currently, lltokenizer does not have a bos_token attribute,
+        # so we have to store our own if we want to use it
         return self._bos_token_id
 
     @property
-    def eos_token_id(self) -> Union[int, None]:
-        return self._eos_token_id
+    def eos_token_id(self) -> int:
+        return self._ll_tokenizer.eos_token
 
-    @property
+    @cached_property
     def bos_token(self) -> Union[bytes, None]:
-        return self._bos_token
+        if self.bos_token_id is None:
+            return None
+        return self.decode([self.bos_token_id])
 
-    @property
-    def eos_token(self) -> Union[bytes, None]:
-        return self._eos_token
+    @cached_property
+    def eos_token(self) -> bytes:
+        return self.decode([self.eos_token_id])
 
     @property
     def chat_template(self) -> Union[Any, None]:
         return self._chat_template
 
-    @property
-    def special_token_ids(self) -> list[int]:
-        return self._special_token_ids
-
     def __call__(self, byte_string: bytes):
         return self.encode(byte_string)
 
-    @abstractmethod
     def encode(self, byte_string: bytes) -> list[int]:
         """Returns a list of tokens that represent the given byte string."""
+        return self._ll_tokenizer.tokenize_bytes(byte_string)
 
     def decode(self, tokens: Sequence[int]) -> bytes:
         """Returns the bytes represented by the given list of tokens."""
-        return b"".join([self.tokens[t] for t in tokens])
+        return self._ll_tokenizer.decode_bytes(list(tokens))
 
     def recode(self, tokens: Sequence[int]) -> list[int]:
         """Redoes a tokenization.

--- a/guidance/models/_engine/_tokenizer.py
+++ b/guidance/models/_engine/_tokenizer.py
@@ -1,11 +1,12 @@
 from typing import Any, Dict, Optional, Sequence, Union
+from abc import ABC, abstractmethod
 
 import numpy as np
 
 from ...chat import ChatTemplate, load_template_class
 
 
-class Tokenizer:
+class Tokenizer(ABC):
     """This is the standardized tokenizer interface used by guidance models.
 
     This class should be subclassed by specific implementations and then used as the
@@ -86,35 +87,27 @@ class Tokenizer:
     def __call__(self, byte_string: bytes):
         return self.encode(byte_string)
 
+    @abstractmethod
     def encode(self, byte_string: bytes) -> list[int]:
         """Returns a list of tokens that represent the given byte string."""
-        raise NotImplementedError(
-            "You need to use a Tokenize subclass that overrides the encode method"
-        )
 
     def decode(self, tokens: Sequence[int]) -> bytes:
         """Returns the bytes represented by the given list of tokens."""
         return b"".join([self.tokens[t] for t in tokens])
 
     def recode(self, tokens: Sequence[int]) -> list[int]:
-        """Redoes a tokenisation.
+        """Redoes a tokenization.
 
         Encoding a string into tokens does not distribute over concatenation.
         That is, in general, `encode(A)+encode(B) != encode(A+B)` (although it
         it may in some cases).
         An LLM will generate token-by-token, but it is possible (even likely) that
-        when the generation is considered as a whole, a better tokenisation may
+        when the generation is considered as a whole, a better tokenization may
         be possible.
         This method takes in a sequence of tokens, and returns an 'improved' sequence.
         """
 
-        # This is the notional behaviour
+        # This is the notional behavior
         # It may need to be overridden in particular cases because
         # we are dealing with LLM ecosystems in the real world
         return self.encode(self.decode(tokens))
-
-    def clean_duplicate_tokens(self, probs):
-        """This moves all the probability mass from duplicate positons on to their primary index."""
-        for i, j in self._duplicate_tokens:
-            probs[j] += probs[i]
-            probs[i] = 0

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -208,12 +208,11 @@ class LlamaCppEngine(Engine):
 
         self._context = _LlamaBatchContext(self.model_obj.n_batch, self.model_obj.n_ctx())
         self._cache_token_ids = []
+        self._n_vocab = len(self.model_obj.n_vocab())
 
         super().__init__(LlamaCppTokenizer(self.model_obj, chat_template=chat_template),
                          compute_log_probs=compute_log_probs, enable_backtrack=enable_backtrack,
                          enable_ff_tokens=enable_ff_tokens, enable_monitoring=enable_monitoring, **kwargs)
-
-        self._n_vocab = len(self.tokenizer.tokens)
 
     def get_logits(self, token_ids):
         """Computes the logits for the given token state.

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -208,7 +208,7 @@ class LlamaCppEngine(Engine):
 
         self._context = _LlamaBatchContext(self.model_obj.n_batch, self.model_obj.n_ctx())
         self._cache_token_ids = []
-        self._n_vocab = len(self.model_obj.n_vocab())
+        self._n_vocab = self.model_obj.n_vocab()
 
         super().__init__(LlamaCppTokenizer(self.model_obj, chat_template=chat_template),
                          compute_log_probs=compute_log_probs, enable_backtrack=enable_backtrack,

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -3,7 +3,6 @@ import re
 import textwrap
 import warnings
 from typing import TYPE_CHECKING, Optional, Union, cast
-import llguidance.hf
 
 from .._schema import GenToken, GenTokenExtra
 from ..chat import ChatTemplate
@@ -22,6 +21,8 @@ try:
     has_transformers = True
 except ModuleNotFoundError:
     has_transformers = False
+else:
+    import llguidance.hf
 
 if TYPE_CHECKING:
      from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -2,11 +2,13 @@ import os
 import re
 import textwrap
 import warnings
-from typing import TYPE_CHECKING, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Union, cast
+import llguidance.hf
 
 from .._schema import GenToken, GenTokenExtra
 from ..chat import ChatTemplate
-from ._engine import Engine, Tokenizer, EngineInterpreter, EngineState, Llama3VisionInterpreter, Phi3VisionInterpreter
+from ._engine import Engine, Tokenizer, EngineInterpreter, Llama3VisionInterpreter, Phi3VisionInterpreter
+from ._engine._tokenizer import TokenizerWrappable
 from ._base import Model
 
 try:
@@ -49,92 +51,84 @@ class ByteTokensError(Exception):
 class TransformersTokenizer(Tokenizer):
     def __init__(
         self,
-        model: Union[str, "PreTrainedModel"],
-        transformers_tokenizer: Union[
-            "PreTrainedTokenizer",
-            "PreTrainedTokenizerFast",
-            None,
-        ],
+        hf_tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
         chat_template: Union[str, ChatTemplate, None] = None,
-        ignore_bos_token: bool = False,
-        **kwargs,
-    ):
-        if transformers_tokenizer is None:
-            if isinstance(model, str):
-                transformers_tokenizer, byte_tokens = self._tokenizer(model, **kwargs)
-            else:
-                raise ValueError(
-                    "A model object was passed in, but no tokenizer was provided. Please provide a tokenizer."
-                )
-        else:
-            is_ptt = isinstance(transformers_tokenizer, transformers_package.PreTrainedTokenizer)
-            is_ptt_fast = isinstance(
-                transformers_tokenizer, transformers_package.PreTrainedTokenizerFast
+    ) -> "TransformersTokenizer":
+        self._orig_tokenizer = hf_tokenizer
+
+        if isinstance(hf_tokenizer, transformers_package.PreTrainedTokenizerFast):
+            ll_tokenizer = llguidance.hf.from_tokenizer(
+                hf_tokenizer=hf_tokenizer,
             )
-            assert is_ptt or is_ptt_fast
-            byte_tokens = self._byte_tokens(transformers_tokenizer)
+        else:
+            byte_tokens = self._byte_tokens(hf_tokenizer)
+            ll_tokenizer = TokenizerWrappable(
+                eos_token_id=hf_tokenizer.bos_token_id, # type: ignore[attr-defined]
+                bos_token_id=hf_tokenizer.eos_token_id, # type: ignore[attr-defined]
+                tokens=byte_tokens,
+                special_token_ids=[
+                    token_id for (token_id, token) in hf_tokenizer.added_tokens_decoder.items()
+                    if token.special
+                ],
+                encode_callable=hf_tokenizer.encode,
+            ).as_ll_tokenizer()
 
-        self._orig_tokenizer = transformers_tokenizer
-
-        # Chat Template logic
-        if chat_template is None and hasattr(self._orig_tokenizer, "chat_template"):
-            chat_template = self._orig_tokenizer.chat_template
-
-        # the superclass does most of the work once we have the tokens
         super().__init__(
-            byte_tokens,
-            chat_template,
-            None if ignore_bos_token else transformers_tokenizer.bos_token_id,
-            transformers_tokenizer.eos_token_id,
-            special_token_ids=[
-                token_id for (token_id, token) in transformers_tokenizer.added_tokens_decoder.items()
-                if token.special
-            ]
+            ll_tokenizer=ll_tokenizer,
+            chat_template=chat_template,
+            bos_token_id=hf_tokenizer.bos_token_id,  # type: ignore[attr-defined]
         )
 
-    def _tokenizer(self, model: str, **kwargs) -> tuple[
-        Union[
-            "PreTrainedTokenizer",
-            "PreTrainedTokenizerFast",
-        ],
-        list[bytes],
-    ]:
-        # make sure transformers is installed
-        if not has_transformers:
-            raise ImportError("Please install transformers with `pip install transformers`")
-
-        try:
-            tokenizer = transformers_package.AutoTokenizer.from_pretrained(
-                model, use_fast=False, **kwargs
-            )
-            byte_tokens = self._byte_tokens(tokenizer)
-        except ImportError:
-            # Raise on ImportError because it's likely a missing dependency that the user can install
-            raise
-        except ByteTokensError as e:
-            # Give a specific warning for ByteTokensError and fall back to fast tokenizer
-            warnings.warn(
-                f"Falling back to fast tokenizer. Could not build byte tokens for model {model!r} due to exception {e.__class__.__name__}: {e}"
-            )
-        except Exception as e:
-            # Fall back for other exceptions
-            warnings.warn(
-                f"Falling back to fast tokenizer. Could not load tokenizer for model {model!r} due to exception {e.__class__.__name__}: {e}"
-            )
-        else:
-            return tokenizer, byte_tokens
-
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        chat_template: Union[str, ChatTemplate, None] = None,
+        use_fast=True,
+        **kwargs
+    ) -> "TransformersTokenizer":
         tokenizer = transformers_package.AutoTokenizer.from_pretrained(
-            model, use_fast=True, **kwargs
+            pretrained_model_name_or_path,
+            use_fast=use_fast,
+            **kwargs
         )
-        try:
-            byte_tokens = self._byte_tokens(tokenizer)
-        except ByteTokensError as e:
-            raise ValueError(f"Fallback to fast tokenizer failed for model {model!r}") from e
-        return tokenizer, byte_tokens
+        return cls(
+            hf_tokenizer=tokenizer,
+            chat_template=chat_template,
+        )
 
+
+    def recode(self, tokens: list[int]) -> list[int]:
+        # the encode/decode cycle might not work if we have partial unicode strings
+        used_tokens = len(tokens)
+        for _ in range(3):
+            try:
+                first_decode = self.decode(tokens).decode("utf8")
+            except UnicodeDecodeError:
+                if used_tokens == 0:
+                    break
+                else:
+                    used_tokens -= 1
+
+        new_ids = list(self.encode(first_decode.encode("utf-8")))
+        if used_tokens < len(tokens):
+            new_ids += tokens[used_tokens:]
+
+        # HACK: check for a bug in the HuggingFace tokenizer
+        # (that will just add extra spaces during an encode-decode cycle)
+        second_decode = self._orig_tokenizer.decode(new_ids)
+        if (
+            second_decode != first_decode
+            and len(second_decode) == len(first_decode) + 1
+            and second_decode.startswith("<s>  ")
+        ):
+            new_ids = new_ids[0:1] + new_ids[2:]
+
+        return new_ids
+
+    @classmethod
     def _byte_tokens(
-        self,
+        cls,
         transformers_tokenizer: Union[
             "PreTrainedTokenizer",
             "PreTrainedTokenizerFast",
@@ -143,7 +137,7 @@ class TransformersTokenizer(Tokenizer):
 
         if hasattr(transformers_tokenizer, "byte_decoder"):
             try:
-                self._check_byte_decoder(
+                cls._check_byte_decoder(
                     transformers_tokenizer.byte_decoder, transformers_tokenizer
                 )
             except ByteDecoderError as e:
@@ -152,33 +146,34 @@ class TransformersTokenizer(Tokenizer):
                 )
                 pass
             else:
-                return self._byte_tokens_from_byte_decoder(
+                return cls._byte_tokens_from_byte_decoder(
                     transformers_tokenizer.byte_decoder, transformers_tokenizer
                 )
 
         if hasattr(transformers_tokenizer, "sp_model"):
-            return self._byte_tokens_from_sp_model(transformers_tokenizer)
+            return cls._byte_tokens_from_sp_model(transformers_tokenizer)
 
         try:
-            return self._byte_tokens_by_encoding_token_strings(transformers_tokenizer)
+            return cls._byte_tokens_by_encoding_token_strings(transformers_tokenizer)
         except ValueError as e:
             warnings.warn(
                 f"Could not build_byte tokens from the tokenizer by encoding token strings: {e}"
             )
             pass
 
-        fallback_byte_decoder = self._fallback_byte_decoder()
+        fallback_byte_decoder = cls._fallback_byte_decoder()
         try:
-            self._check_byte_decoder(fallback_byte_decoder, transformers_tokenizer)
+            cls._check_byte_decoder(fallback_byte_decoder, transformers_tokenizer)
         except ByteDecoderError as e:
             # Should be the only exception that is raised in _byte_tokens
             raise ByteTokensError(
                 "Could not build byte tokens from the tokenizer, and falling back to a standard gpt2 byte_decoder failed"
             ) from e
-        return self._byte_tokens_from_byte_decoder(fallback_byte_decoder, transformers_tokenizer)
+        return cls._byte_tokens_from_byte_decoder(fallback_byte_decoder, transformers_tokenizer)
 
+    @classmethod
     def _byte_tokens_from_byte_decoder(
-        self,
+        cls,
         byte_decoder: dict[str, int],
         transformers_tokenizer: Union[
             "PreTrainedTokenizer",
@@ -193,8 +188,9 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
+    @classmethod
     def _byte_tokens_from_sp_model(
-        self,
+        cls,
         transformers_tokenizer: Union[
             "PreTrainedTokenizer",
             "PreTrainedTokenizerFast",
@@ -217,8 +213,9 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded.replace(space_prefix, b" ")
         return byte_tokens
 
+    @classmethod
     def _byte_tokens_by_encoding_token_strings(
-        self,
+        cls,
         transformers_tokenizer: Union[
             "PreTrainedTokenizer",
             "PreTrainedTokenizerFast",
@@ -228,7 +225,7 @@ class TransformersTokenizer(Tokenizer):
         special_tokens_map = {
             id: token for token, id in transformers_tokenizer.get_added_vocab().items()
         }
-        byte_encoder = self._bytes_to_unicode()
+        byte_encoder = cls._bytes_to_unicode()
         byte_decoder = {v: k for k, v in byte_encoder.items()}
 
         for i in range(len(transformers_tokenizer)):
@@ -258,7 +255,8 @@ class TransformersTokenizer(Tokenizer):
             byte_tokens[i] = byte_coded
         return byte_tokens
 
-    def _fallback_byte_decoder(self) -> dict[str, int]:
+    @classmethod
+    def _fallback_byte_decoder(cls) -> dict[str, int]:
         byte_decoder = transformers_package.AutoTokenizer.from_pretrained(
             "gpt2", use_fast=False
         ).byte_decoder  # fall back to gpt2 mapping
@@ -272,8 +270,9 @@ class TransformersTokenizer(Tokenizer):
 
         return byte_decoder
 
+    @classmethod
     def _check_byte_decoder(
-        self,
+        cls,
         byte_decoder: dict[str, int],
         transformers_tokenizer: Union[
             "PreTrainedTokenizer",
@@ -332,7 +331,8 @@ class TransformersTokenizer(Tokenizer):
         check_byte_decoder_has_all_bytes()
         check_byte_decoder_complex_round_trip()
 
-    def _bytes_to_unicode(self):
+    @classmethod
+    def _bytes_to_unicode(cls):
         bs = (
             list(range(ord("!"), ord("~") + 1))
             + list(range(ord("¡"), ord("¬") + 1))
@@ -347,45 +347,6 @@ class TransformersTokenizer(Tokenizer):
                 n += 1
         cs = [chr(n) for n in cs]
         return dict(zip(bs, cs))
-
-    def encode(self, byte_string: bytes) -> list[int]:
-        assert isinstance(byte_string, bytes)
-        # HF tokenizers take in strings apparently
-        tokenization = self._orig_tokenizer(byte_string.decode(), add_special_tokens=False)
-        return tokenization["input_ids"]
-
-    def decode(self, tokens: Sequence[int]) -> bytes:
-        decoded_str = self._orig_tokenizer.decode(tokens)
-        return decoded_str.encode()
-
-    def recode(self, tokens: Sequence[int]) -> list[int]:
-        # the encode/decode cycle might not work if we have partial unicode strings
-        used_tokens = len(tokens)
-        for _ in range(3):
-            try:
-                first_decode = self.decode(tokens).decode("utf8")
-            except UnicodeDecodeError:
-                if used_tokens == 0:
-                    break
-                else:
-                    used_tokens -= 1
-
-        new_ids = list(self.encode(first_decode.encode("utf-8")))
-        if used_tokens < len(tokens):
-            new_ids += tokens[used_tokens:]
-
-        # HACK: check for a bug in the HuggingFace tokenizer
-        # (that will just add extra spaces during an encode-decode cycle)
-        second_decode = self._orig_tokenizer.decode(new_ids)
-        if (
-            second_decode != first_decode
-            and len(second_decode) == len(first_decode) + 1
-            and second_decode.startswith("<s>  ")
-        ):
-            new_ids = new_ids[0:1] + new_ids[2:]
-
-        return new_ids
-
 
 class TransformersEngine(Engine):
     def __init__(
@@ -446,12 +407,35 @@ class TransformersEngine(Engine):
                 passed_common_kwargs[arg_name] = kwargs[arg_name]
 
         # Create the tokenizer
+        if tokenizer is None:
+            if isinstance(model, str):
+                # Note: prioritize the fast tokenizer if available
+                tokenizer = cast(
+                    Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
+                    transformers_package.AutoTokenizer.from_pretrained(
+                        pretrained_model_name_or_path=model,
+                        use_fast=True,
+                        **kwargs
+                    )
+                )
+            else:
+                raise ValueError(
+                    "If no tokenizer is provided, a model name must be provided to load the tokenizer."
+                )
         my_tokenizer = TransformersTokenizer(
-            model, tokenizer, chat_template, **passed_common_kwargs
+            hf_tokenizer=tokenizer,
+            chat_template=chat_template,
         )
+        self._orig_tokenizer = tokenizer
 
-        super().__init__(my_tokenizer, compute_log_probs=compute_log_probs, enable_backtrack=enable_backtrack,
-                         enable_ff_tokens=enable_ff_tokens, enable_monitoring=enable_monitoring, **kwargs)
+        super().__init__(
+            tokenizer=my_tokenizer,
+            compute_log_probs=compute_log_probs,
+            enable_backtrack=enable_backtrack,
+            enable_ff_tokens=enable_ff_tokens,
+            enable_monitoring=enable_monitoring,
+            **kwargs
+        )
 
     def _model(self, model, **kwargs) -> "PreTrainedModel":
         # intantiate the model if needed
@@ -610,7 +594,7 @@ class TransformersEngine(Engine):
             cache_token_ids.extend(new_token_ids)
             # Need to add special truncating logic here for weird models that have a different output size than tokenizer vocab
             self._cached_logits = (
-                model_out.logits[0, -1, : len(self.tokenizer.tokens)].float().cpu().numpy()
+                model_out.logits[0, -1, : self._orig_tokenizer.vocab_size].float().cpu().numpy()
             )
             self.metrics.engine_input_tokens += len(new_token_ids)
             self.metrics.engine_output_tokens += 1
@@ -620,7 +604,7 @@ class TransformersEngine(Engine):
     def get_per_token_topk_probs(
         self, token_ids: list[int], top_k: int = 5
     ) -> list[GenTokenExtra]:
-        tokenizer = self.tokenizer._orig_tokenizer
+        tokenizer = self._orig_tokenizer
 
         # NOTE (loc) - assume batch size of 1
         input_ids = torch.tensor(token_ids).unsqueeze(0).long().to(self.device)

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -5,6 +5,7 @@ import warnings
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from .._schema import GenToken, GenTokenExtra
+from ..chat import ChatTemplate
 from ._engine import Engine, Tokenizer, EngineInterpreter, EngineState, Llama3VisionInterpreter, Phi3VisionInterpreter
 from ._base import Model
 
@@ -54,8 +55,8 @@ class TransformersTokenizer(Tokenizer):
             "PreTrainedTokenizerFast",
             None,
         ],
-        chat_template=None,
-        ignore_bos_token=False,
+        chat_template: Union[str, ChatTemplate, None] = None,
+        ignore_bos_token: bool = False,
         **kwargs,
     ):
         if transformers_tokenizer is None:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "requests",
     "psutil",
     "guidance-stitch",
-    "llguidance==0.7.19",
+    "llguidance==0.7.22",
 ]
 
 # Our basic list of 'extras'

--- a/tests/tokenizer_common.py
+++ b/tests/tokenizer_common.py
@@ -16,14 +16,15 @@ TOKENIZER_ROUND_TRIP_STRINGS = [
 
 class BaseTestTransformerTokenizers:
     def base_smoke(self, model_name: str):
-        my_tok = models.TransformersTokenizer(
-            model=model_name, transformers_tokenizer=None, trust_remote_code=True
+        my_tok = models.TransformersTokenizer.from_pretrained(
+            model_name, trust_remote_code=True,
         )
         assert my_tok is not None
 
     def base_string_roundtrip(self, model_name: str, target_string: str):
-        my_tok = models.TransformersTokenizer(
-            model=model_name, transformers_tokenizer=None, trust_remote_code=True
+        my_tok = models.TransformersTokenizer.from_pretrained(
+            model_name,
+            trust_remote_code=True,
         )
 
         encoded = my_tok.encode(target_string.encode())


### PR DESCRIPTION
1. Refactors all tokenizers to wrap `llguidance.LLTokenizer` rather than constructing an `LLTokenizer` on the fly when we run the parser
2. Doing so allows each `Tokenizer` class to have control over how it constructs said `LLTokenizer`.
   - `TransformersTokenizer` is able to call `llguidance.hf.from_tokenizer` directly if we have a `transformers.PretrainedTokenizerFast`, bypassing the slow and error-prone preprocessing step of inferring `byte_tokens`
   - `TransformersTokenizer` falls back to the old approach for non-fast tokenizers
   - `LlamaCppTokenizer`, `MockTokenizer`, and `ByteTokenizer` all use the old approach (manually specifying a list of `byte_tokens`). They also implement their own `encode` methods, which are notably passed to the `LLTokenizer` that they wrap

Note that we may get a similar `llguidance.llamacpp.from_tokenizer` for a "native" cpp tokenizer at some point :)

P.S. this refactor may indicate that we actually want to get rid of the `Tokenizer` class all-together, simply using `LLTokenizer` in the `Engine`s. That felt a bit extreme at the moment though, so I decided to leave it as-is.