### PR TITLE
Add experimental LiteLLM support and model switching capability

### DIFF
--- a/guidance/models/_base/_state.py
+++ b/guidance/models/_base/_state.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Optional, TypedDict, Union
+from copy import deepcopy
 
 from ...trace import CaptureOutput
 
@@ -41,3 +42,16 @@ class State(ABC):
             log_probs=log_prob or float("nan"),
             is_append=is_append,
         )
+        
+    def copy(self) -> "State":
+        """Create a copy of the current state."""
+        new_state = self.__class__()
+        # deepcopy everything using __dict__ to ensure we copy the structure
+        for key, value in self.__dict__.items():
+            if isinstance(value, dict):
+                new_state.__dict__[key] = deepcopy(value)
+            elif isinstance(value, list):
+                new_state.__dict__[key] = [deepcopy(item) for item in value]
+            else:
+                new_state.__dict__[key] = deepcopy(value)
+        return new_state

--- a/guidance/models/_engine/_state.py
+++ b/guidance/models/_engine/_state.py
@@ -1,4 +1,5 @@
 from typing import Any
+from copy import deepcopy
 
 from .._base import State
 
@@ -13,3 +14,16 @@ class EngineState(State):
 
     def __str__(self) -> str:
         return self.prompt
+    
+    def copy(self) -> "State":
+        """Create a copy of the current state."""
+        new_state = self.__class__()
+        # deepcopy everything using __dict__ to ensure we copy the structure
+        for key, value in self.__dict__.items():
+            if isinstance(value, dict):
+                new_state.__dict__[key] = deepcopy(value)
+            elif isinstance(value, list):
+                new_state.__dict__[key] = [deepcopy(item) for item in value]
+            else:
+                new_state.__dict__[key] = deepcopy(value)
+        return new_state

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -268,9 +268,10 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
                     )
             elif delta.function_call is not None:
                 raise NotImplementedError("Function calling not yet supported for OpenAI")
-            elif delta.tool_calls is not None:
+            elif delta.tool_calls is not None and len(delta.tool_calls) > 0:
                 raise NotImplementedError("Tool calling not yet supported for OpenAI")
-            elif delta.refusal is not None:
+            # there are cases where vllm does not return refusal field in delta, using None as default value here
+            elif getattr(delta, "refusal", None) is not None:
                 raise ValueError(f"OpenAI refused the request: {delta.refusal}")
 
             if choice.finish_reason is not None:

--- a/guidance/models/experimental/__init__.py
+++ b/guidance/models/experimental/__init__.py
@@ -1,1 +1,2 @@
 from ._vllm import VLLMModel
