### PR TITLE
[Bugfix] Ensure special tokens are tokenized as such (broken by #1218)

### DIFF
--- a/guidance/models/_engine/_tokenizer.py
+++ b/guidance/models/_engine/_tokenizer.py
@@ -69,9 +69,9 @@ class Tokenizer:
     def __call__(self, byte_string: bytes):
         return self.encode(byte_string)
 
-    def encode(self, byte_string: bytes) -> list[int]:
+    def encode(self, byte_string: bytes, *, parse_special: bool = True) -> list[int]:
         """Returns a list of tokens that represent the given byte string."""
-        return self._ll_tokenizer.tokenize_bytes(byte_string)
+        return self._ll_tokenizer.tokenize_bytes(byte_string, parse_special=parse_special)
 
     def decode(self, tokens: Sequence[int]) -> bytes:
         """Returns the bytes represented by the given list of tokens."""

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "requests",
     "psutil",
     "guidance-stitch",
-    "llguidance==0.7.24",
+    "llguidance==0.7.25",
 ]
 
 # Our basic list of 'extras'

--- a/tests/model_integration/test_tokenizers.py
+++ b/tests/model_integration/test_tokenizers.py
@@ -33,3 +33,7 @@ class TestUnauthenticatedTransformerTokenizers(BaseTestTransformerTokenizers):
     @pytest.mark.parametrize("target_string", TOKENIZER_ROUND_TRIP_STRINGS)
     def test_string_roundtrip(self, model_name: str, target_string: str):
         self.base_string_roundtrip(model_name, target_string)
+
+    @pytest.mark.parametrize("model_name", TRANSFORMER_MODELS)
+    def test_eos_bos_token_round_trip(self, model_name: str):
+        self.base_eos_bos_token_round_trip(model_name)

--- a/tests/model_specific/llama_cpp_tests/test_llama_cpp.py
+++ b/tests/model_specific/llama_cpp_tests/test_llama_cpp.py
@@ -231,3 +231,13 @@ class TestLlamaCppTokenizers:
         final_string = decoded.decode()
 
         assert final_string == target_string
+
+    def test_eos_bos_token_round_trip(self, llamacpp_model: guidance.models.LlamaCpp):
+        my_tok = llamacpp_model.engine.tokenizer
+
+        assert my_tok.eos_token == my_tok.decode([my_tok.eos_token_id])
+        assert my_tok.encode(my_tok.eos_token) == [my_tok.eos_token_id]
+
+        if my_tok.bos_token is not None:
+            assert my_tok.bos_token == my_tok.decode([my_tok.bos_token_id])
+            assert my_tok.encode(my_tok.bos_token) == [my_tok.bos_token_id]

--- a/tests/tokenizer_common.py
+++ b/tests/tokenizer_common.py
@@ -32,3 +32,18 @@ class BaseTestTransformerTokenizers:
         final_string = decoded.decode()
 
         assert final_string == target_string
+
+    def base_eos_bos_token_round_trip(
+        self, model_name: str
+    ):
+        my_tok = models.TransformersTokenizer.from_pretrained(
+            model_name,
+            trust_remote_code=True,
+        )
+
+        assert my_tok.eos_token == my_tok.decode([my_tok.eos_token_id])
+        assert my_tok.encode(my_tok.eos_token) == [my_tok.eos_token_id]
+
+        if my_tok.bos_token is not None:
+            assert my_tok.bos_token == my_tok.decode([my_tok.bos_token_id])
+            assert my_tok.encode(my_tok.bos_token) == [my_tok.bos_token_id]


### PR DESCRIPTION
Fixes regression introduced by #1218, where the llamacpp tokenizer fails to parse special tokens. Fixed by adding behavior and corresponding kwarg to llguidance, exposed here (with default True).

Added explicit test for this, as our existing tests did not cover this behavior!