### PR TITLE
[Hotfix] Invalid type for 'response_format': expected an object, but got an array instead.

### DIFF
--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -433,7 +433,7 @@ class OpenAIJSONMixin(BaseOpenAIInterpreter):
                     "schema": node.schema,
                     "strict": True,
                 },
-            },
+            }
         return self._run(
             response_format=response_format,
             **kwargs,


### PR DESCRIPTION
Result of a typo. @riedgar-ms seems we're not even smoke testing oai json -- I think we need a single list of tests like these, parameterized across oai, litellm with various backends, azure inference, aoai, ... Will add this week if I get a chance