+from ._litellm import LiteLLM

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -1,0 +1,214 @@
+from typing import Iterator
+from pydantic import TypeAdapter
+
+from ..._ast import GrammarNode, RuleNode, RegexNode, JsonNode, LarkNode
+from ...trace import OutputAttr, TextOutput
+from .._base import Model
+from .._openai_base import (
+    Message,
+    BaseOpenAIInterpreter,
+)
+
+
+class LiteLLMInterpreter(BaseOpenAIInterpreter):
+    SUPPORTED_ENDPOINT_TYPES = ["openai", "azure", "azure_ai", "gemini", "hosted_vllm"]
+
+    def __init__(self, model_description: dict, **kwargs):
+        try:
+            import litellm
+        except ImportError:
+            raise Exception(
+                "Please install the litellm package version >= 1.71.0 using `pip install litellm -U` in order to use guidance.models.LiteLLM!"
+            )
+
+        self.ep_type = self._check_model(model_description)
+        # set default model to the first one in the list
+        self.model = model_description["model_name"]
+        self.router = litellm.Router(model_list=[model_description])
+
+        super().__init__(model=self.model, client=None, **kwargs)
+
+    def _check_model(self, model_desc: dict) -> str:
+        """Check if the model description is valid."""        
+        for ep_type in self.SUPPORTED_ENDPOINT_TYPES:
+            if model_desc["litellm_params"]["model"].startswith(ep_type):
+                return ep_type
+
+        raise Exception("Cannot parse endpoint type. " 
+                        "Please use this 'model' format in 'litellm_params': endpoint_type/model_name (e.g., openai/gpt-3.5-turbo). "
+                        "Supported endpoints are: " + ", ".join(self.SUPPORTED_ENDPOINT_TYPES))
+
+
+    def _run(self, **kwargs) -> Iterator[OutputAttr]:
+        if self.state.active_role is None:
+            # Should never happen?
+            raise ValueError(
+                "LiteLLM models require chat blocks (e.g. use `with assistant(): ...`)"
+            )
+        if self.state.active_role != "assistant":
+            raise ValueError(
+                "LiteLLM models can only generate as the assistant (i.e. inside of `with assistant(): ...`)"
+            )
+        if self.state.content:
+            raise ValueError(
+                f"LiteLLM models do not support pre-filled assistant messages: got data {self.state.content}."
+            )
+        
+        chunks = self.router.completion(
+            model=self.model, # pass the model name
+            messages=TypeAdapter(list[Message]).dump_python(self.state.messages),  # type: ignore[arg-type]
+            stream=True,
+            **kwargs,
+            )
+        
+        yield from self._handle_stream(chunks)
+
+    def rule(self, node: RuleNode, **kwargs) -> Iterator[OutputAttr]:
+        # if node.stop:
+        #     raise ValueError("Stop condition not yet supported for OpenAI")
+        # if node.suffix:
+        #     raise ValueError("Suffix not yet supported for OpenAI")
+        # if node.stop_capture:
+        #     raise ValueError("Save stop text not yet supported for OpenAI")
+
+        kwargs = kwargs.copy()
+        if node.temperature:
+            kwargs["temperature"] = node.temperature
+        if node.max_tokens:
+            kwargs["max_tokens"] = node.max_tokens
+
+        chunks = self.run(node.value, **kwargs)
+        if node.capture:
+            buffered_text = ""
+            for chunk in chunks:
+                # TODO: this isinstance check is pretty darn fragile.
+                # ~there must be a better way~
+                if isinstance(chunk, TextOutput):
+                    buffered_text += chunk.value
+                yield chunk
+            yield self.state.apply_capture(
+                name=node.capture,
+                value=buffered_text,
+                log_prob=1,  # TODO
+                is_append=node.list_append,
+            )
+        else:
+            yield from chunks
+
+    def regex(self, node: RegexNode, **kwargs) -> Iterator[OutputAttr]:
+        if node.regex is not None and self.ep_type not in ["hosted_vllm"]:
+            raise ValueError(f"Regex is not yet supported for ep {self.ep_type}")
+        
+        if self.ep_type == "hosted_vllm":
+            return self._regex_vllm(node, **kwargs)
+
+        # We're in unconstrained mode now.
+        return self._run(**kwargs)
+    
+    def _regex_vllm(self, node: RegexNode, **kwargs):
+        """Run the regex node using vLLM."""
+        buffer: str = ""
+        for attr in self._run(
+            extra_body=dict(
+                guided_decoding_backend="guidance",
+                guided_regex=node.regex
+            )
+        ):
+            if isinstance(attr, TextOutput):
+                buffer += attr.value
+            yield attr
+    
+    def json(self, node: JsonNode, **kwargs) -> Iterator[OutputAttr]:
+        if self.ep_type in ["openai"] and \
+            (self.model in ["gpt-3.5-turbo"] or self.model.startswith("gpt-4-")):
+            raise ValueError(f"Json is not supported for ep {self.ep_type}/{self.model}")
+
+        schema = {k: v for k,v in node.schema.items() if k != "x-guidance"}
+        schema["additionalProperties"] = False  # Ensure no additional properties are allowed
+        return self._run(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "json_schema",  # TODO?
+                    "schema": schema,
+                    "strict": True,                    
+                }
+            },
+            **kwargs,
+        )
+    
+    def grammar(self, node: GrammarNode, **kwargs) -> Iterator[OutputAttr]:
+        if self.ep_type not in ["hosted_vllm"]:
+            raise ValueError(f"Grammar is not yet supported for ep {self.ep_type}")        
+
+        if self.ep_type == "hosted_vllm":
+            return self._grammar_vllm(node, **kwargs)
+
+        return self._run(**kwargs)
+    
+    def _grammar_vllm(self, node: GrammarNode, **kwargs) -> Iterator[OutputAttr]:
+        """Run the grammar node using vLLM."""
+        buffer: str = ""
+        for attr in self._run(
+            extra_body=dict(
+                guided_decoding_backend="guidance",
+                guided_grammar=node.ll_grammar()
+            )
+        ):
+            if isinstance(attr, TextOutput):
+                buffer += attr.value
+            yield attr
+        matches = node.match(
+            buffer,
+            raise_exceptions=False,
+            # Turn of max_tokens since we don't have access to the tokenizer
+            enforce_max_tokens=False,
+        )
+        if matches is None:
+            # TODO: should probably raise...
+            # raise ValueError("vLLM failed to constrain the grammar")
+            pass
+        else:
+            for name, value in matches.captures.items():
+                log_probs = matches.log_probs[name]
+                if isinstance(value, list):
+                    assert isinstance(log_probs, list)
+                    assert len(value) == len(log_probs)
+                    for v, l in zip(value, log_probs):
+                        yield self.state.apply_capture(
+                            name=name, value=v, log_prob=l, is_append=True
+                        )
+                else:
+                    yield self.state.apply_capture(
+                        name=name, value=value, log_prob=log_probs, is_append=False
+                    )
+
+    def lark(self, node: LarkNode, **kwargs):
+        if self.ep_type not in ["hosted_vllm"]:
+            raise ValueError(f"LarkGrammar is not yet supported for ep {self.ep_type}")
+        
+        if self.ep_type == "hosted_vllm":
+            return self._lark_vllm(node, **kwargs)
+        
+        return self._run(**kwargs)
+
+    def _lark_vllm(self, node: LarkNode, **kwargs):
+        """Run the lark grammar node using vLLM."""
+        buffer: str = ""
+        for attr in self._run(
+            extra_body=dict(
+                guided_decoding_backend="guidance",
+                guided_grammar=node.lark_grammar
+            )
+        ):
+            if isinstance(attr, TextOutput):
+                buffer += attr.value
+            yield attr
+
+class LiteLLM(Model):
+    def __init__(self, model_description: dict, echo=True, **kwargs):
+        interpreter = LiteLLMInterpreter(model_description=model_description, **kwargs)
+        super().__init__(
+            interpreter=interpreter,
+            echo=echo,
+        )

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -11,7 +11,7 @@ from .._openai_base import (
 
 
 class LiteLLMInterpreter(BaseOpenAIInterpreter):
-    SUPPORTED_ENDPOINT_TYPES = ["openai", "azure", "azure_ai", "gemini", "anthropic", "hosted_vllm"]
+    SUPPORTED_ENDPOINT_TYPES = ["openai", "azure_ai", "azure", "gemini", "anthropic", "hosted_vllm"]
 
     def __init__(self, model_description: dict, **kwargs):
         try:

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -64,12 +64,12 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
         yield from self._handle_stream(chunks)
 
     def rule(self, node: RuleNode, **kwargs) -> Iterator[OutputAttr]:
-        # if node.stop:
-        #     raise ValueError("Stop condition not yet supported for OpenAI")
-        # if node.suffix:
-        #     raise ValueError("Suffix not yet supported for OpenAI")
-        # if node.stop_capture:
-        #     raise ValueError("Save stop text not yet supported for OpenAI")
+        if node.stop and self.ep_type not in ["hosted_vllm"]:
+            raise ValueError(f"stop condition not yet supported for {self.ep_type} endpoint")
+        if node.suffix:
+            raise ValueError(f"suffix not yet supported for {self.ep_type} endpoint")
+        if node.stop_capture:
+            raise ValueError(f"stop_capture not yet supported for {self.ep_type} endpoint")
 
         kwargs = kwargs.copy()
         if node.temperature:


### PR DESCRIPTION
This PR adds 
1) support for LiteLLM connector to use many remote endpoints (OpenAI, AzureOpenAI, AzureAI, Gemini and Hosted VLLM).
2) support switching between local models and remote models. Switching between local and remote models is currently not supported.

