### PR TITLE
[Lint] Various fixes

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -6,7 +6,6 @@ permissions:
 
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       commit_id:

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -101,7 +101,7 @@ class ChatMLTemplate(ChatTemplate):
     def get_role_start(self, role_name):
         return f"<|im_start|>{role_name}\n"
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|im_end|>\n"
 
 
@@ -164,7 +164,7 @@ class Llama3ChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|eot_id|>"
 
 
@@ -192,7 +192,7 @@ class Phi3MiniChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|end|>\n"
 
 
@@ -220,7 +220,7 @@ class Phi3SmallMediumChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|end|>\n"
 
 
@@ -242,7 +242,7 @@ class Phi4MiniChatTemplate(ChatTemplate):
     def get_role_start(self, role_name):
         return f"<|{role_name}|>"
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|end|>"
 
 
@@ -334,7 +334,7 @@ class Qwen2dot5ChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|im_end|>\n"
 
 
@@ -359,7 +359,7 @@ class Qwen3ChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|im_end|>\n"
 
 
@@ -391,7 +391,7 @@ class Llama3dot2ChatTemplate(ChatTemplate):
         else:
             raise UnsupportedRoleException(role_name, self)
 
-    def get_role_end(self, role_name=None):
+    def get_role_end(self, role_name=None):  # noqa ARG002
         return "<|eot_id|>"
 
 

--- a/guidance/metrics/_metrics.py
+++ b/guidance/metrics/_metrics.py
@@ -90,7 +90,7 @@ class PeriodicMetricsGenerator:
             except CancelledError:
                 logger.debug("METRICGEN:canceling")
                 break
-            except Exception as e:
+            except Exception as e:  # noqa BLE001
                 logger.debug(f"METRICGEN: {repr(e)}")
                 break
 
@@ -132,7 +132,7 @@ class Monitor:
             import gpustat
 
             has_gpustat = True
-        except:
+        except ImportError:
             logger.warning("gpustat is not installed, run `pip install gpustat` to collect GPU stats.")
 
         if has_gpustat:
@@ -140,8 +140,8 @@ class Monitor:
                 gpu_stats = gpustat.GPUStatCollection.new_query()
                 if len(gpu_stats) > 0:
                     to_collect_gpu_stats = True
-            except:
-                logger.warning("Non-Nvidia GPU monitoring is not supported in this version.")
+            except Exception as e:  # noqa BLE001
+                logger.warning(f"Non-Nvidia GPU monitoring is not supported in this version. {e}")
 
         while not self.stop_flag:
             try:
@@ -176,7 +176,8 @@ class Monitor:
                 if sleep_time > 0:
                     await asyncio.sleep(sleep_time)
 
-            except Exception as e:
+            except Exception as e:  # noqa BLE001
+                logger.error(f"Caught {e}")
                 logger.error(f"MONITOR:{traceback.format_exc()}")
                 await asyncio.sleep(1)  # Wait a bit before retrying on error
 

--- a/guidance/models/_base/_interpreter.py
+++ b/guidance/models/_base/_interpreter.py
@@ -40,7 +40,7 @@ class Interpreter(Generic[S]):
             raise ValueError(f"Cannot open role {node.role!r}: {self.state.active_role!r} is already open.")
         return self.role_start(node, **kwargs)
 
