### PR TITLE
[Bug] Fix `chat_completion()` for Llama3

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -458,7 +458,7 @@ class Engine(ABC):
         with a Lark grammar.
         It is very much experimental in nature, and the API is subject to change.
         """
-        # Get some tokens
+        # Get the tokens which might be needed by the chat template
         tokens = {
             "eos_token": self.tokenizer.eos_token.decode("utf-8"),
             "bos_token": self.tokenizer.bos_token.decode("utf-8")

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -458,11 +458,17 @@ class Engine(ABC):
         with a Lark grammar.
         It is very much experimental in nature, and the API is subject to change.
         """
+        # Get some tokens
+        tokens = {
+            "eos_token": self.tokenizer.eos_token.decode("utf-8"),
+            "bos_token": self.tokenizer.bos_token.decode("utf-8")
+        }
+
         # Render the messages
         chat_template = self.get_chat_template().template_str
         rtemplate = Environment(loader=BaseLoader).from_string(chat_template)
         rendered_prompt = rtemplate.render(
-            messages=messages, eos_token=self.tokenizer.eos_token.decode("utf-8"), tools=tools
+            messages=messages, tools=tools, **tokens
         )
         rendered_prompt += self.get_chat_template().get_role_start("assistant")
 


### PR DESCRIPTION
The LLama3 chat template also needs the BOS token, so add that in when rendering the template.