### Create litellm model
Example to create hosted_vllm model and run a grammar
```python
import guidance
from guidance import system, user, assistant, gen, json, lark

lark_grammar = """
start: "Capital: " CAPITAL ", Population: " INT
CAPITAL: /[A-Z][a-z]+/
INT: /[0-9]+/
"""

litellm_model_desc = {
    "model_name": "DeepSeek-R1-0528-Qwen3-8B-fp8", 
    "litellm_params": { # params for litellm completioncall 
        "model": "hosted_vllm/DeepSeek-R1-0528-Qwen3-8B-fp8", 
        "api_key": "NOKEY",
        "api_base": "http://localhost:5005/v1"
    }
}
lm = guidance.models.experimental.LiteLLM(model_description=litellm_model_desc, echo=False)

with user():
    lm += "What is the capital of France? and its population?"

with assistant():
    lm += lark(lark_grammar=lark_grammar, name="answer")
    print(lm["answer"])
```
Example to create OpenAI model
```
litellm_model_desc = {
    "model_name": "gpt-3.5-turbo", 
    "litellm_params": { # params for litellm completion call 
        "model": "openai/gpt-3.5-turbo", 
        "api_key": os.getenv("OPENAI_API_KEY"),
    }
}
lm = guidance.models.experimental.LiteLLM(model_description=litellm_model_desc, echo=False)
```

