### PR TITLE
fix bug that was skewing token probabilities when masking was applied

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -402,7 +402,8 @@ class Engine(ABC):
         # compute top-k with masking
         masked_top_k: list[GenToken] = []
         if mask is not None:
-            masked_logits = logits + np.frombuffer(mask, dtype=np.uint8)
+            mask = np.frombuffer(mask, dtype=np.uint8)
+            masked_logits = np.where(mask != 0, logits, -np.inf)
             if temperature < _TEMPERATURE_EPSILON:
                 masked_logits = np.where(masked_logits == np.max(masked_logits), 0, -np.inf)
             else:

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -401,13 +401,13 @@ class Engine(ABC):
         # compute top-k with masking
         masked_top_k: list[GenToken] = []
         if mask is not None:
-            # shift logits to [0 - max] range first and apply mask
-            masked_logits = (logits - np.min(logits)) * np.frombuffer(mask, dtype=np.uint8)
-            masked_probs = (
-                softmax(masked_logits)
-                if temperature < 0.0001
-                else softmax(masked_logits / temperature)
-            )
+            masked_logits = logits + np.frombuffer(mask, dtype=np.uint8)
+            if temperature < 0.0001:
+                masked_logits = np.where(masked_logits == np.max(masked_logits), 0, -200)
+            else:
+                masked_logits /= temperature
+
+            masked_probs = softmax(masked_logits)
             masked_top_k = get_top_k(masked_probs, k)
 
         if temperature < 0.0001:

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -404,7 +404,7 @@ class Engine(ABC):
         if mask is not None:
             masked_logits = logits + np.frombuffer(mask, dtype=np.uint8)
             if temperature < _TEMPERATURE_EPSILON:
-                masked_logits = np.where(masked_logits == np.max(masked_logits), 0, -200)
+                masked_logits = np.where(masked_logits == np.max(masked_logits), 0, -np.inf)
             else:
                 masked_logits /= temperature
 


### PR DESCRIPTION
Previously, the logits were skewed substantially when masking was applied since the values inside the mask variable were either 0 or 200 depending on whether they were allowed or not allowed.  The value of 200 was multiplied by the logits, which skewed them much higher than intended, leading to the top token most likely always being selected instead of probabilistically selecting them.  A further fix to temperature is included.  Previously temperatures of 0.0 were treated the same as temperature = 1.0 since softmax was used on the original logits instead of deterministically selecting the highest logit token.