### PR TITLE
[Bug] Fix AssertionError with Gemma2

### DIFF
--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -215,7 +215,11 @@ class LlamaCppEngine(Engine):
                 logits_for_each_batch,
                 axis=0
             )
-            assert logits.shape[0] == len(token_ids) - num_cached
+            assert logits.shape[0] == len(token_ids) - num_cached, (
+                f"Expected {len(token_ids) - num_cached} logits, got {logits.shape[0]}."
+                f"\nEach batch had shape {', '.join(str(x.shape) for x in logits_for_each_batch)}."
+                f"\n{num_cached=}, {len(token_ids)=}, {n_batch=}"
+            )
             return logits
         else:
             return self._cached_logits

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -215,11 +215,7 @@ class LlamaCppEngine(Engine):
                 logits_for_each_batch,
                 axis=0
             )
-            assert logits.shape[0] == len(token_ids) - num_cached, (
-                f"Expected {len(token_ids) - num_cached} logits, got {logits.shape[0]}."
-                f"\nEach batch had shape {', '.join(str(x.shape) for x in logits_for_each_batch)}."
-                f"\n{num_cached=}, {len(token_ids)=}, {n_batch=}"
-            )
+            assert logits.shape[0] == len(token_ids) - num_cached
             return logits
         else:
             return self._cached_logits

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -635,7 +635,11 @@ class TransformersEngine(Engine):
                 logits_for_each_batch,
                 axis=0
             )
-            assert logits.shape[0] == len(token_ids) - num_cached
+            assert logits.shape[0] == len(token_ids) - num_cached, (
+                f"Expected {len(token_ids) - num_cached} logits, got {logits.shape[0]}."
+                f"\nEach batch had shape {', '.join(str(x.shape) for x in logits_for_each_batch)}."
+                f"\n{num_cached=}, {len(token_ids)=}, {len(new_token_ids)=}"
+            )
             return logits
         else:
             return self._cached_logits

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -636,11 +636,7 @@ class TransformersEngine(Engine):
                 logits_for_each_batch,
                 axis=0
             )
-            assert logits.shape[0] == len(token_ids) - num_cached, (
-                f"Expected {len(token_ids) - num_cached} logits, got {logits.shape[0]}."
-                f"\nEach batch had shape {', '.join(str(x.shape) for x in logits_for_each_batch)}."
-                f"\n{num_cached=}, {len(token_ids)=}, {len(new_token_ids)=}"
-            )
+            assert logits.shape[0] == len(token_ids) - num_cached
             return logits
         else:
             return self._cached_logits


### PR DESCRIPTION
Gemma2 has a non-croppable cache, so the cache is reset every time we do a forward pass that doesn't simply append tokens. In this case, `num_cached` wasn't being set to 0 like `past_length`, causing a later assertion to fail.

Note that this fix does not change any behaviors, as `num_cached` isn't actually used for anything after this line (except for the assertion).