### PR TITLE
[OpenAI] Change kwarg for token limit

### DIFF
--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -418,7 +418,7 @@ class OpenAIRuleMixin(BaseOpenAIInterpreter):
         if node.temperature:
             kwargs["temperature"] = node.temperature
         if node.max_tokens:
-            kwargs["max_tokens"] = node.max_tokens
+            kwargs["max_completion_tokens"] = node.max_tokens
 
         chunks = self.run(node.value, **kwargs)
         if node.capture:


### PR DESCRIPTION
For GPT-5, it appears the `max_tokens` arg changes (or may well have been changed a while ago, but we did not update to the new name, and GPT-5 only supports the latter). There will be further updates for GPT-5, though