### PR TITLE
[Test] Fix AOAI Tests for GPT-5

### DIFF
--- a/tests/model_specific/common_chat_testing.py
+++ b/tests/model_specific/common_chat_testing.py
@@ -4,7 +4,9 @@ from guidance import assistant, gen, models, system, user
 from guidance import json as gen_json
 
 
-def smoke_chat(lm: models.Model, has_system_role: bool = True, can_set_temperature: bool = True):
+def smoke_chat(
+    lm: models.Model, has_system_role: bool = True, can_set_temperature: bool = True, token_budget_factor: int = 1
+):
     if has_system_role:
         with system():
             lm += "You are a math wiz."
@@ -15,12 +17,13 @@ def smoke_chat(lm: models.Model, has_system_role: bool = True, can_set_temperatu
         lm += "What is 1 + 1?"
 
     with assistant():
-        lm += gen(max_tokens=10, name="text", temperature=response_temperature)
+        lm += gen(max_tokens=10 * token_budget_factor, name="text", temperature=response_temperature)
 
+    print(str(lm))
     assert len(lm["text"]) > 0
 
 
-def longer_chat_1(lm: models.Model, has_system_role: bool = True):
+def longer_chat_1(lm: models.Model, has_system_role: bool = True, token_budget_factor: int = 1):
     if has_system_role:
         with system():
             lm += "You are a math wiz."
@@ -29,7 +32,7 @@ def longer_chat_1(lm: models.Model, has_system_role: bool = True):
         lm += "What is 1 + 1?"
 
     with assistant():
-        lm += gen(max_tokens=10, name="text")
+        lm += gen(max_tokens=10 * token_budget_factor, name="text")
 
     print(str(lm))
     assert len(lm["text"]) > 0
@@ -38,13 +41,13 @@ def longer_chat_1(lm: models.Model, has_system_role: bool = True):
         lm += "10. Now you pick a number between 0 and 20"
 
     with assistant():
-        lm += gen(max_tokens=2, name="number")
+        lm += gen(max_tokens=20 * token_budget_factor, name="number")
 
     print(str(lm))
     assert len(lm["number"]) > 0
 
 
-def longer_chat_2(lm: models.Model, has_system_role: bool = True):
+def longer_chat_2(lm: models.Model, has_system_role: bool = True, token_budget_factor: int = 1):
     if has_system_role:
         with system():
             lm += "You are a math wiz."
@@ -61,7 +64,7 @@ def longer_chat_2(lm: models.Model, has_system_role: bool = True):
 
     # Resume the previous
     with assistant():
-        lm += gen(max_tokens=10, name="text")
+        lm += gen(max_tokens=10 * token_budget_factor, name="text")
 
     print(str(lm))
     assert len(lm["text"]) > 0
@@ -70,7 +73,7 @@ def longer_chat_2(lm: models.Model, has_system_role: bool = True):
         lm += "10. Now you pick a number between 0 and 20"
 
     with assistant():
-        lm += gen(max_tokens=2, name="number")
+        lm += gen(max_tokens=20 * token_budget_factor, name="number")
 
     print(str(lm))
     assert len(lm["number"]) > 0

--- a/tests/model_specific/common_chat_testing.py
+++ b/tests/model_specific/common_chat_testing.py
@@ -4,16 +4,18 @@ from guidance import assistant, gen, models, system, user
 from guidance import json as gen_json
 
 
-def smoke_chat(lm: models.Model, has_system_role: bool = True):
+def smoke_chat(lm: models.Model, has_system_role: bool = True, can_set_temperature: bool = True):
     if has_system_role:
         with system():
             lm += "You are a math wiz."
+
+    response_temperature = 0.5 if can_set_temperature else None
 
     with user():
         lm += "What is 1 + 1?"
 
     with assistant():
-        lm += gen(max_tokens=10, name="text", temperature=0.5)
+        lm += gen(max_tokens=10, name="text", temperature=response_temperature)
 
     assert len(lm["text"]) > 0
 

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -96,8 +96,10 @@ def azureai_image_model():
 
 
 def test_azureai_openai_chat_smoke(azureai_chat_model):
+    token_budget_factor = 1 if "gpt-5" not in azureai_chat_model._interpreter.model else 20
+    temperature_settable = "gpt-5" not in azureai_chat_model._interpreter.model
     common_chat_testing.smoke_chat(
-        azureai_chat_model, can_set_temperature=("gpt-5" not in azureai_chat_model._interpreter.model)
+        azureai_chat_model, can_set_temperature=temperature_settable, token_budget_factor=token_budget_factor
     )
 
 
@@ -132,11 +134,13 @@ def test_azureai_openai_image_smoke(azureai_image_model: models.Model):
 
 
 def test_azureai_openai_chat_longer_1(azureai_chat_model):
-    common_chat_testing.longer_chat_1(azureai_chat_model)
+    token_budget_factor = 1 if "gpt-5" not in azureai_chat_model._interpreter.model else 20
+    common_chat_testing.longer_chat_1(azureai_chat_model, token_budget_factor=token_budget_factor)
 
 
 def test_azureai_openai_chat_longer_2(azureai_chat_model):
-    common_chat_testing.longer_chat_2(azureai_chat_model)
+    token_budget_factor = 1 if "gpt-5" not in azureai_chat_model._interpreter.model else 20
+    common_chat_testing.longer_chat_2(azureai_chat_model, token_budget_factor=token_budget_factor)
 
 
 def test_azureai_openai_chat_loop(azureai_chat_model):

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -96,7 +96,9 @@ def azureai_image_model():
 
 
 def test_azureai_openai_chat_smoke(azureai_chat_model):
-    common_chat_testing.smoke_chat(azureai_chat_model)
+    common_chat_testing.smoke_chat(
+        azureai_chat_model, can_set_temperature=("gpt-5" not in azureai_chat_model._interpreter.model)
+    )
 
 
 def test_azureai_openai_chat_json(azureai_chat_model: models.Model):

--- a/tests/need_credentials/test_azureai_openai.py
+++ b/tests/need_credentials/test_azureai_openai.py
@@ -96,7 +96,10 @@ def azureai_image_model():
 
 
 def test_azureai_openai_chat_smoke(azureai_chat_model):
+    # GPT-5 needs more tokens for doing its reasoning (even though this is not shown)
+    # Ideally the gen() call would support max_completion_tokens
     token_budget_factor = 1 if "gpt-5" not in azureai_chat_model._interpreter.model else 20
+    # GPT-5 reasoning does not support setting a temperature
     temperature_settable = "gpt-5" not in azureai_chat_model._interpreter.model
     common_chat_testing.smoke_chat(
         azureai_chat_model, can_set_temperature=temperature_settable, token_budget_factor=token_budget_factor


### PR DESCRIPTION
Small tweaks to the AOAI tests, to allow use of GPT-5 models:
- Temperature is not supported with reasoning models, so remove this for GPT-5
- The 'reasoning' portion of the response was using up the token budget, so for GPT-5 models, expand `max_tokens`. Ideally we'd use `max_completion_tokens` but that's not currently exposed by `gen()`