### PR TITLE
[Test] Add Phi-4

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -134,6 +134,7 @@ jobs:
           - "transformers_gemma2_9b_gpu"
           - "llamacpp_llama2_7b_gpu"
           - "transformers_gemma2_9b_cpu"  # CUDA is required for this model
+          - "transformers_phi4_mini_gpu"
     uses: ./.github/workflows/call_gpu_tests.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -115,6 +115,7 @@ jobs:
         model:
           - "llamacpp_llama2_7b_cpu"
           - "transformers_llama3_8b_cpu"
+          - "transformers_phi4_mini_cpu"
     uses: ./.github/workflows/call_cpu_tests.yml
     with:
       os: ${{ matrix.os }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,12 +161,15 @@ def selected_model(selected_model_name: str) -> models.Model:
         )
 
     # PHI-4
-    if selected_model_name == "transformers_phi4_mini_gpu":
-        return models.Transformers(
-            "microsoft/Phi-4-mini-instruct", trust_remote_code=True, device_map="cuda:0"
-        )
     if selected_model_name == "transformers_phi4_mini_cpu":
         return models.Transformers("microsoft/Phi-4-mini-instruct", trust_remote_code=True)
+    if selected_model_name == "transformers_phi4_mini_gpu":
+        return models.Transformers(
+            "microsoft/Phi-4-mini-instruct",
+            trust_remote_code=True,
+            device_map="cuda:0",
+            torch_dtype=bfloat16,
+        )
 
     # QWEN2DOT5
     if selected_model_name == "transformers_qwen2dot5_0dot5b_cpu":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 
 from guidance import models
 
+
 def pytest_addoption(parser):
     SELECTED_MODEL_ENV_VARIABLE = "GUIDANCE_SELECTED_MODEL"
     default_model = os.getenv(SELECTED_MODEL_ENV_VARIABLE, "transformers_gpt2_cpu")
@@ -157,6 +158,12 @@ def selected_model(selected_model_name: str) -> models.Model:
             trust_remote_code=True,
             load_in_8bit=True,
             device_map="cuda:0",
+        )
+
+    # PHI-4
+    if selected_model_name == "transformers_phi4_mini_gpu":
+        return models.Transformers(
+            "microsoft/Phi-4-mini-instruct", trust_remote_code=True, device_map="cuda:0"
         )
 
     # QWEN2DOT5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,10 +164,12 @@ def selected_model(selected_model_name: str) -> models.Model:
     if selected_model_name == "transformers_phi4_mini_cpu":
         return models.Transformers("microsoft/Phi-4-mini-instruct", trust_remote_code=True)
     if selected_model_name == "transformers_phi4_mini_gpu":
+        from torch import bfloat16
         return models.Transformers(
             "microsoft/Phi-4-mini-instruct",
             trust_remote_code=True,
             device_map="cuda:0",
+            torch_dtype=bfloat16,
         )
 
     # QWEN2DOT5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,8 @@ def selected_model(selected_model_name: str) -> models.Model:
         return models.Transformers(
             "microsoft/Phi-4-mini-instruct", trust_remote_code=True, device_map="cuda:0"
         )
+    if selected_model_name == "transformers_phi4_mini_cpu":
+        return models.Transformers("microsoft/Phi-4-mini-instruct", trust_remote_code=True)
 
     # QWEN2DOT5
     if selected_model_name == "transformers_qwen2dot5_0dot5b_cpu":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,6 @@ def selected_model(selected_model_name: str) -> models.Model:
             "microsoft/Phi-4-mini-instruct",
             trust_remote_code=True,
             device_map="cuda:0",
-            torch_dtype=bfloat16,
         )
 
     # QWEN2DOT5

--- a/tests/model_integration/library/test_gen.py
+++ b/tests/model_integration/library/test_gen.py
@@ -51,24 +51,27 @@ def test_metrics_smoke(selected_model: models.Model):
     lm = selected_model
     lm.engine.reset_metrics()
 
-    lm += "abcd"
+    lm += "Generate the next letter: a b c d "
     print(f"{lm.engine.metrics=}")
     lm += gen("first", max_tokens=1)
     print(f"{lm.engine.metrics=}")
+    print(f"{str(lm)=}")
+    all_bytes = str(lm).encode()
+    print(f"{lm._interpreter.engine.tokenizer.encode(all_bytes)=}")
+    generated_bytes = lm["first"].encode()
+    print(f"{lm._interpreter.engine.tokenizer.encode(generated_bytes)=}")
     # Can't be sure of exact count due to token healing
     assert (
-        lm.engine.metrics.engine_output_tokens == 1
-        or lm.engine.metrics.engine_output_tokens == 2
+        lm.engine.metrics.engine_output_tokens == 1 or lm.engine.metrics.engine_output_tokens == 2
     )
     assert lm.engine.metrics.engine_input_tokens >= 1
     last_input_tokens = lm.engine.metrics.engine_input_tokens
 
-    lm += "fg"
+    lm += " f g"
     lm += gen("second", max_tokens=1)
     # Again, trouble with healing
     assert (
-        lm.engine.metrics.engine_output_tokens >= 2
-        or lm.engine.metrics.engine_output_tokens <= 4
+        lm.engine.metrics.engine_output_tokens >= 2 or lm.engine.metrics.engine_output_tokens <= 4
     )
     assert lm.engine.metrics.engine_input_tokens > last_input_tokens
 
@@ -92,9 +95,7 @@ def test_metrics_select(selected_model: models.Model):
     # Guidance should be able to force the generation after only a couple of tokens
     # so even though the options are long, relatively few output tokens should be
     # needed
-    assert (
-        lm.engine.metrics.engine_input_tokens > lm.engine.metrics.engine_output_tokens
-    )
+    assert lm.engine.metrics.engine_input_tokens > lm.engine.metrics.engine_output_tokens
 
 
 def test_unicode(selected_model: models.Model):
@@ -250,11 +251,7 @@ def test_tool_call(selected_model: models.Model):
         return lm + select(
             [
                 number(),
-                expression()
-                + zero_or_more(" ")
-                + operator()
-                + zero_or_more(" ")
-                + expression(),
+                expression() + zero_or_more(" ") + operator() + zero_or_more(" ") + expression(),
                 "(" + expression() + ")",
             ]
         )
@@ -274,8 +271,5 @@ def test_tool_call(selected_model: models.Model):
 
     calculator_tool = Tool(calculator_call(), calculator)
     gpt2 = selected_model
-    lm = (
-        gpt2
-        + "Here are five expressions:\nCalculator(3 * 3) = 33\nCalculator(2 + 1 * 3) = 5\n"
-    )
+    lm = gpt2 + "Here are five expressions:\nCalculator(3 * 3) = 33\nCalculator(2 + 1 * 3) = 5\n"
     lm += gen(max_tokens=30, temperature=0.5, tools=[calculator_tool], stop="\n\n")


### PR DESCRIPTION
Add Phi-4 into the CI test matrices. Due to the ongoing `sentencepiece` difficulties, this is not working in the GPU workflows right now.

At the same time, dig into the `model_integration\library\test_gen.py::test_metrics_smoke` test failures. The token counts weren't quite as expected, and this may be due to the extremely simple prompt being represented by a single token in some models. So it wound up being built up character-by-character by the model, requiring more than a single extra token to 'heal.'