### PR TITLE
[Models] Deal with break in OpenAI

### DIFF
--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -260,12 +260,16 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
             if sampling_params.get("repetition_penalty", None) is not None:
                 raise ValueError("OpenAI models do not support repetition_penalty sampling.")
 
+        extra_kwargs = {}
+        if self.log_probs:
+            extra_kwargs["top_logprobs"] = self.top_k
+
         with self.client.streaming_chat_completions(
             model=self.model,
             messages=cast(list[dict[str, Any]], TypeAdapter(list[Message]).dump_python(self.state.messages)),
             log_probs=self.log_probs,
-            top_logprobs=self.top_k if self.log_probs else None,
             **kwargs,
+            **extra_kwargs,
         ) as chunks:
             yield from self._handle_stream(chunks)
 


### PR DESCRIPTION
The logic around calling the OpenAI client with `top_logprobs` was breaking. Apparently, the complete absence of an argument is different from an argument be present but set to None.