### PR TITLE
Some lints: [F401, F541]

### DIFF
--- a/guidance/__init__.py
+++ b/guidance/__init__.py
@@ -3,10 +3,13 @@ __version__ = "0.2.3"
 import sys
 import types
 
-from . import models
-from ._ast import Function, GrammarNode
+from . import library, models
 from ._guidance import guidance
-from ._utils import strip_multiline_string_indents
+
+# we expose all the library functions at the top level of the module
+from .library import *  # noqa: F403
+
+__all__ = ["guidance", "models", "library", *library.__all__]
 
 
 # This makes the guidance module callable
@@ -16,8 +19,3 @@ class _Guidance(types.ModuleType):
 
 
 sys.modules[__name__].__class__ = _Guidance
-
-# we expose all the library functions at the top level of the module
-# widget debug utilities
-from .debug import clear_widget_debug, dump_widget_debug, enable_widget_debug, widget_debug_info
-from .library import *

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -1,6 +1,6 @@
 import inspect
 import warnings
-from typing import Dict, Union
+from typing import Union
 
 
 class ChatTemplate:

--- a/guidance/library/__init__.py
+++ b/guidance/library/__init__.py
@@ -11,11 +11,44 @@ from ._gen import call_tool, gen, regex
 from ._image import gen_image, image
 from ._json import json
 from ._optional import optional
-from ._role import assistant, role, system, user  # , function, instruction, indent_roles
+from ._role import assistant, role, system, user
 
-# from ..models._model import context_free
 # stateless library functions
 from ._sequences import at_most_n_repeats, exactly_n_repeats, one_or_more, sequence, zero_or_more
 from ._substring import substring
 from ._tool import Tool
 from ._video import gen_video, video
+
+__all__ = [
+    "select",
+    "string",
+    "token_limit",
+    "with_temperature",
+    "audio",
+    "gen_audio",
+    "block",
+    "capture",
+    "gbnf_to_lark",
+    "lark",
+    "call_tool",
+    "gen",
+    "regex",
+    "gen_image",
+    "image",
+    "json",
+    "optional",
+    "assistant",
+    "role",
+    "system",
+    "user",
+    "at_most_n_repeats",
+    "exactly_n_repeats",
+    "one_or_more",
+    "sequence",
+    "zero_or_more",
+    "substring",
+    "Tool",
+    "gen_video",
+    "video",
+    "lark",
+]

--- a/guidance/metrics/_metrics.py
+++ b/guidance/metrics/_metrics.py
@@ -53,7 +53,6 @@ class PeriodicMetricsGenerator:
 
     async def _emit(self):
         import asyncio
-        import time
 
         from ..registry import get_exchange
 

--- a/guidance/models/__init__.py
+++ b/guidance/models/__init__.py
@@ -1,30 +1,15 @@
-# from ._lite_llm import LiteLLM, LiteLLMChat, LiteLLMInstruct, LiteLLMCompletion
-# from ._cohere import Cohere, CohereCompletion, CohereInstruct
-# from ._anthropic import Anthropic
-# from ._googleai import GoogleAI, GoogleAIChat
-# from ._togetherai import (
-#     TogetherAI,
-#     TogetherAIChat,
-#     TogetherAIInstruct,
-#     TogetherAICompletion,
-# )
 from . import experimental
 from ._base import Model
 from ._llama_cpp import LlamaCpp
-from ._mock import Mock  # , MockChat
-
-# from .vertexai._vertexai import (
-#     VertexAI,
-#     VertexAIChat,
-#     VertexAICompletion,
-#     VertexAIInstruct,
-# )
-# from ._azure_openai import (
-#     AzureOpenAI,
-# )
-# from ._azureai_studio import AzureAIStudioChat
+from ._mock import Mock
 from ._openai import OpenAI
+from ._transformers import Transformers
 
-# from ._engine import Instruct, Chat
-# local models
-from ._transformers import Transformers, TransformersTokenizer
+__all__ = [
+    "Model",
+    "OpenAI",
+    "LlamaCpp",
+    "Transformers",
+    "Mock",
+    "experimental",
+]

