### PR TITLE
[Notebooks] Re-enable 'Clear Syntax' notebook

### DIFF
--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -82,20 +82,8 @@ class TestArtOfPromptDesign:
         nb_path = TestArtOfPromptDesign.BASE_APD_PATH / "react.ipynb"
         run_notebook(nb_path)
 
-    @pytest.mark.xfail(reason="Issue #1004")
     def test_use_clear_syntax(self):
         call_delay_secs = slowdown()
 
-        azureai_endpoint = os.getenv("AZUREAI_CHAT_ENDPOINT", None)
-
-        parsed_url = urlparse(azureai_endpoint)
-        parsed_query = parse_qs(parsed_url.query)
-        azureai_deployment = pathlib.Path(parsed_url.path).parts[3]
-        version = parsed_query["api-version"]
-        min_azureai_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"
-
-        os.environ["AZUREAI_CHAT_BASE_ENDPOINT"] = min_azureai_endpoint
-        os.environ["AZUREAI_CHAT_API_VERSION"] = version[0]
-        os.environ["AZUREAI_CHAT_DEPLOYMENT"] = azureai_deployment
         nb_path = TestArtOfPromptDesign.BASE_APD_PATH / "use_clear_syntax.ipynb"
         run_notebook(nb_path, params=dict(call_delay_secs=call_delay_secs))


### PR DESCRIPTION
The 'Clear Syntax' notebook has been updated for use in the new website, and is now working. Tidy up some of the test infrastructure code which is no longer needed (and caused trouble on Windows).

Closes #1004 .