### PR TITLE
Include top-k tokens for fast-forwarded and input tokens

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -436,7 +436,7 @@ class Engine(ABC):
 def get_top_k(_probs: NDArray, _k: int = 5) -> list[int]:
     if _k <= 0:
         return []
-    top_k_indices = _probs.argpartition(-_k)[-_k:]
+    top_k_indices = _probs.argpartition(-_k)[-_k:].tolist()
     # Sort by probability in descending order, as above argpartition
     # does not guarantee order. Sorting the smaller array is faster.
     return sorted(top_k_indices, key=lambda idx: _probs[idx], reverse=True)

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -148,11 +148,9 @@ class Engine(ABC):
                 else:
                     # Remove the issued token from ff_tokens
                     ff_tokens = ff_tokens[1:]
+                # Note: only need to update usage in this branch (issued_token is not None), as these ff_tokens
+                # will otherwise just be counted as "input_tokens" when we call get_logits below
                 usage.ff_tokens += len(ff_tokens)
-            else:
-                # If we don't have an issued token, we are at the start of the loop
-                # and we count all the ff_tokens as "input"
-                usage.input_tokens += len(ff_tokens)
 
             if parser.has_pending_stop() and (
                 # There are no ff_tokens

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -207,8 +207,10 @@ class LlamaCppEngine(Engine):
 
         # If our cached logits are valid, we can include them when we include_all_uncached_tokens
         # this lets us give logits FOR the first uncached token, not just the logits that follow it,
+        last_cache_included = False
         if self._cached_logits is not None and num_cached == len(self._cached_token_ids):
             logits_for_each_batch = [self._cached_logits] + logits_for_each_batch
+            last_cache_included = True
 
         # save the results
         self._cached_token_ids = token_ids.copy()
@@ -216,7 +218,7 @@ class LlamaCppEngine(Engine):
 
         if include_all_uncached_tokens:
             logits = np.concatenate(logits_for_each_batch, axis=0)
-            if self._cached_logits is not None and num_cached == len(self._cached_token_ids):
+            if last_cache_included:
                 assert logits.shape[0] == len(token_ids) - num_cached + 1
             else:
                 assert logits.shape[0] == len(token_ids) - num_cached

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -595,8 +595,10 @@ class TransformersEngine(Engine):
 
         # If our cached logits are valid, we can include them when we include_all_uncached_tokens
         # this lets us give logits FOR the first uncached token, not just the logits that follow it,
+        last_cache_included = False
         if self._cached_logits is not None and num_cached == len(self._cached_token_ids):
             logits_for_each_batch = [self._cached_logits] + logits_for_each_batch
+            last_cache_included = True
 
         # save the results
         self._past_key_values = model_out.past_key_values
@@ -605,7 +607,7 @@ class TransformersEngine(Engine):
 
         if include_all_uncached_tokens:
             logits = np.concatenate(logits_for_each_batch, axis=0)
-            if self._cached_logits is not None and num_cached == len(self._cached_token_ids):
+            if last_cache_included:
                 assert logits.shape[0] == len(token_ids) - num_cached + 1
             else:
                 assert logits.shape[0] == len(token_ids) - num_cached


### PR DESCRIPTION
- Applies sampling parameters before computing probabilities for ff and input tokens (previously we only included temperature)
   - Note: this happens sequentially / in a loop, so it may add some non-trivial overhead. But it increases consistency with the probabilities we show for generated tokens 
- Computes top-k and adds this as metadata to all tokens, not just those that are generated
   - This may also add some non-trivial overhead 
- Slight changes to llamacpp and transformers engines to ensure we remember the final logits from the previous forward pass. Shouldn't increase overhead as we're not maintaining a long "running cache"

@nopdive I'm somewhat hesitant to merge this before resolving one thing: all of the overheads listed above can be turned off by passing `enable_monitoring=False` at init time, but this is orthogonal to `echo`, and it happens without regard for whether the user is in a terminal or notebook environment (note: this is not a behavioral change). Do we have a way to programmatically check this?