### PR TITLE
[Build] Bump package pins

### DIFF
--- a/.github/workflows/ci_credentials.yml
+++ b/.github/workflows/ci_credentials.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - build/*
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - build/*
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -11,6 +11,9 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - build/*
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - build/*
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - build/*
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - build/*
   workflow_dispatch:
     inputs:
       commit_id:

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-llamacpp_requires = ["llama-cpp-python==0.3.12"]
-transformers_requires = ["transformers==4.51.3"]
+llamacpp_requires = ["llama-cpp-python==0.3.14"]
+transformers_requires = ["transformers==4.54.1"]
 
 install_requires = [
     "numpy",


### PR DESCRIPTION
Bump the pins on `transformers` and `llama-cpp-python`.

Also have the CI run on `build/*` branches, to make updates like this less tedious in future.