### PR TITLE
[Dep] Bump llama-cpp-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-llamacpp_requires = ["llama-cpp-python==0.3.14"]
+llamacpp_requires = ["llama-cpp-python==0.3.16"]
 transformers_requires = ["transformers==4.53.3"]
 
 install_requires = [


### PR DESCRIPTION
Bump the version of `llama-cpp-python` used in tests to the latest. Unfortunately, `transformers` is proving less co-operative.