### PR TITLE
[Hygiene] Fix some warnings in the tests

### DIFF
--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -11,6 +11,7 @@ import numpy as np
 import logging
 from typing import Union, cast
 import pathlib
+import pydantic
 import urllib
 import http
 import re
@@ -271,34 +272,34 @@ def softmax(array: np.ndarray, axis: int = -1) -> np.ndarray:
     return exp_x_shifted / np.sum(exp_x_shifted, axis=axis, keepdims=True)
 
 
-def pydantic_no_default_repr(obj, target_fields=None):
+def pydantic_no_default_repr(obj: pydantic.BaseModel, target_fields=None):
     if target_fields is None:
         records = (
             f'{getattr(obj, name)!r}'
-            for name, field in obj.model_fields.items()
+            for name, field in obj.__class__.model_fields.items()
             if getattr(obj, name) != field.default and not field.exclude
         )
     else:
         records = (
             f'{getattr(obj, name)!r}'
-            for name, field in obj.model_fields.items()
+            for name, field in obj.__class__.model_fields.items()
             if getattr(obj, name) != field.default and not field.exclude and name in target_fields
         )
     out = f'{type(obj).__name__}:{":".join(records)}'
     return out
 
 
-def pydantic_no_default_str(obj, target_fields=None):
+def pydantic_no_default_str(obj: pydantic.BaseModel, target_fields=None):
     if target_fields is None:
         records = (
             f'{getattr(obj, name)!s}'
-            for name, field in obj.model_fields.items()
+            for name, field in obj.__class__.model_fields.items()
             if getattr(obj, name) != field.default and not field.exclude
         )
     else:
         records = (
             f'{getattr(obj, name)!s}'
-            for name, field in obj.model_fields.items()
+            for name, field in obj.__class__.model_fields.items()
             if getattr(obj, name) != field.default and not field.exclude and name in target_fields
         )
     out = "\n".join(records)

--- a/tests/model_specific/llama_cpp_tests/test_llama_cpp.py
+++ b/tests/model_specific/llama_cpp_tests/test_llama_cpp.py
@@ -1,13 +1,12 @@
+import pytest
 import platform
 import sys
-import warnings
 
 import numpy as np
 import pytest
 
 import guidance
 from guidance import gen, select
-
 
 from tests.tokenizer_common import TOKENIZER_ROUND_TRIP_STRINGS
 
@@ -122,13 +121,16 @@ def test_repeat_calls(llamacpp_model: guidance.models.Model, selected_model_name
         lm = llama2 + "How much is 2 + 2? " + gen(name="test", max_tokens=10, temperature=0)
         a.append(lm["test"])
         assert a[-1] == a[0]
-
-        assert not expect_failure, "Unexpected pass"
     except AssertionError:
         if expect_failure:
-            warnings.warn("Got expected failure")
+            pytest.xfail(f"Expected failure for {selected_model_name}")
         else:
+            # Unexpected failure, raise the error
             raise
+    else:
+        if expect_failure:
+            # Simulate an XPASS (no pytest.xpass)
+            pytest.fail(f"XPASS: unexpected pass for {selected_model_name}")
 
 
 def test_suffix(llamacpp_model: guidance.models.Model):


### PR DESCRIPTION
`tests/model_specific/llama_cpp_tests/test_llama_cpp.py::test_repeat_calls`
- Remove `UserWarning` on xfail condition and use `pytest.xfail` instead

`tests/model_specific/test_visual.py`: 48 warnings
- Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0