-    def role_start(self, node: RoleStart, **kwargs) -> Iterator[OutputAttr]:
+    def role_start(self, node: RoleStart, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
     def _role_end(self, node: RoleEnd, **kwargs) -> Iterator[OutputAttr]:
@@ -50,20 +50,20 @@ class Interpreter(Generic[S]):
             raise ValueError(f"Cannot close role {node.role!r}: {self.state.active_role!r} is open.")
         return self.role_end(node, **kwargs)
 
-    def role_end(self, node: RoleEnd, **kwargs) -> Iterator[OutputAttr]:
+    def role_end(self, node: RoleEnd, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
-    def text(self, node: LiteralNode, **kwargs) -> Iterator[OutputAttr]:
+    def text(self, node: LiteralNode, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
-    def image_blob(self, node: ImageBlob, **kwargs) -> Iterator[OutputAttr]:
+    def image_blob(self, node: ImageBlob, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
     def image_url(self, node: ImageUrl, **kwargs) -> Iterator[OutputAttr]:
         image_bytes = bytes_from(node.url, allow_local=False)
         return self.image_blob(ImageBlob(data=base64.b64encode(image_bytes)), **kwargs)
 
-    def grammar(self, node: GrammarNode, **kwargs) -> Iterator[OutputAttr]:
+    def grammar(self, node: GrammarNode, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
     def regex(self, node: RegexNode, **kwargs) -> Iterator[OutputAttr]:
@@ -93,10 +93,10 @@ class Interpreter(Generic[S]):
     def lark(self, node: LarkNode, **kwargs) -> Iterator[OutputAttr]:
         return self.grammar(node, **kwargs)
 
-    def audio_blob(self, node: AudioBlob, **kwargs) -> Iterator[OutputAttr]:
+    def audio_blob(self, node: AudioBlob, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
-    def gen_audio(self, node: GenAudio, **kwargs) -> Iterator[OutputAttr]:
+    def gen_audio(self, node: GenAudio, **kwargs) -> Iterator[OutputAttr]:  # noqa ARG002
         raise UnsupportedNodeError(interpreter=self, node=node)
 
 

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -101,7 +101,7 @@ class LlamaCppEngine(Engine):
                 try:
                     with open(os.path.expanduser("~/.llama_cpp_model"), "r") as file:
                         model = file.read().replace("\n", "")
-                except:
+                except OSError:
                     pass
                 if len(model.strip()) == 0:
                     raise ValueError(
@@ -116,7 +116,7 @@ class LlamaCppEngine(Engine):
             # patch over https://github.com/abetlen/llama-cpp-python/issues/729
             try:
                 sys.stdout.fileno()
-            except:
+            except:  # noqa BLE001
                 logger.warning(
                     "Cannot use verbose=True in this context (probably CoLab). See https://github.com/abetlen/llama-cpp-python/issues/729"
                 )
@@ -225,7 +225,6 @@ class LlamaCpp(Model):
         model=None,
         echo=True,
         compute_log_probs=False,
-        api_key=None,
         chat_template=None,
         enable_backtrack=True,
         enable_ff_tokens=True,

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -147,7 +147,9 @@ class TransformersTokenizer(Tokenizer):
             try:
                 cls._check_byte_decoder(transformers_tokenizer.byte_decoder, transformers_tokenizer)
             except ByteDecoderError as e:
-                warnings.warn(f"Tokenizer has a byte_decoder, but it can't be used to construct byte_tokens: {e}")
+                warnings.warn(
+                    f"Tokenizer has a byte_decoder, but it can't be used to construct byte_tokens: {e}", stacklevel=1
+                )
                 pass
             else:
                 return cls._byte_tokens_from_byte_decoder(transformers_tokenizer.byte_decoder, transformers_tokenizer)
@@ -158,7 +160,9 @@ class TransformersTokenizer(Tokenizer):
         try:
             return cls._byte_tokens_by_encoding_token_strings(transformers_tokenizer)
         except ValueError as e:
-            warnings.warn(f"Could not build_byte tokens from the tokenizer by encoding token strings: {e}")
+            warnings.warn(
+                f"Could not build_byte tokens from the tokenizer by encoding token strings: {e}", stacklevel=1
+            )
             pass
 
         fallback_byte_decoder = cls._fallback_byte_decoder()
@@ -361,7 +365,7 @@ class TransformersEngine(Engine):
             try:
                 with open(os.path.expanduser("~/.transformers_model"), "r") as file:
                     model = file.read().replace("\n", "")
-            except:
+            except OSError:
                 pass
 
         self.model_obj = self._model(model, **kwargs)
@@ -494,7 +498,7 @@ class TransformersEngine(Engine):
             ):
                 # The __init__ API isn't consistent between different cache types, but there seems to be consistency
                 # between these two types, so we can use the same logic for both.
-                warnings.warn("Cache is too small. Re-initializing cache with larger size.")
+                warnings.warn("Cache is too small. Re-initializing cache with larger size.", stacklevel=1)
                 cache_type = type(past_key_values)
                 config = self.model_obj.config
                 device = self.model_obj.device
@@ -511,7 +515,8 @@ class TransformersEngine(Engine):
                 )
             else:
                 warnings.warn(
-                    f"Cache is too small. Resetting cache (no method implemented to resize cache for type {type(past_key_values)})."
+                    f"Cache is too small. Resetting cache (no method implemented to resize cache for type {type(past_key_values)}).",
+                    stacklevel=1,
                 )
                 self._past_key_values = None
             past_length = 0
@@ -525,7 +530,8 @@ class TransformersEngine(Engine):
                     self._past_key_values.crop(num_cached)
                 else:
                     warnings.warn(
-                        f"Cropping unsupported for cache type: {type(self._past_key_values)}. Resetting cache."
+                        f"Cropping unsupported for cache type: {type(self._past_key_values)}. Resetting cache.",
+                        stacklevel=1,
                     )
                     if hasattr(self._past_key_values, "reset"):
                         # Use built-in reset method if available to avoid constructing/allocating a new cache
@@ -563,7 +569,7 @@ class TransformersEngine(Engine):
                 # Need to add special truncating logic here for weird models that have a different output size than tokenizer vocab
                 logits_for_each_batch.append(model_out.logits[0, :, : self.tokenizer._vocab_size].float().cpu().numpy())
             except AssertionError:
-                for i, new_token_id in enumerate(new_token_ids):
+                for _, new_token_id in enumerate(new_token_ids):
                     input_ids = torch.tensor([new_token_id]).unsqueeze(0).to(self.device)
 
                     model_out = self.model_obj(


### PR DESCRIPTION
Clean up a number of linting errors, by fix or suppression as appropriate. Mainly unused arguments, overly broad exception catching, or `warnings.warn()` called without a `stacklevel` argument.

Also stop the Docs build triggering on PRs, since it will likely eventually make use of secrets.