### PR TITLE
[Test] Update for sentencepiece

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,6 @@ all_requires = set()
 for v in extras_requires.values():
     all_requires = all_requires.union(v)
 
-# See
-# https://github.com/guidance-ai/guidance/issues/1222
-sentencepiece_dependency = "sentencepiece" if sys.version_info.minor != 13 else "dbowring-sentencepiece"
-
 # Required for builds etc.
 doc_requires = [
     "ipython",

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ test_requires = [
     "papermill",
     "pillow",
     "protobuf",
-    sentencepiece_dependency,
+    "sentencepiece",
     "torch",
     "transformers",
     "tiktoken>=0.3",


### PR DESCRIPTION
It appears that `sentencepiece` has been updated with Python 3.13 support, and the [replacement package](https://pypi.org/project/dbowring-sentencepiece/) we were using has been yanked from PyPI. Update `setup.py` to reflect this.

Closes #1222 