### PR TITLE
[Refactor] Move TypeAdapter serialization from `OpenAIClientWrapper` to `BaseOpenAIInterpreter`

### DIFF
--- a/guidance/models/_azureai.py
+++ b/guidance/models/_azureai.py
@@ -1,7 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Callable, ContextManager, Iterator, Optional, Union, cast
-
-from pydantic import TypeAdapter
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Iterator, Optional, Union, cast
 
 from guidance._schema import SamplingParams
 
@@ -13,7 +11,6 @@ from ._base import Model
 from ._openai_base import (
     BaseOpenAIClientWrapper,
     BaseOpenAIInterpreter,
-    Message,
     OpenAIAudioMixin,
     OpenAIClientWrapper,
     OpenAIImageMixin,
@@ -162,14 +159,14 @@ class AzureAIClientWrapper(BaseOpenAIClientWrapper):
     def streaming_chat_completions(
         self,
         model: str,
-        messages: list[Message],
+        messages: list[dict[str, Any]],
         log_probs: Optional[int] = None,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
         request = self.client.complete(
             body={
                 "model": model,
-                "messages": TypeAdapter(list[Message]).dump_python(messages),
+                "messages": messages,
                 "log_probs": log_probs,
                 "stream": True,
                 **kwargs,

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -4,7 +4,7 @@ import wave
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from io import BytesIO
-from typing import TYPE_CHECKING, ContextManager, Iterator, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Literal, Optional, Union, cast
 
 from pydantic import BaseModel, Discriminator, Field, TypeAdapter
 from typing_extensions import Annotated, assert_never
@@ -163,7 +163,7 @@ class BaseOpenAIClientWrapper(ABC):
     def streaming_chat_completions(
         self,
         model: str,
-        messages: list[Message],
+        messages: list[dict[str, Any]],
         log_probs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
@@ -178,7 +178,7 @@ class OpenAIClientWrapper(BaseOpenAIClientWrapper):
     def streaming_chat_completions(
         self,
         model: str,
-        messages: list[Message],
+        messages: list[dict[str, Any]],
         log_probs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
@@ -186,7 +186,7 @@ class OpenAIClientWrapper(BaseOpenAIClientWrapper):
 
         return self.client.chat.completions.create(
             model=model,
-            messages=TypeAdapter(list[Message]).dump_python(messages),  # type: ignore[arg-type]
+            messages=messages,
             logprobs=log_probs,
             stream=True,
             stream_options={"include_usage": True},
@@ -257,7 +257,7 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
 
         with self.client.streaming_chat_completions(
             model=self.model,
-            messages=self.state.messages,
+            messages=cast(list[dict[str, Any]], TypeAdapter(list[Message]).dump_python(self.state.messages)),
             log_probs=self.log_probs,
             **kwargs,
         ) as chunks:

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -1,13 +1,11 @@
-from typing import TYPE_CHECKING, ContextManager, Iterator, Optional
-
-from pydantic import TypeAdapter
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Optional
 
 from guidance._schema import SamplingParams
 
 from ..._ast import GrammarNode, JsonNode, RegexNode, RuleNode
 from ...trace import OutputAttr, TextOutput
 from .._base import Model
-from .._openai_base import BaseOpenAIClientWrapper, BaseOpenAIInterpreter, Message
+from .._openai_base import BaseOpenAIClientWrapper, BaseOpenAIInterpreter
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletionChunk
@@ -22,7 +20,7 @@ class LiteLLMOpenAIClientWrapper(BaseOpenAIClientWrapper):
     def _wrapped_completion(
         self,
         model: str,
-        messages: list[Message],
+        messages: list[dict[str, Any]],
         log_probs: bool,
         **kwargs,
     ) -> Iterator["ChatCompletionChunk"]:
@@ -30,7 +28,7 @@ class LiteLLMOpenAIClientWrapper(BaseOpenAIClientWrapper):
         kwargs["stream"] = True  # Ensure we are streaming here
         stream_wrapper = self.router.completion(
             model=model,
-            messages=TypeAdapter(list[Message]).dump_python(messages),  # type: ignore[arg-type]
+            messages=messages,
             logprobs=log_probs,
             **kwargs,
         )
@@ -46,7 +44,7 @@ class LiteLLMOpenAIClientWrapper(BaseOpenAIClientWrapper):
     def streaming_chat_completions(
         self,
         model: str,
-        messages: list[Message],
+        messages: list[dict[str, Any]],
         log_probs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:


### PR DESCRIPTION
Just simplifies things a little bit:

Makes `OpenAIClientWrapper.streaming_chat_completions` take a more generic `list[dict[str, Any]]` rather than `list[Message]`, letting us call `TypeAdapter(list[Message]).dump_python(messages)` in just one place (`BaseOpenAIInterpreter`) rather than in each `streaming_chat_completions` implementation