--- a/guidance/models/_azureai.py
+++ b/guidance/models/_azureai.py
@@ -122,7 +122,7 @@ def create_azure_openai_model(
         names include `base_url` and `organization`
     """
     if has_audio_support and has_image_support:
-        raise ValueError(f"No known models have both audio and image support")
+        raise ValueError("No known models have both audio and image support")
 
     interpreter_cls: type[AzureOpenAIInterpreter]
     if (model_name and "audio-preview" in model_name) or has_audio_support:

--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -27,7 +27,6 @@ from ...trace import (
     RoleCloserInput,
     RoleOpenerInput,
     StatelessGuidanceInput,
-    TokenOutput,
     TraceNode,
 )
 from ...trace._trace import AudioInput

--- a/guidance/models/_byte_tokenizer.py
+++ b/guidance/models/_byte_tokenizer.py
@@ -2,7 +2,6 @@ from typing import List
 
 import numpy as np
 
-from ..chat import load_template_class
 from ._engine import Tokenizer
 from ._engine._tokenizer import TokenizerWrappable
 

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Generator, Iterator, Optional, TypedDict, Union
+from typing import Generator, Optional, TypedDict
 
 import numpy as np
 from numpy.typing import NDArray

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -475,7 +475,7 @@ class OpenAIImageMixin(BaseOpenAIInterpreter):
             # TODO: just store format on ImageOutput type
             format = pil_image.format
             if format is None:
-                raise ValueError(f"Cannot upload image with unknown format")
+                raise ValueError("Cannot upload image with unknown format")
 
         mime_type = f"image/{format.lower()}"
         self.state.content.append(

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -31,9 +31,7 @@ from ._base import Interpreter, State
 
 if TYPE_CHECKING:
     import openai
-    from openai import OpenAI
     from openai.types.chat import ChatCompletionChunk
-    from openai.types.chat.chat_completion_chunk import ChoiceLogprobs
 
 
 def get_role_start(role: str) -> str:

--- a/guidance/models/experimental/__init__.py
+++ b/guidance/models/experimental/__init__.py
@@ -1,2 +1,7 @@
 from ._litellm import LiteLLM
 from ._vllm import VLLMModel
+
+__all__ = [
+    "LiteLLM",
+    "VLLMModel",
+]

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -4,7 +4,7 @@ from pydantic import TypeAdapter
 
 from guidance._schema import SamplingParams
 
-from ..._ast import GrammarNode, JsonNode, LarkNode, RegexNode, RuleNode
+from ..._ast import GrammarNode, JsonNode, RegexNode, RuleNode
 from ...trace import OutputAttr, TextOutput
 from .._base import Model
 from .._openai_base import BaseOpenAIClientWrapper, BaseOpenAIInterpreter, Message

--- a/guidance/registry/__init__.py
+++ b/guidance/registry/__init__.py
@@ -1,3 +1,12 @@
 """Registry module that contains singletons."""
 
 from ._registry import get_bg_async, get_exchange, get_monitor, get_renderer, get_trace_handler, set_renderer
+
+__all__ = [
+    "get_bg_async",
+    "get_exchange",
+    "get_monitor",
+    "get_renderer",
+    "get_trace_handler",
+    "set_renderer",
+]

--- a/guidance/trace/__init__.py
+++ b/guidance/trace/__init__.py
@@ -28,3 +28,26 @@ from ._trace import (
     TraceNode,
     VideoOutput,
 )
+
+__all__ = [
+    "TraceNode",
+    "TraceHandler",
+    "InputAttr",
+    "OutputAttr",
+    "NodeAttr",
+    "LiteralInput",
+    "StatefulGuidanceInput",
+    "StatelessGuidanceInput",
+    "RoleOpenerInput",
+    "RoleCloserInput",
+    "EmbeddedInput",
+    "ImageInput",
+    "AudioOutput",
+    "ImageOutput",
+    "VideoOutput",
+    "CaptureOutput",
+    "TextOutput",
+    "TokenOutput",
+    "Token",
+    "Backtrack",
+]

--- a/guidance/visual/__init__.py
+++ b/guidance/visual/__init__.py
@@ -19,3 +19,24 @@ from ._message import (
 )
 from ._renderer import AutoRenderer, JupyterWidgetRenderer, Renderer
 from ._trace import display_trace_tree, trace_node_to_html, trace_node_to_str
+
+__all__ = [
+    "TopicExchange",
+    "GuidanceMessage",
+    "ClientReadyMessage",
+    "ClientReadyAckMessage",
+    "ExecutionCompletedMessage",
+    "ExecutionStartedMessage",
+    "MetricMessage",
+    "OutputRequestMessage",
+    "ResetDisplayMessage",
+    "TraceMessage",
+    "deserialize_message",
+    "serialize_message",
+    "display_trace_tree",
+    "trace_node_to_html",
+    "trace_node_to_str",
+    "AutoRenderer",
+    "JupyterWidgetRenderer",
+    "Renderer",
+]

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -11,6 +11,7 @@ import traceback
 import weakref
 from asyncio import Queue
 from functools import lru_cache, partial
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Callable, Optional
 from warnings import warn
 
@@ -31,20 +32,14 @@ from ._message import (
 )
 
 try:
-    from IPython import get_ipython
-    from IPython.display import HTML, clear_output, display
+    from IPython.display import display
 
     ipython_imported = True
 except ImportError:
     ipython_imported = False
 
 
-try:
-    import stitch  # type: ignore[import-untyped]
-
-    stitch_installed = True
-except ImportError:
-    stitch_installed = False
+stitch_installed = find_spec("stitch") is not None
 
 if TYPE_CHECKING:
     from stitch import StitchWidget
@@ -443,7 +438,6 @@ class JupyterWidgetRenderer(Renderer):
 
     def enable_debug(self) -> None:
         """Enable debug mode in the widget to capture message history."""
-        from ..registry import get_bg_async
 
         self._debug_enabled = True
         self._debug_messages = []  # Clear previous messages

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -114,7 +114,7 @@ def _on_stitch_clientmsg(recv_queue_weakref: weakref.ReferenceType["Queue"], cha
 
 
 def _on_cell_completion(renderer_weakref: weakref.ReferenceType["JupyterWidgetRenderer"], info) -> None:
-    logger.debug(f"CELL:executed")
+    logger.debug("CELL:executed")
     try:
         renderer = renderer_weakref()
         if renderer is None:
@@ -202,7 +202,7 @@ async def _handle_send_messages(
                 # NOTE(nopdive): This at random times, appears to fire two changes instead of one change event.
                 renderer.stitch_widget.kernelmsg = message_json
             else:
-                logger.debug(f"SEND:jupyter:send but no widget")
+                logger.debug("SEND:jupyter:send but no widget")
             renderer.send_queue.task_done()
         except Exception as _:
             logger.error(f"SEND:err:{traceback.format_exc()}")
@@ -325,7 +325,7 @@ class JupyterWidgetRenderer(Renderer):
                     if message_trace_node.parent == last_trace_node.root():  # pragma: no cover
                         ancestor_idx = 0
                     else:
-                        logger.debug(f"DIVERGENCE:full_reset")
+                        logger.debug("DIVERGENCE:full_reset")
                         ancestor_idx = 0
 
                 return True, ancestor_idx

--- a/guidance/visual/_trace.py
+++ b/guidance/visual/_trace.py
@@ -83,7 +83,7 @@ def trace_node_to_html(node: TraceNode, prettify_roles=False) -> str:
                 if not prettify_roles:
                     buffer.append("</span>")
                 if isinstance(active_role.input, RoleCloserInput) and prettify_roles:
-                    buffer.append(f"</div></div>")
+                    buffer.append("</div></div>")
                 active_role = None
         elif isinstance(node.output, ImageOutput):
             buffer.append(

--- a/tests/model_integration/library/test_subgrammar.py
+++ b/tests/model_integration/library/test_subgrammar.py
@@ -1,9 +1,6 @@
 import json
 import re
 
-import numpy as np
-import pytest
-from jsonschema import validate
 
 import guidance
 from guidance import (

--- a/tests/model_specific/test_transformers.py
+++ b/tests/model_specific/test_transformers.py
@@ -1,7 +1,7 @@
 import jinja2
 import pytest
 
-from guidance import assistant, gen, guidance, models, select, system, user
+from guidance import assistant, gen, guidance, models, select, user
 
 from ..utils import get_model
 

--- a/tests/need_credentials/test_anthropic.py
+++ b/tests/need_credentials/test_anthropic.py
@@ -1,9 +1,8 @@
 import pytest
 
 import guidance
-from guidance import assistant, capture, gen, select, system, user
+from guidance import assistant, gen, select, system, user
 
-from ..utils import get_model
 
 
 def test_anthropic_chat():

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -1,14 +1,11 @@
-import json
 import pathlib
 from urllib.parse import parse_qs, urlparse
 
-import pydantic
 import pytest
 import requests
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 from guidance import assistant, gen, gen_audio, image, models, system, user
-from guidance import json as gen_json
 from guidance.models._azureai import create_azure_openai_model
 
 from ..model_specific import common_chat_testing

--- a/tests/need_credentials/test_cohere.py
+++ b/tests/need_credentials/test_cohere.py
@@ -1,7 +1,7 @@
 import pytest
 
 import guidance
-from guidance import assistant, capture, gen, role, select, system, user
+from guidance import gen, role
 
 
 def test_lite_llm_basic():

--- a/tests/need_credentials/test_googleai.py
+++ b/tests/need_credentials/test_googleai.py
@@ -1,12 +1,10 @@
 import pytest
 
-from guidance import gen, models, select
 
-from ..utils import get_model
 
 
 def test_gemini_pro():
-    from guidance import assistant, gen, models, system, user
+    from guidance import assistant, gen, models, user
 
     try:
         vmodel = models.GoogleAI("gemini-pro")

--- a/tests/need_credentials/test_lite_llm.py
+++ b/tests/need_credentials/test_lite_llm.py
@@ -1,9 +1,8 @@
 import pytest
 
 import guidance
-from guidance import assistant, capture, gen, select, system, user
+from guidance import assistant, gen, select, system, user
 
-from ..utils import get_model
 
 
 def test_lite_llm_basic_openai():

--- a/tests/need_credentials/test_tokenizers.py
+++ b/tests/need_credentials/test_tokenizers.py
@@ -1,6 +1,5 @@
 import pytest
 
-from guidance import models
 from tests.tokenizer_common import TOKENIZER_ROUND_TRIP_STRINGS, BaseTestTransformerTokenizers
 
 # Since this is under 'need_credentials' we can assume that HF_TOKEN

--- a/tests/need_credentials/test_vertexai.py
+++ b/tests/need_credentials/test_vertexai.py
@@ -1,8 +1,7 @@
 import pytest
 
-from guidance import gen, models, role, select
+from guidance import gen, models, role
 
-from ..utils import get_model
 
 
 def test_palm2_instruct():
@@ -65,7 +64,7 @@ def test_palm2_chat():
 
 
 def test_gemini_chat():
-    from guidance import assistant, gen, models, system, user
+    from guidance import assistant, gen, models, user
 
     try:
         vmodel = models.VertexAI("gemini-pro")

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qs, urlparse
 import papermill as pm
 import pytest
 
-from ..utils import env_or_skip, slowdown
+from ..utils import slowdown
 
 BASE_NB_PATH = pathlib.Path("./notebooks").absolute()
 

--- a/tests/unit/library/test_image.py
+++ b/tests/unit/library/test_image.py
@@ -1,14 +1,6 @@
-import pathlib
-import tempfile
-import uuid
-from urllib.error import HTTPError, URLError
 
-import pytest
-import requests
 
-from guidance import image, models
 
-from ...utils import remote_image_url
 
 #################################################################################
 # The tests below need to be rewritten once multimodal support is complete

--- a/tests/unit/library/test_pydantic.py
+++ b/tests/unit/library/test_pydantic.py
@@ -8,7 +8,6 @@ import pytest
 from pydantic.json_schema import to_jsonable_python as pydantic_to_jsonable_python
 
 from guidance import json as gen_json
-from guidance import models
 
 from ...utils import check_match_failure as _check_match_failure
 from ...utils import generate_and_check as _generate_and_check

--- a/tests/unit/test_ll.py
+++ b/tests/unit/test_ll.py
@@ -8,7 +8,6 @@ from huggingface_hub import hf_hub_download
 
 import guidance
 from guidance import (
-    GrammarNode,
     capture,
     gen,
     one_or_more,
@@ -17,6 +16,7 @@ from guidance import (
     select,
     string,
 )
+from guidance._ast import GrammarNode
 from guidance.library._subgrammar import as_regular_grammar, lexeme, subgrammar
 
 log_level = 10

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 import guidance
-from guidance import gen, models, system, user
+from guidance import gen, models
 
 
 def test_call_embeddings():

--- a/tests/unit/test_visual.py
+++ b/tests/unit/test_visual.py
@@ -3,7 +3,6 @@ from base64 import b64encode
 
 import pytest
 
-from guidance._topics import DEFAULT_TOPIC
 from guidance.registry import get_bg_async
 from guidance.trace import Backtrack, LiteralInput, TextOutput, Token, TokenOutput, TraceHandler
 from guidance.visual import (


### PR DESCRIPTION
F401 has been bugging me for some time (unused imports throughout the repo). This PR removes a number of unused imports, additionally adding all re-exported imports in `**/__init__.py` to `__all__`.

@riedgar-ms would you be open to adding this lint to our `ruff.toml`? Not a high priority, but it just helps keep things a bit cleaner.

Threw F541 in there too, for some reason auto-fixing some F401s had side-effects.