### PR TITLE
[Build] Pass through token for code coverage

### DIFF
--- a/.github/workflows/call_cpu_tests.yml
+++ b/.github/workflows/call_cpu_tests.yml
@@ -19,6 +19,8 @@ on:
     secrets:
       HF_TOKEN:
         required: false
+      CODECOV_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       os:

--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -19,6 +19,8 @@ on:
     secrets:
       HF_TOKEN:
         required: false
+      CODECOV_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       os:

--- a/.github/workflows/call_gpu_tests.yml
+++ b/.github/workflows/call_gpu_tests.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install other packages
         shell: bash
         run: |
-          python -m pip install accelerate
+          python -m pip install accelerate gpustat
       - name: Install guidance in ${{ inputs.os }}
         shell: bash
         run: |

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -41,6 +41,7 @@ jobs:
       codeCovPython: ${{ vars.CODECOV_PYTHON }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   cpu_big:
     strategy:
@@ -59,6 +60,7 @@ jobs:
       codeCovPython: ${{ vars.CODECOV_PYTHON }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   gpu_tests:
     strategy:
@@ -79,3 +81,4 @@ jobs:
       codeCovPython: ${{ vars.CODECOV_PYTHON }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[all,llamacpp,test]
+      - name: Install gpustat
+        shell: bash
+        run: |
+          python -m pip install gpustat
       - name: Azure login
         uses: azure/login@v2
         with:


### PR DESCRIPTION
It appears that we may not have been passing the CodeCov token around properly. Remedy this oversight.

Also ensure that `gpustat` is installed when it may be appropriate.