### PR TITLE
Improve chat-format smoke tests; fix bug in TransformereTokenizer where chat template was not being inferred

### DIFF
--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -353,7 +353,7 @@ class SpecialToken(GrammarNode):
         raise ValueError("SpecialToken must have either text, id, or range set")
 
     @property
-    def is_terminal(self) -> bool:
+    def is_allowed_in_lark_terminal(self) -> bool:
         return False
 
     def _run(self, interpreter: "Interpreter[S]", **kwargs) -> Iterator[OutputAttr]:

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -75,6 +75,11 @@ class TransformersTokenizer(Tokenizer):
                 ],
                 encode_callable=hf_tokenizer.encode,
             ).as_ll_tokenizer()
+
+        # Get chat template from the tokenizer if not provided
+        if chat_template is None and isinstance(hf_tokenizer.chat_template, str):
+            chat_template = hf_tokenizer.chat_template
+
         super().__init__(
             ll_tokenizer=ll_tokenizer,
             chat_template=chat_template,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,14 +188,18 @@ def selected_model(selected_model_name: str) -> models.Model:
 
 
 @pytest.fixture(scope="module")
-def llamacpp_model(selected_model, selected_model_name):
-    if selected_model_name in [
-        "llamacpp_llama2_7b_cpu",
-        "llamacpp_llama2_7b_gpu",
-        "llamacpp_gemma2_9b_cpu",
-        "llamacpp_phi3_mini_4k_instruct_cpu",
-        "llamacpp_mistral_7b_cpu",
-    ]:
+def llamacpp_model(selected_model: models.Model, selected_model_name: str) -> models.LlamaCpp:
+    if isinstance(selected_model, models.LlamaCpp):
         return selected_model
-    else:
-        pytest.skip("Requires Llama-Cpp model")
+    pytest.skip(
+        f"Selected model {selected_model_name} is not a LlamaCpp model, skipping llamacpp_model fixture"
+    )
+
+
+@pytest.fixture(scope="module")
+def transformers_model(selected_model: models.Model, selected_model_name: str) -> models.Transformers:
+    if isinstance(selected_model, models.Transformers):
+        return selected_model
+    pytest.skip(
+        f"Selected model {selected_model_name} is not a Transformers model, skipping transformers_model fixture"
+    )

--- a/tests/model_specific/llama_cpp_tests/test_chat_templates.py
+++ b/tests/model_specific/llama_cpp_tests/test_chat_templates.py
@@ -4,7 +4,7 @@ import pytest
 import guidance
 
 
-def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_model_name):
+def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp):
     # Retrieve the template string
     if (
         hasattr(llamacpp_model.engine.model_obj, "metadata")

--- a/tests/model_specific/llama_cpp_tests/test_chat_templates.py
+++ b/tests/model_specific/llama_cpp_tests/test_chat_templates.py
@@ -3,8 +3,6 @@ import pytest
 
 import guidance
 
-from guidance.chat import CHAT_TEMPLATE_CACHE
-
 
 def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_model_name):
     # Retrieve the template string
@@ -15,9 +13,6 @@ def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_mo
         model_chat_template = llamacpp_model.engine.model_obj.metadata["tokenizer.chat_template"]
     else:
         pytest.skip("Chat template not available from LlamaCpp object")
-
-    lm = guidance.models.Mock("")
-    lm._interpreter.chat_template = CHAT_TEMPLATE_CACHE[model_chat_template]()
 
     messages = [
         {"role": "user", "content": "Good_day_to_you!"},
@@ -37,6 +32,7 @@ def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_mo
         eos_token=llamacpp_model.engine.tokenizer.eos_token.decode(),
     )
 
+    lm = llamacpp_model
     with guidance.user():
         lm += "Good_day_to_you!"
     with guidance.assistant():

