### PR TITLE
Add mask latency to usage

### DIFF
--- a/guidance/_schema.py
+++ b/guidance/_schema.py
@@ -34,6 +34,12 @@ class TokenUsage(BaseModel):
     ttft_ms: Annotated[float, Ge(0)] = 0.0
     """Time to first token in ms"""
 
+    mask_times_ms: list[Annotated[float, Ge(0)]] = Field(default_factory=list)
+    """List of mask times in ms for each token generated."""
+
+    mask_overheads_ms: list[Annotated[float, Ge(0)]] = Field(default_factory=list)
+    """List of mask overhead times in ms for each token generated."""
+
     @computed_field  # type: ignore[misc]
     @property
     def output_tokens(self) -> NonNegativeInt:

--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -313,6 +313,9 @@ class Model:
         # TODO(hudson): make this public API once we stabilize the data structure
         return self._interpreter.state.get_usage()
 
+    def _reset_usage(self) -> None:
+        self._interpreter.state.reset_usage()
+
 
 class ModelStream:
     def __init__(

--- a/guidance/models/_base/_state.py
+++ b/guidance/models/_base/_state.py
@@ -27,6 +27,10 @@ class State(ABC):
         """Get the current token usage."""
         return self._token_usage
 
+    def reset_usage(self) -> None:
+        """Reset the current token usage."""
+        self._token_usage = TokenUsage()
+
     @abstractmethod
     def __str__(self) -> str:
         pass

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -106,9 +106,8 @@ class Engine(ABC):
         sampling_params: Optional[SamplingParams]
             Additional sampling parameters to apply to the logits.
         """
-        # Note: t0 will get reset further down in the loop, just after the break condition
+        t0: Optional[float] = None
         _t0 = time.time()
-        t0 = _t0
 
         # TODO: Pass these to get_logits
         # images = state.images
@@ -129,6 +128,12 @@ class Engine(ABC):
         usage = TokenUsage(round_trips=1, ff_tokens=0)
 
         while not parser.done():
+            if t0 is None:
+                # On the first iteration, we include prompt tokenization + parser construction time
+                t0 = _t0
+            else:
+                t0 = time.time()
+
             recode = False
             if issued_token is None:
                 prefix_tokens, backtrack, ff_tokens, mask_fut = parser.process_prompt(
@@ -280,9 +285,6 @@ class Engine(ABC):
                 parser.cleanup()
                 # Ensure we break AFTER yielding the final response
                 break
-            # Reset time down here instead of at the top of the loop in order to make sure
-            # we take sampling time into account
-            t0 = time.time()
 
             # Help the type checker: assert that everything we need to get the next token is not None
             assert logits is not None

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -195,8 +195,10 @@ class Engine(ABC):
             mask, ll_response, mask_compute_ms = mask_fut.result()
             # Mask time is the time it took to advance the parser plus the total time spent computing mask
             usage.mask_times_ms.append(parser_lat_ms + mask_compute_ms)
-            # Mask overhead time is the time it took to advance the parser plus the total time spent on overhead
-            usage.mask_overheads_ms.append(parser_lat_ms + max(mask_compute_ms - logits_lat_ms, 0))
+            # Mask overhead time is the time it took to advance the parser plus the total time spent waiting
+            # on the mask future (i.e. time spent computing mask LESS the portion of that time parallelized with logits)
+            t4 = time.time()
+            usage.mask_overheads_ms.append(parser_lat_ms + (t4 - t3) * 1000)
 
             legacy_engine_response = ll_response.progress.to_engine_call_response()
 

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -195,7 +195,7 @@ class Engine(ABC):
 
             # Important: don't wait on this future until after getting the logits;
             # this allows the mask to be built concurrently with model inference
-            mask, ll_response = mask_fut.result()
+            mask, ll_response, _ = mask_fut.result()
             legacy_engine_response = ll_response.progress.to_engine_call_response()
 
             ff_probs: Optional[NDArray] = None


### PR DESCRIPTION
Adds some usage metrics:
1. `mask_times_ms` is a list of latencies that includes both 
   - the time to advance the parser (with related overheads such as tokenizing the backtrack bytes, recoding the tokens if needed, ...)
   - the time spent calculating the mask
2. `mask_overheads_ms` is the same, *less* the time that was parallelized with the logit computation
   - note: only the time spent calculating the mask can be parallelized 

Also adds a (private) method to Model: `_reset_usage`

@JC1DA happy to just return summary stats, but I figured the whole list might be more useful if you're looking for more distributional quantities.