### PR TITLE
[Test] Correct skip for `test_repeat_calls`

### DIFF
--- a/tests/model_specific/llama_cpp_tests/test_llama_cpp.py
+++ b/tests/model_specific/llama_cpp_tests/test_llama_cpp.py
@@ -75,7 +75,7 @@ def test_repeat_calls(llamacpp_model: guidance.models.Model, selected_model_name
         ("llamacpp_llama2_7b_cpu", "3.10", "Linux", "x86_64"),
         ("llamacpp_llama2_7b_cpu", "3.11", "Linux", "x86_64"),
         ("llamacpp_llama2_7b_cpu", "3.12", "Linux", "x86_64"),
-        ("llamacpp_llama2_7b_cpu", "3.12", "Linux", "x86_64"),
+        ("llamacpp_llama2_7b_cpu", "3.13", "Linux", "x86_64"),
         ("llamacpp_phi3_mini_4k_instruct_cpu", "3.9", "Windows", "AMD64"),
         ("llamacpp_phi3_mini_4k_instruct_cpu", "3.10", "Windows", "AMD64"),
         ("llamacpp_phi3_mini_4k_instruct_cpu", "3.11", "Windows", "AMD64"),


### PR DESCRIPTION
Correct a typo in one of the skips for `test_llamacpp.py::test_repeat_calls` which should get the Linux CI build to Green.

Note #1225 though.