### PR TITLE
Bump `llguidance` dependency to `1.0.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     "requests",
     "psutil",
     "guidance-stitch==0.1.5",
-    "llguidance==0.7.26",
+    "llguidance==1.0.1",
 ]
 
 # Our basic list of 'extras'


### PR DESCRIPTION
Use the newly stabilized llguidance dependency; no changes needed on our side.