### PR TITLE
[Hotfix]: pass `log_probs` (not `logprobs`) to OAI

### DIFF
--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -251,7 +251,7 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
 
         with self.client.streaming_chat_completions(
             model=self.model,
-            messages=TypeAdapter(list[Message]).dump_python(self.state.messages),  # type: ignore[arg-type]
+            messages=self.state.messages,
             log_probs=self.log_probs,
             **kwargs,
         ) as chunks:


### PR DESCRIPTION
Not everything uses the same spelling. Also fix pydantic warnings.