--- a/tests/model_specific/llama_cpp_tests/test_chat_templates.py
+++ b/tests/model_specific/llama_cpp_tests/test_chat_templates.py
@@ -37,12 +37,21 @@ def test_chat_format_smoke(llamacpp_model: guidance.models.LlamaCpp, selected_mo
         lm += "Good_day_to_you!"
     with guidance.assistant():
         lm += "Hello!"
-    # Only check substring due to BOS/EOS tokens
-    if selected_model_name == "llamacpp_mistral_7b_cpu":
-        # The templates extracted via Transformers and GGUF are somewhat
-        # different for Mistral. This is showing up in slightly
-        # different spacing (our template is putting in a few extra spaces)
-        # so at least make sure the 'tags' are correct
-        assert str(lm).replace(" ", "") in jinja2_render.replace(" ", "")
+
+    # Compare the tokenization of the strings, rather than the strings
+    # themselves (e.g. `<|user|>` may tokenize the same as `<|user|>\n`)
+    lm_tokens = lm._interpreter.engine.tokenizer.encode(
+        str(lm).encode()
+    )
+    jinja2_tokens = lm._interpreter.engine.tokenizer.encode(
+        jinja2_render.encode()
+    )
+
+    # Only check substring due to BOS/EOS tokens, unfinished closing tags
+    diff = len(jinja2_tokens) - len(lm_tokens)
+    assert diff >= 0
+    for i in range(diff+1):
+        if jinja2_tokens[i:i+len(lm_tokens)] == lm_tokens:
+            break
     else:
-        assert str(lm) in jinja2_render
+        raise AssertionError("lm mismatches jinja template", str(lm), str(jinja2_render))

--- a/tests/model_specific/test_transformers.py
+++ b/tests/model_specific/test_transformers.py
@@ -1,4 +1,5 @@
 import pytest
+import jinja2
 
 from guidance import gen, select, models, assistant, system, user, guidance
 
@@ -197,3 +198,52 @@ def test_phi3_basic_completion_badtokens(phi3_model: models.Model):
     lm += gen("five", max_tokens=10)
 
     assert len(lm["five"]) > 0
+
+def test_chat_format_smoke(selected_model):
+    # Retrieve the template string
+    if isinstance(selected_model.engine.tokenizer._orig_tokenizer.chat_template, str):
+        model_chat_template = selected_model.engine.tokenizer._orig_tokenizer.chat_template
+    else:
+        pytest.skip("Chat template not available from Transformers object")
+
+    messages = [
+        {"role": "user", "content": "Good_day_to_you!"},
+        {"role": "assistant", "content": "Hello!"},
+    ]
+
+    # Note that llama-cpp-python does provide a llama_chat_apply_template function
+    # but details about its use are thin on the ground and according to
+    # https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template
+    # it does its own thing internally
+    jinja2_template = jinja2.Environment(loader=jinja2.BaseLoader()).from_string(
+        model_chat_template
+    )
+    jinja2_render = jinja2_template.render(
+        messages=messages,
+        bos_token=selected_model.engine.tokenizer.bos_token.decode(),
+        eos_token=selected_model.engine.tokenizer.eos_token.decode(),
+    )
+
+    lm = selected_model
+    with user():
+        lm += "Good_day_to_you!"
+    with assistant():
+        lm += "Hello!"
+
+    # Compare the tokenization of the strings, rather than the strings
+    # themselves (e.g. `<|user|>` may tokenize the same as `<|user|>\n`)
+    lm_tokens = lm._interpreter.engine.tokenizer.encode(
+        str(lm).encode()
+    )
+    jinja2_tokens = lm._interpreter.engine.tokenizer.encode(
+        jinja2_render.encode()
+    )
+
+    # Only check substring due to BOS/EOS tokens, unfinished closing tags
+    diff = len(jinja2_tokens) - len(lm_tokens)
+    assert diff >= 0
+    for i in range(diff+1):
+        if jinja2_tokens[i:i+len(lm_tokens)] == lm_tokens:
+            break
+    else:
+        raise AssertionError("lm mismatches jinja template", str(lm), str(jinja2_render))

--- a/tests/model_specific/test_transformers.py
+++ b/tests/model_specific/test_transformers.py
@@ -199,10 +199,10 @@ def test_phi3_basic_completion_badtokens(phi3_model: models.Model):
 
     assert len(lm["five"]) > 0
 
-def test_chat_format_smoke(selected_model):
+def test_chat_format_smoke(transformers_model: models.Transformers):
     # Retrieve the template string
-    if isinstance(selected_model.engine.tokenizer._orig_tokenizer.chat_template, str):
-        model_chat_template = selected_model.engine.tokenizer._orig_tokenizer.chat_template
+    if isinstance(transformers_model.engine.tokenizer._orig_tokenizer.chat_template, str):
+        model_chat_template = transformers_model.engine.tokenizer._orig_tokenizer.chat_template
     else:
         pytest.skip("Chat template not available from Transformers object")
 
@@ -220,11 +220,11 @@ def test_chat_format_smoke(selected_model):
     )
     jinja2_render = jinja2_template.render(
         messages=messages,
-        bos_token=selected_model.engine.tokenizer.bos_token.decode(),
-        eos_token=selected_model.engine.tokenizer.eos_token.decode(),
+        bos_token=transformers_model.engine.tokenizer.bos_token.decode(),
+        eos_token=transformers_model.engine.tokenizer.eos_token.decode(),
     )
 
-    lm = selected_model
+    lm = transformers_model
     with user():
         lm += "Good_day_to_you!"
     with assistant():


### PR DESCRIPTION
While I'd like to get rid of our machinery around chat templates entirely (see https://github.com/guidance-ai/guidance/pull/1249), I think that is a little ways off. In the meantime, this PR improves our tests of said machinery and fixes a few bugs that these improved tests caught.

- Modifies llama_cpp `test_chat_format_smoke` to make it use the *actual* `Model` rather than a `Mock`, ensuring that we're actually testing the code path that would be hit under typical usage
- Relaxes the assertions made in `test_chat_format_smoke` from `assert jinja2_render.contains(str(lm))` to `assert is_subarray(tokenize(str(lm)), tokenize(jinja2_render))`, as tokenization is not one-to-one
- Adds an equivalent test for transformers in `test_chat_format_smoke`
- `TransformerTokenizer` was not correcly inferring the chat template from the model; this is fixed by actually using the model's chat template in the `TransformerTokenizer`'s `__init__` method
- Using the correct chat template on the correct `Model` object surfaced another bug, whereby `SpecialToken` was not correctly marked with `is_allowed_in_lark_terminal=False` (fixed)