### PR TITLE
Fix OpenAI notebook example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 .env
 .DS_Store
 venv/
+.venv/
 
 # Ignore native library built by setup
 guidance/*.so

--- a/notebooks/api_examples/models/OpenAI.ipynb
+++ b/notebooks/api_examples/models/OpenAI.ipynb
@@ -15,61 +15,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Instruct usage"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>instruction</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>What is a popular flavor?</div></div><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>Some</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> popular</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> flavors</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> include</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> chocolate</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>,</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> vanilla</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>,</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> strawberry</span></pre>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from guidance import models, gen, instruction\n",
-    "\n",
-    "# this relies on the environment variable OPENAI_API_KEY being set\n",
-    "gpt35_instruct = models.OpenAI('gpt-3.5-turbo-instruct')\n",
-    "\n",
-    "lm = gpt35_instruct\n",
-    "with instruction():\n",
-    "    lm += \"What is a popular flavor?\"\n",
-    "lm += gen('flavor', max_tokens=10, stop=\".\")"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Chat usage"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>system</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>You only speak in ALL CAPS.</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>user</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>What is the captial of Greenland?</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2); align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>assistant</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>THE</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> CAPITAL</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> OF</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> GREEN</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>LAND</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> IS</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> NU</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>UK</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>.</span></div></div></pre>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "35202c6828f843c591c6a77fadacb339",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
       ]
      },
      "metadata": {},
@@ -77,12 +39,11 @@
     }
    ],
    "source": [
-    "from guidance import system, user, assistant\n",
+    "from guidance import gen, system, user, assistant\n",
+    "from guidance.models import OpenAI\n",
     "\n",
-    "# this relies on the environment variable OPENAI_API_KEY being set\n",
-    "gpt35 = models.OpenAI('gpt-3.5-turbo')\n",
-    "\n",
-    "lm = gpt35\n",
+    "# Set the OPENAI_API_KEY environment variable first!\n",
+    "lm = OpenAI('gpt-4.1')\n",
     "\n",
     "with system():\n",
     "    lm += \"You only speak in ALL CAPS.\"\n",
@@ -106,7 +67,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "adatest",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -120,7 +81,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.11"
   },
   "orig_nbformat": 4
  },

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -57,9 +57,12 @@ class TestModels:
 
     def test_azure_openai(self):
         call_delay_secs = slowdown()
-
         nb_path = TestModels.BASE_MODEL_PATH / "AzureOpenAI.ipynb"
         run_notebook(nb_path, params=dict(call_delay_secs=call_delay_secs))
+
+    def test_openai(self):
+        nb_path = TestModels.BASE_MODEL_PATH / "OpenAI.ipynb"
+        run_notebook(nb_path)
 
 
 class TestArtOfPromptDesign:


### PR DESCRIPTION
This PR fixes the OpenAI notebook example and adds it to CI so that it gets tested regularly.

`instruction()`, as far as I can tell, does not exist anymore.

I've also added `.venv/` to `.gitignore`, as that is also a common naming convention for virtual environments.