### PR TITLE
Bump `llama-cpp-python` version; use `llama_memory_seq_rm` in place of removed `llama_memory_seq_rm`

### DIFF
--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -174,7 +174,8 @@ class LlamaCppEngine(Engine):
             num_cached = num_cached - 1
 
         # clear obsolete parts of kv cache
-        llama_cpp.llama_kv_cache_seq_rm(self.model_obj.ctx, -1, num_cached, -1)
+        kv = llama_cpp.llama_get_memory(self.model_obj.ctx)
+        llama_cpp.llama_memory_seq_rm(kv, -1, num_cached, -1)
 
         # eval the model
         logits_for_each_batch: list[np.ndarray] = []

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-llamacpp_requires = ["llama-cpp-python==0.3.9"]
+llamacpp_requires = ["llama-cpp-python==0.3.12"]
 transformers_requires = ["transformers==4.51.3"]
 
 install_requires = [


### PR DESCRIPTION
Thank you @jovemexausto for the fix!

Closes #1306

@paulbkoch @riedgar-ms we could reasonably use `llama_kv_self_seq_rm` instead as suggested in the linked issue if we want to preserve support for `llama-cpp-python` v0.3.9, however note that is has been deprecated (but is still present in v0.3.12).