### PR TITLE
[Bug] Normalised capture names not preserved

### DIFF
--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -646,10 +646,10 @@ class LarkSerializer:
             res = name
             attrs = []
             if node.capture is not None:
-                if node.capture != name or node.list_append:
-                    capture_name = node.capture
-                    if node.list_append:
-                        capture_name = f"__LIST_APPEND:{capture_name}"
+                capture_name = node.capture
+                if node.list_append:
+                    capture_name = f"__LIST_APPEND:{capture_name}"
+                if capture_name != name:
                     attrs.append(f"capture={json.dumps(capture_name)}")
                 else:
                     attrs.append("capture")

--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -646,7 +646,7 @@ class LarkSerializer:
             res = name
             attrs = []
             if node.capture is not None:
-                if node.capture != node.name or node.list_append:
+                if node.capture != name or node.list_append:
                     capture_name = node.capture
                     if node.list_append:
                         capture_name = f"__LIST_APPEND:{capture_name}"

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -6,6 +6,15 @@ import guidance
 from guidance import gen, models, regex, select
 
 
+def test_capture_casing(selected_model):
+    # From issue 1172
+    lm = selected_model
+    lm += "This is a test of the capture function: " + gen(name="Text", max_tokens=10)
+    assert len(lm["Text"]) > 0
+    assert "Text" in lm
+    assert "text" not in lm
+
+
 def test_fstring(selected_model):
     lm = selected_model
     lm += f"this is a test {select(['item1', 'item2'])}"

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -9,10 +9,9 @@ from guidance import gen, models, regex, select
 def test_capture_casing(selected_model):
     # From issue 1172
     lm = selected_model
-    lm += "This is a test of the capture function: " + gen(name="Text", max_tokens=10)
-    assert len(lm["Text"]) > 0
-    assert "Text" in lm
-    assert "text" not in lm
+    lm += "This is a test of the capture function: " + gen(name="CamelCaseName", max_tokens=10)
+    assert "CamelCaseName" in lm
+    assert len(lm["CamelCaseName"]) > 0
 
 
 def test_fstring(selected_model):

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -11,6 +11,7 @@ def test_capture_casing(selected_model):
     lm = selected_model
     lm += "This is a test of the capture function: " + gen(name="CamelCaseName", max_tokens=10)
     assert "CamelCaseName" in lm
+    assert isinstance(lm["CamelCaseName"], str)
     assert len(lm["CamelCaseName"]) > 0
 
 

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -14,6 +14,19 @@ def test_capture_casing(selected_model):
     assert len(lm["CamelCaseName"]) > 0
 
 
+def test_capture_casing_listappend(selected_model):
+    lm = selected_model
+    lm += """Write three story title options about the arctic circle:
+OUTLINE
+"""
+    lm += '1. "' + gen(name="camelStory", max_tokens=20, list_append=True, stop='"') + '"'
+    lm += '2. "' + gen(name="camelStory", max_tokens=20, list_append=True, stop='"') + '"'
+    lm += '3. "' + gen(name="camelStory", max_tokens=20, list_append=True, stop='"') + '"'
+    assert isinstance(lm["camelStory"], list)
+    assert len(lm["camelStory"]) == 3
+    assert all(isinstance(item, str) for item in lm["camelStory"])
+
+
 def test_fstring(selected_model):
     lm = selected_model
     lm += f"this is a test {select(['item1', 'item2'])}"


### PR DESCRIPTION
We had a bug in the processing of capture names. If a capture name is also a valid Lark rule name, then it can be left in place. Otherwise (e.g. if it mixes upper and lower case), we have to normalise it, and use the `capture="OriginalName"` feature of our Lark grammar. This wasn't being done.

Fixes #1172 