### PR TITLE
[Build] Work around sentencepiece

### DIFF
--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -59,6 +59,7 @@ jobs:
           python -m pip install --upgrade pip
       # =====================================
       # Cope with sentencepiece
+      # https://github.com/guidance-ai/guidance/issues/1222
       - name: Install other packages
         shell: bash
         run: |

--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -57,10 +57,19 @@ jobs:
         shell: bash
         run : |
           python -m pip install --upgrade pip
+      # =====================================
+      # Cope with sentencepiece
       - name: Install other packages
         shell: bash
         run: |
           python -m pip install sentencepiece accelerate
+        if: ${{ inputs.python-version != "3.13" }}
+      - name: Install other packages
+        shell: bash
+        run: |
+          python -m pip install dbowring-sentencepiece accelerate
+        if: ${{ inputs.python-version == "3.13" }}
+      # =====================================
       - name: Install guidance in ${{ inputs.os }}
         shell: bash
         run: |

--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -63,12 +63,12 @@ jobs:
         shell: bash
         run: |
           python -m pip install sentencepiece accelerate
-        if: ${{ inputs.python-version != "3.13" }}
+        if: ${{ inputs.python-version != '3.13' }}
       - name: Install other packages
         shell: bash
         run: |
           python -m pip install dbowring-sentencepiece accelerate
-        if: ${{ inputs.python-version == "3.13" }}
+        if: ${{ inputs.python-version == '3.13' }}
       # =====================================
       - name: Install guidance in ${{ inputs.os }}
         shell: bash

--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -53,11 +53,17 @@ jobs:
           sudo apt-get --yes update
           sudo apt-get --yes install cuda-toolkit-12.6
           echo "/usr/local/cuda-12.6/bin" >> $GITHUB_PATH
+      - name: Upgrade pip
+        shell: bash
+        run : |
+          python -m pip install --upgrade pip
+      - name: Install other packages
+        shell: bash
+        run: |
+          python -m pip install sentencepiece accelerate
       - name: Install guidance in ${{ inputs.os }}
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install sentencepiece accelerate
           CMAKE_ARGS="-DGGML_CUDA=on" python -m pip install -e .[llamacpp,transformers,test]
       - name: Check GPU available
         shell: bash

--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           python -m pip install sentencepiece accelerate
         if: ${{ inputs.python-version != '3.13' }}
-      - name: Install other packages
+      - name: Install other packages (Hack)
         shell: bash
         run: |
           python -m pip install dbowring-sentencepiece accelerate

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ for v in extras_requires.values():
 
 # See
 # https://github.com/guidance-ai/guidance/issues/1222
-sentencepiece_dependency = "sentencepiece" if sys.version_info.minor != 13 else "dbowring-sentencepiece"
+sentencepiece_dependency = (
+    "sentencepiece" if sys.version_info.minor != 13 else "dbowring-sentencepiece"
+)
 
 # Required for builds etc.
 doc_requires = [

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,10 @@ all_requires = set()
 for v in extras_requires.values():
     all_requires = all_requires.union(v)
 
+# See
+# https://github.com/guidance-ai/guidance/issues/1222
+sentencepiece_dependency = "sentencepiece" if sys.version_info.minor != 13 else "dbowring-sentencepiece"
+
 # Required for builds etc.
 doc_requires = [
     "ipython",
@@ -73,7 +77,7 @@ test_requires = [
     "papermill",
     "pillow",
     "protobuf",
-    "sentencepiece",
+    sentencepiece_dependency,
     "torch",
     "transformers",
     "tiktoken>=0.3",


### PR DESCRIPTION
It appears that the current release of `sentencepiece` which is available on PyPI does not support Python 3.13. So for this specific version, use a community provided build for 3.13. See issue #1222 for further details.

This fix will break if `sentencepiece` still hasn't been updated by the time we try moving to Python 3.14. This is intentional; a fix this ugly should be somewhat fragile, so that we don't forget it's there.