### PR TITLE
[OAI/AOAI] Fix error passing `top_logprobs` when `logprobs` is False

### DIFF
--- a/guidance/models/_azureai.py
+++ b/guidance/models/_azureai.py
@@ -167,7 +167,7 @@ class AzureAIClientWrapper(BaseOpenAIClientWrapper):
             body={
                 "model": model,
                 "messages": messages,
-                "log_probs": log_probs,
+                "logprobs": log_probs,
                 "stream": True,
                 **kwargs,
             },

--- a/guidance/models/_azureai.py
+++ b/guidance/models/_azureai.py
@@ -160,14 +160,14 @@ class AzureAIClientWrapper(BaseOpenAIClientWrapper):
         self,
         model: str,
         messages: list[dict[str, Any]],
-        log_probs: Optional[int] = None,
+        logprobs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
         request = self.client.complete(
             body={
                 "model": model,
                 "messages": messages,
-                "logprobs": log_probs,
+                "logprobs": logprobs,
                 "stream": True,
                 **kwargs,
             },

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -164,7 +164,7 @@ class BaseOpenAIClientWrapper(ABC):
         self,
         model: str,
         messages: list[dict[str, Any]],
-        log_probs: bool,
+        logprobs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
         """Streaming chat completions."""
@@ -179,7 +179,7 @@ class OpenAIClientWrapper(BaseOpenAIClientWrapper):
         self,
         model: str,
         messages: list[dict[str, Any]],
-        log_probs: bool,
+        logprobs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
         """Streaming chat completions."""
@@ -187,7 +187,7 @@ class OpenAIClientWrapper(BaseOpenAIClientWrapper):
         return self.client.chat.completions.create(
             model=model,
             messages=messages,
-            logprobs=log_probs,
+            logprobs=logprobs,
             stream=True,
             stream_options={"include_usage": True},
             **kwargs,
@@ -263,7 +263,7 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
         with self.client.streaming_chat_completions(
             model=self.model,
             messages=cast(list[dict[str, Any]], TypeAdapter(list[Message]).dump_python(self.state.messages)),
-            log_probs=self.log_probs,
+            logprobs=self.log_probs,
             top_logprobs=self.top_k if self.log_probs else None,
             **kwargs,
         ) as chunks:

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -197,7 +197,7 @@ class OpenAIClientWrapper(BaseOpenAIClientWrapper):
 class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
     """Base class for interacting with OpenAI models."""
 
-    log_probs: bool = True
+    logprobs: bool = True
     # TODO: have top-k be passed programmatically and only if echo=True
     top_k: Optional[int] = 5
 
@@ -263,8 +263,8 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
         with self.client.streaming_chat_completions(
             model=self.model,
             messages=cast(list[dict[str, Any]], TypeAdapter(list[Message]).dump_python(self.state.messages)),
-            logprobs=self.log_probs,
-            top_logprobs=self.top_k if self.log_probs else None,
+            logprobs=self.logprobs,
+            top_logprobs=self.top_k if self.logprobs else None,
             **kwargs,
         ) as chunks:
             yield from self._handle_stream(chunks)
@@ -500,7 +500,7 @@ class OpenAIImageMixin(BaseOpenAIInterpreter):
 
 class OpenAIAudioMixin(BaseOpenAIInterpreter):
     # Audio models don't support logprobs
-    log_probs: bool = False
+    logprobs: bool = False
 
     def audio_blob(self, node: AudioBlob, **kwargs) -> Iterator[OutputAttr]:
         format = "wav"  # TODO: infer from node

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -76,7 +76,7 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
 
         # Disable log_probs for any remote endpoints by default.
         # Otherwise, generation will fail for some endpoints.
-        self.log_probs = False
+        self.logprobs = False
 
         super().__init__(model=self.model, client=self.client, **kwargs)
 

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -21,7 +21,7 @@ class LiteLLMOpenAIClientWrapper(BaseOpenAIClientWrapper):
         self,
         model: str,
         messages: list[dict[str, Any]],
-        log_probs: bool,
+        logprobs: bool,
         **kwargs,
     ) -> Iterator["ChatCompletionChunk"]:
         """Wrapped completion call within a context manager."""
@@ -29,7 +29,7 @@ class LiteLLMOpenAIClientWrapper(BaseOpenAIClientWrapper):
         stream_wrapper = self.router.completion(
             model=model,
             messages=messages,
-            logprobs=log_probs,
+            logprobs=logprobs,
             **kwargs,
         )
 
@@ -45,14 +45,14 @@ class LiteLLMOpenAIClientWrapper(BaseOpenAIClientWrapper):
         self,
         model: str,
         messages: list[dict[str, Any]],
-        log_probs: bool,
+        logprobs: bool,
         **kwargs,
     ) -> ContextManager[Iterator["ChatCompletionChunk"]]:
         """Streaming chat completions."""
         return self._wrapped_completion(
             model=model,
             messages=messages,
-            log_probs=log_probs,
+            logprobs=logprobs,
             **kwargs,
         )  # type: ignore[return-value]
 


### PR DESCRIPTION
Largely a duplicate of #1314; attempting independent fix. Generally changes `log_probs` to `logprobs`, to match the underlying API.