### PR TITLE
[Build] Trigger CI on push to `main`

### DIFF
--- a/.github/workflows/ci_credentials.yml
+++ b/.github/workflows/ci_credentials.yml
@@ -6,6 +6,9 @@ permissions:
 
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -6,6 +6,9 @@ permissions:
 
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -5,6 +5,9 @@
 name: CI Tests - Notebook
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       commit_id:


### PR DESCRIPTION
Trigger three of the CI builds (Credentials, Doc, Notebooks) on pushes to `main`. These are builds which would be in the gate but for the fact that they access secrets, and breakages need to be caught quickly.