### PR TITLE
[Build] Add CodeCov to unit tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,12 @@ jobs:
           python -m pip install -e .[unittest]
       - name: Unit Tests
         run: |
-          pytest -vv ./tests/unit
+          pytest -vv --cov=guidance --cov-report=xml --cov-report=term-missing \
+            ./tests/unit
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   cpu_tests:
     strategy:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,8 +9,8 @@ on:
         required: false
         type: string
   schedule:
-    # Run at 11:00 UTC every day
-    - cron: "00 11 * * *"
+    # Run at 10:00 UTC every day
+    - cron: "00 10 * * *"
 
 jobs:
   unit_tests:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,6 @@
-name: pull_request
+name: Pull Request
 
 on:
-  push:
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The unit test run (part of the PR workflow) did not include code coverage, which affects our coverage numbers. Correct this.

Also remove the `push` trigger from the PR build and give it a non-snake name.