Example to create Gemini model
```python
litellm_model_desc = {
    "model_name": "gemini-2.5", 
    "litellm_params": { # params for litellm completion/embedding call 
        "model": "gemini/gemini-2.5-flash-preview-05-20", 
        "api_key": os.getenv("GEMINI_API_KEY"),
        "reasoning_effort" : "low"
    }
}

lm = guidance.models.experimental.LiteLLM(model_description=litellm_model_desc, echo=False)
```

Please check [LiteLLM Router](https://docs.litellm.ai/docs/routing) for other endpoint description formats.

### Switching between local models
```python
lm = guidance.models.Transformers(model="Qwen/Qwen3-0.6B", echo=False)
with user():
    lm += "What is the capital of France? and its population?"
    
new_lm = lm + guidance.models.LlamaCpp(model="Qwen3-1.7B-Q8_0.gguf", echo=False)
with assistant():
    new_lm += guidance.gen(max_tokens=80, temperature=0.7, name="_answer")
    
print(new_lm["_answer"])
```

### Switching between remote models
```python
lm = guidance.models.OpenAI(model="gpt-3.5-turbo", echo=False, api_key=os.getenv("OPENAI_API_KEY"))

with user():
    lm += "What is the capital of France? and its population?"
    
litellm_model_desc = {
    "model_name": "DeepSeek-R1-0528-Qwen3-8B-fp8", 
    "litellm_params": { # params for litellm completion call 
        "model": "hosted_vllm/DeepSeek-R1-0528-Qwen3-8B-fp8", 
        "api_key": "NOKEY",
        "api_base": "http://localhost:5005/v1"
    }
}

switched_lm = lm + guidance.models.experimental.LiteLLM(model_description=litellm_model_desc, echo=False)
```