### PR TITLE
Switch from `time.time` to `time.monotonic` for engine timing

### DIFF
--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -111,10 +111,10 @@ class TokenParser:
         return prefix_tokens, backtrack, ff_tokens, mask_fut
 
     def compute_mask(self) -> tuple[Optional[bytes], LLInterpreterResponse, float]:
-        t0 = time.time()
+        t0 = time.monotonic()
         mask, ll_response_string = self.ll_interpreter.compute_mask()
         ll_response = LLInterpreterResponse.model_validate_json(ll_response_string)
-        return mask, ll_response, (time.time() - t0) * 1000
+        return mask, ll_response, (time.monotonic() - t0) * 1000
 
     def _parse(
         self,


### PR DESCRIPTION
@JC1DA not sure how consistently you were able to repro the "negative time" issue, but please test this out and see if it fixes your issue. I don't see any logic errors with the timings, so all "should" be non-negative. Potentially, the issue has to do with timing in a thread, and `time.monotonic` should help if this is indeed the case. Perhaps a little over-zealously, I converted all the other `time.time` calls to `monotonic` too -- shouldn't hurt.