### PR TITLE
[Hotfix] Pop `x-guidance` key when passing schemas to OpenAI

### DIFF
--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -237,7 +237,8 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
                 "type": "json_schema",
                 "json_schema": {
                     "name": "json_schema",  # TODO?
-                    "schema": node.schema,
+                    # x-guidance is disallowed
+                    "schema": {k: v for k,v in node.schema.items() if k != "x-guidance"},
                     "strict": True,
                 },
             },


### PR DESCRIPTION
OpenAI disallows the `x-guidance` key (which we use for setting whitespace, k/v separators, and leniency options), rather than ignoring it as an unknown key. We need to omit it from the schemas we pass to OpenAI to avoid errors.

TODO: warn the user this is happening if they chose any non-standard options?