### PR TITLE
Fix duplicated apply_temp_and_sampling_params on logits array

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -361,7 +361,7 @@ class Engine(ABC):
             return _logits
 
         # TODO: only get unmasked probs if we're either echoing or if we have no mask
-        filtered_logits = apply_temp_and_sampling_params(logits, sampling_params)
+        filtered_logits = apply_temp_and_sampling_params(np.array(logits), sampling_params)
         probs = softmax(filtered_logits)
 
         top_k: list[int] = []

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -361,7 +361,8 @@ class Engine(ABC):
             return _logits
 
         # TODO: only get unmasked probs if we're either echoing or if we have no mask
-        filtered_logits = apply_temp_and_sampling_params(np.array(logits), sampling_params)
+        # NOTE: we clone logits here to avoid modifying the original logits twice
+        filtered_logits = apply_temp_and_sampling_params(np.array(logits, copy=True), sampling_params)
         probs = softmax(filtered_logits)
 
         top_k: list[int] = []


### PR DESCRIPTION
Copy logits array before calling `apply_temp_and_sampling_params`, as this function mutates said logits.