### PR TITLE
[Lint] PEP 604 (UP007, UP045)

### DIFF
--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -12,7 +12,6 @@ from typing import (
     Callable,
     Iterator,
     Literal,
-    Optional,
     Sequence,
     TypedDict,
     TypeVar,

--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -278,11 +278,11 @@ class GrammarNode(Tagged, ASTNode):
 
     def match(
         self,
-        byte_string: Union[str, bytes],
+        byte_string: str | bytes,
         allow_partial: bool = False,
         raise_exceptions: bool = False,
         enforce_max_tokens: bool = True,
-    ) -> Union[Match, None]:
+    ) -> Match | None:
         if isinstance(byte_string, str):
             byte_string = byte_string.encode()
         parser = ByteParser(self.ll_grammar(enforce_max_tokens=enforce_max_tokens))
@@ -328,9 +328,9 @@ class LiteralNode(GrammarNode):
 
 @dataclass(frozen=True)
 class SpecialToken(GrammarNode):
-    text: Optional[str] = None
-    id: Optional[int] = None
-    range: Optional[tuple[int, int]] = None
+    text: str | None = None
+    id: int | None = None
+    range: tuple[int, int] | None = None
 
     def __post_init__(self):
         if [self.text, self.id, self.range].count(None) != 2:
@@ -360,7 +360,7 @@ class SpecialToken(GrammarNode):
 
 @dataclass(frozen=True)
 class RegexNode(GrammarNode):
-    regex: Optional[str]
+    regex: str | None
 
     def _run(self, interpreter: "Interpreter[S]", **kwargs) -> Iterator[OutputAttr]:
         return interpreter.regex(self, **kwargs)
@@ -421,7 +421,7 @@ class JoinNode(GrammarNode):
 class RepeatNode(GrammarNode):
     node: GrammarNode
     min: int
-    max: Optional[int]
+    max: int | None
 
     @property
     def is_null(self) -> bool:
@@ -465,13 +465,13 @@ class SubstringNode(GrammarNode):
 class RuleNode(GrammarNode):
     name: str
     value: GrammarNode
-    capture: Optional[str] = None
+    capture: str | None = None
     list_append: bool = False
-    temperature: Optional[float] = None
-    max_tokens: Optional[int] = None
-    stop: Optional[Union[RegexNode, LiteralNode]] = None
-    suffix: Optional[LiteralNode] = None
-    stop_capture: Optional[str] = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+    stop: RegexNode | LiteralNode | None = None
+    suffix: LiteralNode | None = None
+    stop_capture: str | None = None
     lazy: bool = False
 
     def __post_init__(self) -> None:
@@ -508,7 +508,7 @@ class RuleNode(GrammarNode):
 
 @dataclass(frozen=True, eq=False)
 class RuleRefNode(GrammarNode):
-    target: Optional[RuleNode] = field(default=None, init=False)
+    target: RuleNode | None = field(default=None, init=False)
 
     def set_target(self, target: RuleNode) -> None:
         if self.target is not None:
@@ -544,7 +544,7 @@ class BaseSubgrammarNode(GrammarNode):
 @dataclass(frozen=True)
 class SubgrammarNode(BaseSubgrammarNode):
     body: GrammarNode
-    skip_regex: Optional[str] = None
+    skip_regex: str | None = None
 
     def _run(self, interpreter: "Interpreter[S]", **kwargs) -> Iterator[OutputAttr]:
         return interpreter.subgrammar(self, **kwargs)
@@ -552,23 +552,23 @@ class SubgrammarNode(BaseSubgrammarNode):
 
 class LLGJsonCompileOptions(TypedDict):
     # defaults to ","
-    item_separator: Optional[str]
+    item_separator: str | None
     # defaults to ":"
-    key_separator: Optional[str]
+    key_separator: str | None
     # defaults to None - depends on whitespace_flexible
-    whitespace_pattern: Optional[str]
+    whitespace_pattern: str | None
     # defaults to true (r"[\x20\x0A\x0D\x09]+"); if false, no whitespace is allowed
-    whitespace_flexible: Optional[bool]
+    whitespace_flexible: bool | None
     # defaults to false
-    coerce_one_of: Optional[bool]
+    coerce_one_of: bool | None
     # ignore unimplemented keywords; defaults to false
-    lenient: Optional[bool]
+    lenient: bool | None
 
 
 @dataclass(frozen=True, eq=False)
 class JsonNode(BaseSubgrammarNode):
-    schema: Optional[dict[str, Any]] = None
-    llg_options: Optional[LLGJsonCompileOptions] = None
+    schema: dict[str, Any] | None = None
+    llg_options: LLGJsonCompileOptions | None = None
 
     def _run(self, interpreter: "Interpreter[S]", **kwargs) -> Iterator[OutputAttr]:
         return interpreter.json(self, **kwargs)
@@ -615,15 +615,15 @@ class ToolCallNode(ASTNode):
     tools: dict[str, Tool]
     tool_choice: Literal["auto", "required"] = "auto"
     parallel_tool_calls: bool = False
-    plaintext_regex: Optional[str] = None
+    plaintext_regex: str | None = None
 
     @classmethod
     def from_tools(
         cls,
-        tools: list[Union[callable, Tool]],
+        tools: list[callable | Tool],
         tool_choice: Literal["auto", "required"] = "auto",
         parallel_tool_calls: bool = False,
-        plaintext_regex: Optional[str] = None,
+        plaintext_regex: str | None = None,
     ) -> "ToolCallNode":
         tool_defs = {}
         for tool in tools:

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -25,20 +25,20 @@ def regex(pattern: str) -> RegexNode:
 
 
 def gen(
-    regex: Optional[str] = None,
-    stop: Optional[str] = None,
-    stop_regex: Optional[str] = None,
-    suffix: Optional[str] = None,
-    stop_capture: Optional[str] = None,
-    name: Optional[str] = None,
-    temperature: Optional[float] = None,
-    max_tokens: Optional[int] = None,
+    regex: str | None = None,
+    stop: str | None = None,
+    stop_regex: str | None = None,
+    suffix: str | None = None,
+    stop_capture: str | None = None,
+    name: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
     list_append: bool = False,
 ) -> RuleNode:
     if stop is not None and stop_regex is not None:
         raise ValueError("You cannot specify both a stop and a stop_regex")
 
-    stop_value: Union[LiteralNode, RegexNode, None] = None
+    stop_value: LiteralNode | RegexNode | None = None
     if stop is not None:
         stop_value = LiteralNode(stop)
     elif stop_regex is not None:
@@ -59,8 +59,8 @@ def gen(
 
 
 def select(
-    options: Sequence[Union[str, int, float, GrammarNode]],
-    name: Optional[str] = None,
+    options: Sequence[str | int | float | GrammarNode],
+    name: str | None = None,
     list_append: bool = False,
 ) -> GrammarNode:
     """Choose between a set of options.
@@ -114,7 +114,7 @@ def select(
     )
 
 
-def repeat(value: Union[str, int, float, GrammarNode], min: int, max: Optional[int] = None) -> GrammarNode:
+def repeat(value: str | int | float | GrammarNode, min: int, max: int | None = None) -> GrammarNode:
     node: GrammarNode
     if isinstance(value, (int, float)):
         node = string(str(value))
@@ -181,10 +181,10 @@ def capture(value: GrammarNode, name: str, list_append: bool = False) -> RuleNod
 
 def subgrammar(
     body: GrammarNode,
-    name: Optional[str] = None,
-    skip_regex: Optional[str] = None,
-    max_tokens: Optional[int] = None,
-    temperature: Optional[float] = None,
+    name: str | None = None,
+    skip_regex: str | None = None,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
 ) -> RuleNode:
     capture_name = name
     name = name or (body.name if isinstance(body, RuleNode) else "subgrammar")

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -1,6 +1,6 @@
 import dataclasses
 import re
-from typing import Optional, Sequence, Union
+from typing import Sequence
 
 from ._ast import (
     Function,

--- a/guidance/_guidance.pyi
+++ b/guidance/_guidance.pyi
@@ -5,7 +5,6 @@ from typing import (
     Callable,
     Literal,
     TypeVar,
-    Union,
     overload,
 )
 

--- a/guidance/_guidance.pyi
+++ b/guidance/_guidance.pyi
@@ -21,7 +21,7 @@ _in_stateless_context: ContextVar[bool]
 
 P = ParamSpec("P")
 M: TypeAlias = Any  # sort of Union[Model, GrammarNode]?
-R = TypeVar("R", bound=Union[Function, RuleNode])
+R = TypeVar("R", bound=Function | RuleNode)
 GuidanceWrappable = Callable[Concatenate[M, P], M]
 GuidanceFunction = Callable[P, R]
 StatefulGuidanceFunction = GuidanceFunction[P, Function]
@@ -71,7 +71,7 @@ def guidance(
     cache: bool = ...,
     dedent: bool = ...,
     model: type[Model] = ...,
-) -> GuidanceFunction[P, Union[Function, RuleNode]]: ...
+) -> GuidanceFunction[P, Function | RuleNode]: ...
 @overload
 def guidance(
     f: None = None,
@@ -80,4 +80,4 @@ def guidance(
     cache: bool = ...,
     dedent: bool = ...,
     model: type[Model] = ...,
-) -> Callable[[GuidanceWrappable[P]], GuidanceFunction[P, Union[Function, RuleNode]]]: ...
+) -> Callable[[GuidanceWrappable[P]], GuidanceFunction[P, Function | RuleNode]]: ...

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -53,11 +53,11 @@ class TokenParser:
         return self._done
 
     def advance(
-        self, token_id: Optional[int]
+        self, token_id: int | None
     ) -> tuple[
         int,
         list[int],
-        Future[tuple[Optional[bytes], LLInterpreterResponse, float]],
+        Future[tuple[bytes | None, LLInterpreterResponse, float]],
     ]:
         if self.done():
             raise TokenParserException("Cannot advance on a done parser")
@@ -74,7 +74,7 @@ class TokenParser:
         int,  # backtrack
         list[int],  # ff_tokens
         # mask: Optional[bytes] (None if stop), ll_response: LLInterpreterResponse
-        Future[tuple[Optional[bytes], LLInterpreterResponse]],
+        Future[tuple[bytes | None, LLInterpreterResponse]],
     ]:
         new_prompt_tokens = self.ll_interpreter.process_prompt(prompt_tokens)
         if (
@@ -110,7 +110,7 @@ class TokenParser:
 
         return prefix_tokens, backtrack, ff_tokens, mask_fut
 
-    def compute_mask(self) -> tuple[Optional[bytes], LLInterpreterResponse, float]:
+    def compute_mask(self) -> tuple[bytes | None, LLInterpreterResponse, float]:
         t0 = time.monotonic()
         mask, ll_response_string = self.ll_interpreter.compute_mask()
         ll_response = LLInterpreterResponse.model_validate_json(ll_response_string)
@@ -123,14 +123,14 @@ class TokenParser:
             int,  # backtrack
             list[int],  # ff_tokens
             # mask: Optional[bytes] (None if stop), ll_response: LLInterpreterResponse, mask_compute_ms: float
-            Future[tuple[Optional[bytes], LLInterpreterResponse, float]],
+            Future[tuple[bytes | None, LLInterpreterResponse, float]],
         ],
-        Optional[int],
+        int | None,
         None,
     ]:
         backtrack = 0
         ff_tokens: list[int] = []
-        token_id: Optional[int] = None
+        token_id: int | None = None
         while True:
             # Note: need to call/set has_pending_stop before spinning up the compute mask
             # future as the two methods cannot be called concurrently
@@ -205,7 +205,7 @@ class ByteParser:
         self.tokenizer = ByteTokenizer()
         self.token_parser = TokenParser(grammar, self.tokenizer)
         self.bytes = b""
-        self.gen_data: Optional[GenData] = None
+        self.gen_data: GenData | None = None
         self.pos = 0
         self._variables: dict[str, Any] = {}
         self._variables_log_probs: dict[str, Any] = {}
@@ -230,7 +230,7 @@ class ByteParser:
             mask[t[0]] = 1
         return mask
 
-    def _advance(self, token_id: Optional[int]) -> None:
+    def _advance(self, token_id: int | None) -> None:
         if self.gen_data is not None:
             tokens = self.gen_data.tokens
         else:

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -1,7 +1,7 @@
 import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any, Generator, Optional
+from typing import TYPE_CHECKING, Any, Generator
 
 import llguidance  # type: ignore[import-untyped]
 import numpy as np

--- a/guidance/_schema.py
+++ b/guidance/_schema.py
@@ -19,7 +19,7 @@ class TokenUsage(BaseModel):
     cached_output_tokens: NonNegativeInt = 0
     """Number of forward passes we avoided by hitting the KV cache."""
 
-    ff_tokens: Optional[NonNegativeInt] = None
+    ff_tokens: NonNegativeInt | None = None
     """Number of output tokens that were fast-forwarded by the parser (if applicable)."""
 
     round_trips: NonNegativeInt = 0
@@ -54,7 +54,7 @@ class TokenUsage(BaseModel):
 
     @computed_field  # type: ignore[misc]
     @property
-    def token_savings(self) -> Optional[Annotated[float, Ge(0), Le(1)]]:
+    def token_savings(self) -> Annotated[float, Ge(0), Le(1)] | None:
         """The fraction of output tokens that were fast-forwarded by the parser (if applicable)."""
         if self.ff_tokens is None:
             return None
@@ -172,7 +172,7 @@ class LLProgressFinalText(BaseModel):
 
 
 LLProgressItem = Annotated[
-    Union[LLProgressCapture, LLProgressText, LLProgressFinalText],
+    LLProgressCapture | LLProgressText | LLProgressFinalText,
     Field(discriminator="object"),
 ]
 
@@ -226,11 +226,11 @@ class LLProgress(RootModel):
 class LLInterpreterResponse(BaseModel):
     progress: LLProgress
     stop: bool
-    temperature: Optional[float]
+    temperature: float | None
 
 
 class SamplingParams(TypedDict):
-    top_p: Optional[float]
-    top_k: Optional[int]
-    min_p: Optional[float]
-    repetition_penalty: Optional[float]
+    top_p: float | None
+    top_k: int | None
+    min_p: float | None
+    repetition_penalty: float | None

--- a/guidance/_schema.py
+++ b/guidance/_schema.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Any, Literal, Optional, TypedDict, Union
+from typing import Any, Literal, TypedDict
 
 from annotated_types import Ge, Le
 from pydantic import BaseModel, Field, NonNegativeInt, RootModel, computed_field, model_validator

--- a/guidance/_tools.py
+++ b/guidance/_tools.py
@@ -3,7 +3,7 @@ import inspect
 import textwrap
 import traceback
 from types import TracebackType
-from typing import TYPE_CHECKING, Annotated, Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Callable, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_serializer
 

--- a/guidance/_tools.py
+++ b/guidance/_tools.py
@@ -28,7 +28,7 @@ class CustomTool(BaseModel):
 
 class FunctionTool(BaseModel):
     type: Literal["function"] = "function"
-    parameters: Union[builtins.type[BaseModel], dict[str, Any]]
+    parameters: builtins.type[BaseModel] | dict[str, Any]
 
     @classmethod
     def from_callable(cls, callable: Callable) -> "FunctionTool":
@@ -62,7 +62,7 @@ class FunctionTool(BaseModel):
         return self.serialize_parameters(self.parameters)
 
     @field_serializer("parameters", mode="plain")
-    def serialize_parameters(self, parameters: Union[builtins.type[BaseModel], dict[str, Any]]) -> dict[str, Any]:
+    def serialize_parameters(self, parameters: builtins.type[BaseModel] | dict[str, Any]) -> dict[str, Any]:
         if isinstance(parameters, type) and issubclass(parameters, BaseModel):
             return parameters.model_json_schema()
         elif isinstance(parameters, dict):
@@ -71,7 +71,7 @@ class FunctionTool(BaseModel):
             raise TypeError(f"Unsupported parameters type: {type(parameters)}. Expected a Pydantic model or a dict.")
 
 
-ToolType = Annotated[Union[FunctionTool, CustomTool], Field(discriminator="type")]
+ToolType = Annotated[FunctionTool | CustomTool, Field(discriminator="type")]
 
 
 class Tool(BaseModel):
@@ -79,7 +79,7 @@ class Tool(BaseModel):
     description: str
     tool: ToolType
     callable: Callable
-    exc_formatter: Optional[Callable[[type[BaseException], BaseException, TracebackType], str]] = None
+    exc_formatter: Callable[[type[BaseException], BaseException, TracebackType], str] | None = None
 
     def call(self, *args, **kwargs) -> Any:
         try:
@@ -97,9 +97,9 @@ class Tool(BaseModel):
         cls,
         callable: Callable,
         *,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        parameters: Optional[Union[builtins.type[BaseModel], dict[str, Any]]] = None,
+        name: str | None = None,
+        description: str | None = None,
+        parameters: builtins.type[BaseModel] | dict[str, Any] | None = None,
     ) -> "Tool":
         if parameters is not None:
             tool = FunctionTool(parameters=parameters)
@@ -119,8 +119,8 @@ class Tool(BaseModel):
         pattern: str,
         callable: Callable,
         *,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
     ) -> "Tool":
         return Tool(
             name=name or callable.__name__,
@@ -140,8 +140,8 @@ class Tool(BaseModel):
         lark: str,
         callable: Callable,
         *,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
     ) -> "Tool":
         return Tool(
             name=name or callable.__name__,
@@ -161,8 +161,8 @@ class Tool(BaseModel):
         grammar: "GrammarNode",
         callable: Callable,
         *,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
     ) -> "Tool":
         from guidance._guidance import GuidanceFunction
 

--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -12,7 +12,7 @@ import textwrap
 import types
 import urllib
 import weakref
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import numpy as np
 import pydantic

--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def bytes_from(src: Union[str, pathlib.Path, bytes], allow_local: bool) -> bytes:
+def bytes_from(src: str | pathlib.Path | bytes, allow_local: bool) -> bytes:
     if isinstance(src, str) and re.match(r"[^:/]+://", src):
         with urllib.request.urlopen(src) as response:
             response = cast(http.client.HTTPResponse, response)

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -1,6 +1,5 @@
 import inspect
 import warnings
-from typing import Union
 
 
 class ChatTemplate:

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -9,7 +9,7 @@ class ChatTemplate:
     def get_role_start(self, role_name: str, **kwargs):
         raise NotImplementedError("You need to use a ChatTemplate subclass that overrides the get_role_start method")
 
-    def get_role_end(self, role_name: Union[str, None] = None):
+    def get_role_end(self, role_name: str | None = None):
         raise NotImplementedError("You need to use a ChatTemplate subclass that overrides the get_role_start method")
 
 

--- a/guidance/debug.py
+++ b/guidance/debug.py
@@ -34,7 +34,7 @@ def enable_widget_debug() -> None:
         logger.warning(f"Debug mode only available with Jupyter widget renderer, got {type(renderer)}")
 
 
-def dump_widget_debug() -> Optional[str]:
+def dump_widget_debug() -> str | None:
     """Get captured debug data as a JSON string.
 
     Returns the captured widget messages and state as a JSON string,

--- a/guidance/debug.py
+++ b/guidance/debug.py
@@ -1,7 +1,6 @@
 """Debug utilities for the guidance widget."""
 
 import logging
-from typing import Optional
 
 from .registry import get_renderer
 from .visual._renderer import AutoRenderer, JupyterWidgetRenderer

--- a/guidance/library/_audio.py
+++ b/guidance/library/_audio.py
@@ -1,6 +1,5 @@
 import base64
 import pathlib
-import typing
 
 from .._ast import AudioBlob, GenAudio
 from .._guidance import guidance

--- a/guidance/library/_audio.py
+++ b/guidance/library/_audio.py
@@ -8,7 +8,7 @@ from .._utils import bytes_from
 
 
 @guidance
-def audio(lm, src: typing.Union[str, pathlib.Path, bytes], allow_local: bool = True):
+def audio(lm, src: str | pathlib.Path | bytes, allow_local: bool = True):
     bytes_data = bytes_from(src, allow_local=allow_local)
     base64_bytes = base64.b64encode(bytes_data)
     lm += AudioBlob(data=base64_bytes)

--- a/guidance/library/_block.py
+++ b/guidance/library/_block.py
@@ -8,7 +8,7 @@ from ..models._base._model import _active_blocks
 
 class Block:
     def __init__(
-        self, name: Optional[str], opener: Union[str, Function, ASTNode], closer: Union[str, Function, ASTNode]
+        self, name: str | None, opener: str | Function | ASTNode, closer: str | Function | ASTNode
     ):
         self.name = name
         self.opener = opener

--- a/guidance/library/_block.py
+++ b/guidance/library/_block.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from typing import Optional, Union
 
 from .._ast import ASTNode, Function
 from .._guidance import _in_stateless_context

--- a/guidance/library/_ebnf.py
+++ b/guidance/library/_ebnf.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from llguidance.gbnf_to_lark import gbnf_to_lark as _gbnf_to_lark
 

--- a/guidance/library/_ebnf.py
+++ b/guidance/library/_ebnf.py
@@ -9,9 +9,9 @@ from .._grammar import capture, token_limit, with_temperature
 def lark(
     lark_grammar: str,
     *,
-    name: Optional[str] = None,
-    temperature: Optional[float] = None,
-    max_tokens: Optional[int] = None,
+    name: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
 ) -> GrammarNode:
     """
     Builds a guidance grammar from (a variant of) the EBNF syntax used by the Lark parsing toolkit.

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from .._ast import ToolCallNode
 from .._grammar import capture, quote_regex

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -18,13 +18,13 @@ def gen(
     regex=None,
     tools=None,
     hide_tool_call=False,
-    stop: Union[str, list[str], None] = None,
-    stop_regex: Union[str, list[str], None] = None,
-    suffix: Optional[str] = None,
+    stop: str | list[str] | None = None,
+    stop_regex: str | list[str] | None = None,
+    suffix: str | None = None,
     n=1,
     temperature=None,
     top_p=1.0,
-    save_stop_text: Union[bool, str] = False,
+    save_stop_text: bool | str = False,
     tool_choice: Literal["auto", "required"] = "auto",
 ):
     """Generate a set of tokens until a given stop criteria has been met.

--- a/guidance/library/_image.py
+++ b/guidance/library/_image.py
@@ -11,7 +11,7 @@ from ..trace._trace import ImageOutput
 
 
 @guidance
-def image(lm, src: typing.Union[str, pathlib.Path, bytes], allow_local: bool = True):
+def image(lm, src: str | pathlib.Path | bytes, allow_local: bool = True):
     if isinstance(src, str) and re.match(r"^(?!file://)[^:/]+://", src):
         lm += ImageUrl(url=src)
     else:

--- a/guidance/library/_image.py
+++ b/guidance/library/_image.py
@@ -2,7 +2,6 @@ import base64
 import importlib.resources
 import pathlib
 import re
-import typing
 
 from .._ast import ImageBlob, ImageUrl
 from .._guidance import guidance

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -1,5 +1,5 @@
 from json import loads as json_loads
-from typing import Any, Mapping, Optional, Union
+from typing import Any, Mapping, TypeAlias, Union
 
 import pydantic
 
@@ -7,7 +7,7 @@ from .._ast import JsonNode, LLGJsonCompileOptions, RuleNode
 from .._grammar import capture, token_limit, with_temperature
 from ._pydantic import pydantic_to_json_schema
 
-JSONSchema = Union[bool, Mapping[str, Any]]
+JSONSchema: TypeAlias = bool | Mapping[str, Any]
 
 
 def json(

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -11,20 +11,14 @@ JSONSchema = Union[bool, Mapping[str, Any]]
 
 
 def json(
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
-    schema: Union[
-        None,
-        str,
-        JSONSchema,
-        type[pydantic.BaseModel],
-        pydantic.TypeAdapter[Any],
-    ] = None,
-    temperature: Optional[float] = None,
-    max_tokens: Optional[int] = None,
-    separators: Optional[tuple[str, str]] = None,
+    schema: None | str | JSONSchema | type[pydantic.BaseModel] | pydantic.TypeAdapter[Any] = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    separators: tuple[str, str] | None = None,
     whitespace_flexible: bool = False,
-    whitespace_pattern: Optional[str] = None,
+    whitespace_pattern: str | None = None,
     lenient: bool = False,
 ):
     """Generate valid JSON according to the supplied JSON schema or `pydantic` model.

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -1,5 +1,5 @@
 from json import loads as json_loads
-from typing import Any, Mapping, TypeAlias, Union
+from typing import Any, Mapping, TypeAlias
 
 import pydantic
 

--- a/guidance/library/_sequences.py
+++ b/guidance/library/_sequences.py
@@ -15,7 +15,7 @@ def at_most_n_repeats(model, value, n_repeats: int):
 
 
 @guidance(stateless=True)
-def sequence(model, value, min_length: int = 0, max_length: Union[int, None] = None):
+def sequence(model, value, min_length: int = 0, max_length: int | None = None):
     # Just an alias for repeat for now -- TODO: remove?
     return model + repeat(value, min=min_length, max=max_length)
 

--- a/guidance/library/_sequences.py
+++ b/guidance/library/_sequences.py
@@ -1,4 +1,3 @@
-from typing import Union
 
 from .._grammar import repeat
 from .._guidance import guidance

--- a/guidance/library/_substring.py
+++ b/guidance/library/_substring.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, Iterable, Literal, Optional, Union
+from typing import Callable, Iterable, Literal
 
 from .._ast import RuleNode, SubstringNode
 

--- a/guidance/library/_substring.py
+++ b/guidance/library/_substring.py
@@ -11,8 +11,8 @@ def chunk_on_word(text: str) -> list[str]:
 def substring(
     target_string: str,
     *,
-    chunk: Union[Literal["word", "character"], Callable[[str], Iterable[str]]] = "word",
-    name: Optional[str] = None,
+    chunk: Literal["word", "character"] | Callable[[str], Iterable[str]] = "word",
+    name: str | None = None,
 ) -> RuleNode:
     chunks: Iterable[str]
     if chunk == "word":

--- a/guidance/library/_video.py
+++ b/guidance/library/_video.py
@@ -11,7 +11,7 @@ from ..trace._trace import VideoOutput
 
 
 @guidance
-def video(lm, src: typing.Union[str, pathlib.Path, bytes], allow_local: bool = True):
+def video(lm, src: str | pathlib.Path | bytes, allow_local: bool = True):
     # TODO(nopdive): Mock for testing. Remove all of this code later.
     bytes_data = bytes_from(src, allow_local=allow_local)
     base64_bytes = base64.b64encode(bytes_data)

--- a/guidance/library/_video.py
+++ b/guidance/library/_video.py
@@ -1,7 +1,6 @@
 import base64
 import importlib.resources
 import pathlib
-import typing
 
 from .._guidance import guidance
 from .._utils import bytes_from

--- a/guidance/models/_azureai.py
+++ b/guidance/models/_azureai.py
@@ -36,11 +36,11 @@ class AzureOpenAIInterpreter(OpenAIRuleMixin, OpenAIJSONMixin, OpenAIRegexMixin,
         azure_endpoint: str,
         azure_deployment: str,
         model_name: str,
-        api_version: Optional[str] = None,
-        api_key: Optional[str] = None,
-        azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[Callable[[], str]] = None,
-        reasoning_effort: Optional[str] = None,
+        api_version: str | None = None,
+        api_key: str | None = None,
+        azure_ad_token: str | None = None,
+        azure_ad_token_provider: Callable[[], str] | None = None,
+        reasoning_effort: str | None = None,
         **kwargs,
     ):
         try:
@@ -79,14 +79,14 @@ def create_azure_openai_model(
     echo: bool = True,
     *,
     model_name: str,
-    api_version: Optional[str] = None,
-    api_key: Optional[str] = None,
-    azure_ad_token: Optional[str] = None,
-    azure_ad_token_provider: Optional[Callable[[], str]] = None,
+    api_version: str | None = None,
+    api_key: str | None = None,
+    azure_ad_token: str | None = None,
+    azure_ad_token_provider: Callable[[], str] | None = None,
     has_audio_support: bool = False,
     has_image_support: bool = False,
-    sampling_params: Optional[SamplingParams] = None,
-    reasoning_effort: Optional[str] = None,
+    sampling_params: SamplingParams | None = None,
+    reasoning_effort: str | None = None,
     **kwargs,
 ) -> Model:
     """Create a Model capable of interacting with an Azure AI OpenAI deployment
@@ -192,7 +192,7 @@ class AzureInferenceInterpreter(OpenAIRuleMixin, OpenAIJSONMixin, OpenAIRegexMix
         endpoint: str,
         credential: Union["AzureKeyCredential", "TokenCredential"],
         model_name: str,
-        reasoning_effort: Optional[str] = None,
+        reasoning_effort: str | None = None,
     ):
         try:
             import azure.ai.inference
@@ -222,10 +222,10 @@ def create_azure_aifoundry_model(
     echo: bool = True,
     *,
     model_name: str,
-    api_key: Optional[str] = None,
+    api_key: str | None = None,
     token_credential: Optional["TokenCredential"] = None,
-    sampling_params: Optional[SamplingParams] = None,
-    reasoning_effort: Optional[str] = None,
+    sampling_params: SamplingParams | None = None,
+    reasoning_effort: str | None = None,
 ) -> Model:
     """Create a Model capable of interacting with an Azure AI OpenAI deployment
 
@@ -251,7 +251,7 @@ def create_azure_aifoundry_model(
             "Please install the azure-core package using `pip install -U azure-core` in order to use guidance.models.AzureAI!"
         ) from ie
 
-    credential: Union[AzureKeyCredential, TokenCredential, None] = None
+    credential: AzureKeyCredential | TokenCredential | None = None
     if api_key and token_credential:
         raise ValueError("Specify either api_key or token_credential")
     elif api_key:

--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -4,7 +4,7 @@ import queue
 import threading
 from contextvars import ContextVar, copy_context
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Iterator, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Iterator, TypeVar, Union
 
 from typing_extensions import Self
 

--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -72,14 +72,14 @@ class Model:
         self._active_blocks: dict[Block, int] = {}
         self.sampling_params: SamplingParams = sampling_params
 
-        self._parent: Optional["Model"] = None
-        self._parent_id: Optional[int] = None
+        self._parent: "Model" | None = None
+        self._parent_id: int | None = None
         self._id: int = _gen_id()
         self._trace_nodes: set[TraceNode] = set()
         self._update_trace_node(self._id, self._parent_id, None, False)
 
     def _update_trace_node(
-        self, identifier: int, parent_id: Optional[int], node_attr: Optional[NodeAttr] = None, echo=False
+        self, identifier: int, parent_id: int | None, node_attr: NodeAttr | None = None, echo=False
     ) -> None:
         from ..._topics import TRACE_TOPIC
         from ...registry import get_exchange, get_trace_handler
@@ -97,7 +97,7 @@ class Model:
                 topic=TRACE_TOPIC,
             )
 
-    def __add__(self, other: Union[str, Function, ASTNode]) -> Self:
+    def __add__(self, other: str | Function | ASTNode) -> Self:
         self = self.copy()
         self = self._apply_blocks()
         if isinstance(other, str):
@@ -233,7 +233,7 @@ class Model:
     def __contains__(self, key: str) -> bool:
         return key in self._interpreter.state.captures
 
-    def get(self, key: str, default: Optional[D] = None) -> Union[str, list[str], None, D]:
+    def get(self, key: str, default: D | None = None) -> str | list[str] | None | D:
         """Return the value of a variable, or a default value if the variable is not present.
 
         Parameters
@@ -248,7 +248,7 @@ class Model:
         except KeyError:
             return default
 
-    def set(self, key: str, value: Union[str, list[str]]) -> Self:
+    def set(self, key: str, value: str | list[str]) -> Self:
         """Return a new model with the given variable value set.
 
         Parameters
@@ -277,7 +277,7 @@ class Model:
         self._interpreter.state.captures.pop(key)
         return self
 
-    def log_prob(self, key: str, default: Optional[D] = None) -> Union[float, list[Union[float, None]], None, D]:
+    def log_prob(self, key: str, default: D | None = None) -> float | list[float | None] | None | D:
         """Return the log probability of a variable, or a default value if the variable is not present.
 
         Parameters
@@ -332,7 +332,7 @@ class ModelStream:
         self.grammar = grammar
         self.timeout = timeout
 
-    def __add__(self, grammar: Union[str, ASTNode]) -> Self:
+    def __add__(self, grammar: str | ASTNode) -> Self:
         """Extend this delayed chain of execution with another grammar append."""
         if self.grammar is None:
             return ModelStream(self.model, grammar)

--- a/guidance/models/_base/_state.py
+++ b/guidance/models/_base/_state.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from ..._schema import TokenUsage
 from ...metrics import emit_usage

--- a/guidance/models/_base/_state.py
+++ b/guidance/models/_base/_state.py
@@ -8,13 +8,13 @@ from ...trace import CaptureOutput
 
 class CaptureVar(TypedDict):
     value: str
-    log_prob: Optional[float]
+    log_prob: float | None
 
 
 class State(ABC):
-    def __init__(self, token_usage: Optional[TokenUsage] = None) -> None:
-        self.captures: dict[str, Union[CaptureVar, list[CaptureVar]]] = {}
-        self.active_role: Optional[str] = None
+    def __init__(self, token_usage: TokenUsage | None = None) -> None:
+        self.captures: dict[str, CaptureVar | list[CaptureVar]] = {}
+        self.active_role: str | None = None
         self._token_usage: TokenUsage = token_usage or TokenUsage()
 
     def add_usage(self, usage: TokenUsage) -> None:
@@ -36,7 +36,7 @@ class State(ABC):
         pass
 
     def apply_capture(
-        self, name: str, value: Optional[str], log_prob=Optional[float], is_append: bool = False
+        self, name: str, value: str | None, log_prob=Optional[float], is_append: bool = False
     ) -> CaptureOutput:
         if value is None:
             # A "reset" signal

--- a/guidance/models/_base/_state.py
+++ b/guidance/models/_base/_state.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, TypedDict, Union
+from typing import Optional, TypedDict
 
 from ..._schema import TokenUsage
 from ...metrics import emit_usage
@@ -36,7 +36,7 @@ class State(ABC):
         pass
 
     def apply_capture(
-        self, name: str, value: str | None, log_prob=Optional[float], is_append: bool = False
+        self, name: str, value: str | None, log_prob: float | None, is_append: bool = False
     ) -> CaptureOutput:
         if value is None:
             # A "reset" signal

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Generator, Optional, TypedDict, Union
+from typing import Any, Generator, TypedDict
 
 import numpy as np
 from jinja2 import BaseLoader, Environment

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -87,7 +87,7 @@ class Engine(ABC):
         state: EngineState,
         grammar: str,
         ensure_bos_token: bool = True,
-        sampling_params: Optional[SamplingParams] = None,
+        sampling_params: SamplingParams | None = None,
     ) -> Generator[EngineResponse, None, TokenUsage]:
         """Main entry point for the inference-parser loop. Yields EngineCallResponse objects as
         the parser advances through the grammar.
@@ -120,7 +120,7 @@ class Engine(ABC):
         )
 
         last_temperature = 1.0
-        issued_token: Optional[GenToken] = None
+        issued_token: GenToken | None = None
         usage = TokenUsage(round_trips=1, ff_tokens=0)
 
         while not parser.done():
@@ -201,7 +201,7 @@ class Engine(ABC):
 
             legacy_engine_response = ll_response.progress.to_engine_call_response()
 
-            ff_probs: Optional[NDArray] = None
+            ff_probs: NDArray | None = None
             if logits is not None and self._enable_token_probabilities:
                 # Exclude the "next token" logits
                 # Note: may not have logits for all ff tokens if some prefix of them hit cache
@@ -337,11 +337,11 @@ class Engine(ABC):
         logits: NDArray,
         logits_lat_ms: float,
         token_ids: list[int],
-        mask: Optional[bytes],
+        mask: bytes | None,
         temperature: float,
         k: int,
         compute_unmasked_probs: bool,
-        sampling_params: Optional[SamplingParams],
+        sampling_params: SamplingParams | None,
     ) -> GenTokenExtra:
         """Get the next token and associated top-k tokens from the engine.
 
@@ -376,7 +376,7 @@ class Engine(ABC):
         if k > 0 and not compute_unmasked_probs:
             raise ValueError("If k > 0, compute_unmasked_probs must be True to get the top-k tokens.")
 
-        probs: Optional[NDArray] = None
+        probs: NDArray | None = None
         top_k: list[int] = []
         if compute_unmasked_probs or mask is None:
             # NOTE: we clone logits here to avoid modifying the original logits twice
@@ -387,7 +387,7 @@ class Engine(ABC):
             # Get the top-k tokens from the unmasked logits
             top_k = get_top_k(probs, k)
 
-        masked_probs: Optional[NDArray] = None
+        masked_probs: NDArray | None = None
         if mask is not None:
             np_mask = np.frombuffer(mask, dtype=np.uint8)
             masked_logits = np.where(np_mask != 0, logits, -np.inf)
@@ -450,7 +450,7 @@ class Engine(ABC):
         )
 
     def chat_completion_streaming(
-        self, messages: dict[str, str], grammar: str, tools: Union[list[dict[str, Any]], None] = None
+        self, messages: dict[str, str], grammar: str, tools: list[dict[str, Any]] | None = None
     ) -> Generator[tuple[bytes, dict[str, str]], None, None]:
         """Generate a single streaming chat completion, constrained by a Lark grammar.
 
@@ -483,7 +483,7 @@ class Engine(ABC):
             yield nxt_bytes, nxt_captures
 
     def chat_completion(
-        self, messages: dict[str, str], grammar: str, tools: Union[list[dict[str, Any]], None] = None
+        self, messages: dict[str, str], grammar: str, tools: list[dict[str, Any]] | None = None
     ) -> tuple[str, dict[str, str]]:
         """Generate a single chat completion, constrained by a Lark grammar.
 
@@ -527,7 +527,7 @@ def apply_temp_and_sampling_params(
     logits: NDArray,
     token_ids: list[int],
     temperature: float,
-    sampling_params: Optional[SamplingParams],
+    sampling_params: SamplingParams | None,
 ) -> NDArray:
     """Apply the sampling parameters to the logits."""
     if sampling_params is None:

--- a/guidance/models/_engine/_tokenizer.py
+++ b/guidance/models/_engine/_tokenizer.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Sequence
 
 import llguidance
 

--- a/guidance/models/_engine/_tokenizer.py
+++ b/guidance/models/_engine/_tokenizer.py
@@ -10,7 +10,7 @@ from ...chat import ChatTemplate, load_template_class
 @dataclass
 class TokenizerWrappable:
     eos_token_id: int
-    bos_token_id: Optional[int]
+    bos_token_id: int | None
     tokens: list[bytes]
     special_token_ids: list[int]
     encode_callable: Callable[[bytes], list[int]]
@@ -33,8 +33,8 @@ class Tokenizer:
     def __init__(
         self,
         ll_tokenizer: llguidance.LLTokenizer,
-        chat_template: Union[str, ChatTemplate, None],
-        bos_token_id: Optional[int] = None,
+        chat_template: str | ChatTemplate | None,
+        bos_token_id: int | None = None,
     ):
         self._ll_tokenizer = ll_tokenizer
         # This method supports None, a huggingface style jinja2_template_str, or a ChatTemplate subclass
@@ -47,7 +47,7 @@ class Tokenizer:
         return self._ll_tokenizer.is_special_token(token_id)
 
     @property
-    def bos_token_id(self) -> Union[int, None]:
+    def bos_token_id(self) -> int | None:
         # Currently, lltokenizer does not have a bos_token attribute,
         # so we have to store our own if we want to use it
         return self._bos_token_id
@@ -57,7 +57,7 @@ class Tokenizer:
         return self._ll_tokenizer.eos_token
 
     @cached_property
-    def bos_token(self) -> Union[bytes, None]:
+    def bos_token(self) -> bytes | None:
         if self.bos_token_id is None:
             return None
         return self.decode([self.bos_token_id])
@@ -67,7 +67,7 @@ class Tokenizer:
         return self.decode([self.eos_token_id])
 
     @property
-    def chat_template(self) -> Union[Any, None]:
+    def chat_template(self) -> Any | None:
         return self._chat_template
 
     def __call__(self, byte_string: bytes):

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -5,7 +5,7 @@ import os
 import sys
 from itertools import takewhile
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -59,7 +59,7 @@ class _LlamaBatchContext:
 
 
 class LlamaCppTokenizer(Tokenizer):
-    def __init__(self, model_obj: "Llama", chat_template: Union[str, ChatTemplate, None] = None):
+    def __init__(self, model_obj: "Llama", chat_template: str | ChatTemplate | None = None):
         self._model_obj = model_obj
 
         vocab = llama_cpp.llama_model_get_vocab(model_obj.model)
@@ -245,7 +245,7 @@ class LlamaCpp(Model):
         enable_backtrack=True,
         enable_ff_tokens=True,
         enable_monitoring=True,
-        sampling_params: Optional[SamplingParams] = None,
+        sampling_params: SamplingParams | None = None,
         **llama_cpp_kwargs,
     ):
         """Build a new LlamaCpp model object that represents a model in a given state."""

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class MockTokenizer(Tokenizer):
-    def __init__(self, tokens: Sequence[bytes], special_token_ids: Optional[list[int]] = None):
+    def __init__(self, tokens: Sequence[bytes], special_token_ids: list[int] | None = None):
         self.tokens = tokens
         self.byte_trie = ByteTrie(self.tokens, np.arange(len(self.tokens)))
 
@@ -93,14 +93,14 @@ class MockEngine(Engine):
 
     def get_next_token_with_top_k(
         self,
-        logits: Optional[np.ndarray],
-        logits_lat_ms: Optional[float],
+        logits: np.ndarray | None,
+        logits_lat_ms: float | None,
         token_ids: list[int],
-        mask: Optional[bytes],
+        mask: bytes | None,
         temperature: float,
         k: int,
         compute_unmasked_probs: bool,
-        sampling_params: Optional[SamplingParams],
+        sampling_params: SamplingParams | None,
     ) -> GenTokenExtra:
         self.called_temperatures.append(temperature)
         return super().get_next_token_with_top_k(
@@ -166,7 +166,7 @@ class Mock(Model):
     def __init__(
         self,
         byte_patterns=[],
-        sampling_params: Optional[SamplingParams] = None,
+        sampling_params: SamplingParams | None = None,
         echo=False,
         force=False,
         **kwargs,

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Sequence
+from typing import Sequence
 
 import numpy as np
 

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -18,8 +18,8 @@ class OpenAIInterpreter(OpenAIRuleMixin, OpenAIJSONMixin, OpenAIRegexMixin, Base
     def __init__(
         self,
         model: str,
-        api_key: Optional[str] = None,
-        reasoning_effort: Optional[str] = None,
+        api_key: str | None = None,
+        reasoning_effort: str | None = None,
         **kwargs,
     ):
         try:
@@ -37,11 +37,11 @@ class OpenAI(Model):
     def __init__(
         self,
         model: str,
-        sampling_params: Optional[SamplingParams] = None,
+        sampling_params: SamplingParams | None = None,
         echo: bool = True,
         *,
-        api_key: Optional[str] = None,
-        reasoning_effort: Optional[str] = None,
+        api_key: str | None = None,
+        reasoning_effort: str | None = None,
         **kwargs,
     ):
         """Build a new OpenAI model object that represents a model in a given state.

--- a/guidance/models/_openai.py
+++ b/guidance/models/_openai.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from guidance._schema import SamplingParams
 

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -5,7 +5,7 @@ import wave
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Literal, TypeAlias, Union, cast
 
 from pydantic import BaseModel, Discriminator, Field, TypeAdapter
 from typing_extensions import Annotated, assert_never
@@ -81,7 +81,7 @@ class ImageUrlContent(BaseModel):
     image_url: ImageUrlContentInner
 
 
-Content = Annotated[TextContent | AudioContent | ImageUrlContent, Discriminator("type")]
+Content: TypeAlias = Annotated[TextContent | AudioContent | ImageUrlContent, Discriminator("type")]
 
 
 class ContentMessage(BaseModel):
@@ -125,7 +125,7 @@ class ToolCallResult(BaseModel):
     content: str
 
 
-Message = Union[ContentMessage, AssistantAudioMessage, ToolCallMessage, ToolCallResult]
+Message: TypeAlias = ContentMessage | AssistantAudioMessage | ToolCallMessage | ToolCallResult
 
 
 class OpenAIState(State):

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -81,7 +81,7 @@ class ImageUrlContent(BaseModel):
     image_url: ImageUrlContentInner
 
 
-Content = Annotated[Union[TextContent, AudioContent, ImageUrlContent], Discriminator("type")]
+Content = Annotated[TextContent | AudioContent | ImageUrlContent, Discriminator("type")]
 
 
 class ContentMessage(BaseModel):
@@ -111,7 +111,7 @@ class CustomCall(BaseModel):
     custom: Custom
 
 
-ToolCall = Annotated[Union[FunctionCall, CustomCall], Discriminator("type")]
+ToolCall = Annotated[FunctionCall | CustomCall, Discriminator("type")]
 
 
 class ToolCallMessage(BaseModel):
@@ -133,7 +133,7 @@ class OpenAIState(State):
         super().__init__()
         self.messages: list[Message] = []
         self.content: list[Content] = []
-        self.audio: Optional[AssistantAudio] = None
+        self.audio: AssistantAudio | None = None
 
     def apply_text(self, text: str) -> None:
         if len(self.content) > 0 and isinstance(self.content[-1], TextContent):
@@ -141,7 +141,7 @@ class OpenAIState(State):
         else:
             self.content.append(TextContent(type="text", text=text))
 
-    def get_active_message(self) -> Optional[Message]:
+    def get_active_message(self) -> Message | None:
         if self.active_role is None:
             return None
         if self.active_role not in ["system", "user", "assistant"]:
@@ -253,9 +253,9 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
 
     logprobs: bool = True
     # TODO: have top-k be passed programmatically and only if echo=True
-    top_k: Optional[int] = 5
+    top_k: int | None = 5
 
-    def __init__(self, model: str, client: BaseOpenAIClientWrapper, *, reasoning_effort: Optional[str] = None):
+    def __init__(self, model: str, client: BaseOpenAIClientWrapper, *, reasoning_effort: str | None = None):
         super().__init__(state=OpenAIState())
         self.model = model
         self.client = client
@@ -291,7 +291,7 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
         self.state.apply_text(node.value)
         yield TextOutput(value=node.value, is_input=True)
 
-    def _run(self, tools: Optional[dict[str, Tool]] = None, **kwargs) -> Iterator[OutputAttr]:
+    def _run(self, tools: dict[str, Tool] | None = None, **kwargs) -> Iterator[OutputAttr]:
         if self.state.active_role is None:
             # Should never happen?
             raise ValueError("OpenAI models require chat blocks (e.g. use `with assistant(): ...`)")
@@ -336,11 +336,11 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
     def _handle_stream(
         self,
         chunks: Iterator["ChatCompletionChunk"],
-        tools: Optional[dict[str, Tool]],
+        tools: dict[str, Tool] | None,
     ) -> Iterator[OutputAttr]:
         _t0 = time.time()
         t0 = _t0
-        audio: Optional[AssistantAudio] = None
+        audio: AssistantAudio | None = None
         final_tool_calls: dict[int, ToolCall] = {}
         # We made another call to the OpenAI API, so we count it as a round trip.
         usage = TokenUsage(round_trips=1)
@@ -402,8 +402,8 @@ class BaseOpenAIInterpreter(Interpreter[OpenAIState]):
                         )
                 else:
                     yield TextOutput(value=delta.content, is_generated=True, latency_ms=latency_ms)
-            elif (delta_audio := cast(Optional[dict], getattr(delta, "audio", None))) is not None:
-                transcript_chunk: Optional[str] = None
+            elif (delta_audio := cast(dict | None, getattr(delta, "audio", None))) is not None:
+                transcript_chunk: str | None = None
                 if audio is None:
                     assert delta_audio.get("id") is not None
                     audio = AssistantAudio(

--- a/guidance/models/_openai_base.py
+++ b/guidance/models/_openai_base.py
@@ -5,7 +5,7 @@ import wave
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Literal, TypeAlias, Union, cast
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Literal, TypeAlias, cast
 
 from pydantic import BaseModel, Discriminator, Field, TypeAdapter
 from typing_extensions import Annotated, assert_never

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -4,7 +4,7 @@ import re
 import textwrap
 import warnings
 from itertools import takewhile
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 import numpy as np
 

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -58,7 +58,7 @@ class TransformersTokenizer(Tokenizer):
     def __init__(
         self,
         hf_tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
-        chat_template: Union[str, ChatTemplate, None] = None,
+        chat_template: str | ChatTemplate | None = None,
     ):
         self._orig_tokenizer = hf_tokenizer
 
@@ -95,7 +95,7 @@ class TransformersTokenizer(Tokenizer):
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: str,
-        chat_template: Union[str, ChatTemplate, None] = None,
+        chat_template: str | ChatTemplate | None = None,
         use_fast=True,
         **kwargs,
     ) -> "TransformersTokenizer":
@@ -383,11 +383,7 @@ class TransformersEngine(Engine):
             self.model = model
         self.device = self.model_obj.device  # otherwise note the current device
 
-        self._past_key_values: Union[
-            transformers_package.Cache,
-            tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]],
-            None,
-        ] = None
+        self._past_key_values: transformers_package.Cache | tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]] | None = None
         self._cached_logits = None
         self._cached_token_ids: list[int] = []
 
@@ -632,13 +628,13 @@ class Transformers(Model):
             "PreTrainedTokenizerFast",
             None,
         ] = None,
-        interpreter_cls: Optional[type[EngineInterpreter]] = None,
+        interpreter_cls: type[EngineInterpreter] | None = None,
         echo=True,
         chat_template=None,
         enable_backtrack=True,
         enable_ff_tokens=True,
         enable_monitoring=True,
-        sampling_params: Optional[SamplingParams] = None,
+        sampling_params: SamplingParams | None = None,
         **kwargs,
     ):
         """Build a new Transformers model object that represents a model in a given state."""

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -264,7 +264,7 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
 
 class LiteLLM(Model):
     def __init__(
-        self, model_description: dict, sampling_params: Optional[SamplingParams] = None, echo: bool = True, **kwargs
+        self, model_description: dict, sampling_params: SamplingParams | None = None, echo: bool = True, **kwargs
     ):
         interpreter = LiteLLMInterpreter(model_description=model_description, **kwargs)
         super().__init__(

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Optional
+from typing import TYPE_CHECKING, Any, ContextManager, Iterator
 
 from guidance._schema import SamplingParams
 

--- a/guidance/models/experimental/_sglang.py
+++ b/guidance/models/experimental/_sglang.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Optional
+from typing import Iterator
 
 from guidance._schema import SamplingParams
 

--- a/guidance/models/experimental/_sglang.py
+++ b/guidance/models/experimental/_sglang.py
@@ -12,8 +12,8 @@ class SglangInterpreter(BaseOpenAIInterpreter):
     def __init__(
         self,
         model: str,
-        base_url: Optional[str] = None,
-        api_key: Optional[str] = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
         **kwargs,
     ):
         try:
@@ -156,7 +156,7 @@ class SglangInterpreter(BaseOpenAIInterpreter):
 
 
 class SglangModel(Model):
-    def __init__(self, model: str, sampling_params: Optional[SamplingParams] = None, echo: bool = True, **kwargs):
+    def __init__(self, model: str, sampling_params: SamplingParams | None = None, echo: bool = True, **kwargs):
         super().__init__(
             interpreter=SglangInterpreter(model=model, **kwargs),
             sampling_params=SamplingParams() if sampling_params is None else sampling_params,

--- a/guidance/models/experimental/_vllm.py
+++ b/guidance/models/experimental/_vllm.py
@@ -12,8 +12,8 @@ class VLLMInterpreter(BaseOpenAIInterpreter):
     def __init__(
         self,
         model: str,
-        base_url: Optional[str] = None,
-        api_key: Optional[str] = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
         **kwargs,
     ):
         try:
@@ -88,7 +88,7 @@ class VLLMInterpreter(BaseOpenAIInterpreter):
 
 
 class VLLMModel(Model):
-    def __init__(self, model: str, sampling_params: Optional[SamplingParams] = None, echo: bool = True, **kwargs):
+    def __init__(self, model: str, sampling_params: SamplingParams | None = None, echo: bool = True, **kwargs):
         super().__init__(
             interpreter=VLLMInterpreter(model=model, **kwargs),
             sampling_params=SamplingParams() if sampling_params is None else sampling_params,

--- a/guidance/models/experimental/_vllm.py
+++ b/guidance/models/experimental/_vllm.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Optional
+from typing import Iterator
 
 from guidance._schema import SamplingParams
 

--- a/guidance/trace/_trace.py
+++ b/guidance/trace/_trace.py
@@ -3,7 +3,7 @@
 import logging
 import weakref
 from itertools import count
-from typing import Annotated, Any, ClassVar, Generator, Optional, Union
+from typing import Annotated, Any, ClassVar, Generator, Optional
 
 from pydantic import Base64Bytes, BaseModel, Discriminator, Field, Tag, computed_field, model_validator
 

--- a/guidance/trace/_trace.py
+++ b/guidance/trace/_trace.py
@@ -37,7 +37,7 @@ class NodeAttr(BaseModel):
     @classmethod
     def as_discriminated_union(cls) -> type["NodeAttr"]:
         return Annotated[
-            Union[tuple(Annotated[tp, Tag(tp.__name__)] for tp in cls._subclasses)],
+            tuple(Annotated[tp, Tag(tp.__name__)] for tp in cls._subclasses),
             Discriminator(
                 lambda x: x["class_name"] if isinstance(x, dict) else x.class_name,
             ),
@@ -121,9 +121,9 @@ class RoleOpenerInput(InputAttr):
     This usually occurs as a role context and __enter__ is called.
     """
 
-    name: Optional[str] = None
-    text: Optional[str] = None
-    closer_text: Optional[str] = None
+    name: str | None = None
+    text: str | None = None
+    closer_text: str | None = None
 
 
 class RoleCloserInput(InputAttr):
@@ -132,8 +132,8 @@ class RoleCloserInput(InputAttr):
     This usually occurs as a role context and __exit__ is called.
     """
 
-    name: Optional[str] = None
-    text: Optional[str] = None
+    name: str | None = None
+    text: str | None = None
 
 
 class AudioOutput(OutputAttr):
@@ -182,7 +182,7 @@ class Token(BaseModel):
 
 class TokenOutput(TextOutput):
     token: Token
-    top_k: Optional[list[Token]] = None
+    top_k: list[Token] | None = None
 
 
 class Backtrack(OutputAttr):
@@ -197,7 +197,7 @@ class CaptureOutput(OutputAttr):
     """
 
     name: str
-    value: Optional[str] = None
+    value: str | None = None
     is_append: bool = False
     log_probs: float = 0.0
 
@@ -354,7 +354,7 @@ class TraceHandler(BaseModel):
     def __hash__(self):
         return hash(id(self))
 
-    def update_node(self, identifier: int, parent_id: Optional[int], node_attr: Optional[NodeAttr] = None) -> TraceNode:
+    def update_node(self, identifier: int, parent_id: int | None, node_attr: NodeAttr | None = None) -> TraceNode:
         """Update the trace node with the given identifier.
 
         If the trace node does not exist, it will be created.

--- a/guidance/visual/_jupyter.py
+++ b/guidance/visual/_jupyter.py
@@ -1,7 +1,7 @@
 """Jupyter specific utilities."""
 
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 from uuid import uuid4
 
 try:

--- a/guidance/visual/_jupyter.py
+++ b/guidance/visual/_jupyter.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 IPythonCallback = Callable[[Any], None]
 
 
-def ipy_handle_event_once(cb: IPythonCallback, event_name: str) -> tuple[Optional[IPythonCallback], str]:
+def ipy_handle_event_once(cb: IPythonCallback, event_name: str) -> tuple[IPythonCallback | None, str]:
     ipy = get_ipython()
     cell_session_id = str(uuid4())
 

--- a/guidance/visual/_message.py
+++ b/guidance/visual/_message.py
@@ -4,7 +4,7 @@ Messages are required to be added to the model registry for serialization.
 """
 
 from itertools import count
-from typing import Annotated, ClassVar, Optional, Union
+from typing import Annotated, ClassVar
 
 from pydantic import BaseModel, Discriminator, Field, Tag, TypeAdapter, computed_field, model_validator
 

--- a/guidance/visual/_message.py
+++ b/guidance/visual/_message.py
@@ -38,7 +38,7 @@ class GuidanceMessage(BaseModel):
     @classmethod
     def as_discriminated_union(cls) -> type["GuidanceMessage"]:
         return Annotated[
-            Union[tuple(Annotated[tp, Tag(tp.__name__)] for tp in cls._subclasses)],
+            tuple(Annotated[tp, Tag(tp.__name__)] for tp in cls._subclasses),
             Discriminator(
                 lambda x: x["class_name"] if isinstance(x, dict) else x.class_name,
             ),
@@ -49,15 +49,15 @@ class TraceMessage(GuidanceMessage):
     """Update on a trace node."""
 
     trace_id: int
-    parent_trace_id: Optional[int] = None
-    node_attr: Optional[NodeAttr.as_discriminated_union()] = None  # type: ignore
+    parent_trace_id: int | None = None
+    node_attr: NodeAttr.as_discriminated_union() | None = None  # type: ignore
 
 
 class MetricMessage(GuidanceMessage):
     """Metric that has been emitted."""
 
     name: str
-    value: Union[float, str, list[float], list[str]] = Field(union_mode="left_to_right")
+    value: float | str | list[float] | list[str] = Field(union_mode="left_to_right")
     scalar: bool = True
 
 
@@ -71,7 +71,7 @@ class ExecutionCompletedMessage(GuidanceMessage):
     This functions as the last message sent to client.
     """
 
-    last_trace_id: Optional[int] = None
+    last_trace_id: int | None = None
     is_err: bool = False
 
 

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -10,7 +10,7 @@ import traceback
 from asyncio import Queue
 from functools import lru_cache, partial
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from warnings import warn
 from weakref import ReferenceType, WeakKeyDictionary, WeakValueDictionary, finalize, ref
 

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -111,7 +111,7 @@ def _put_nowait_queue(queue: Queue, val: object) -> None:
     get_bg_async().call_soon_threadsafe(queue.put_nowait, val)
 
 
-def _cleanup(recv_queue: Optional[Queue], send_queue: Optional[Queue], log_msg: str, exchange_cb) -> None:
+def _cleanup(recv_queue: Queue | None, send_queue: Queue | None, log_msg: str, exchange_cb) -> None:
     from ..registry import get_exchange
 
     log_cleanup(log_msg)
@@ -289,9 +289,9 @@ class JupyterWidgetRenderer(Renderer):
         self.widget_messages: WeakKeyDictionary["StitchWidget", list[GuidanceMessage]] = WeakKeyDictionary()
         self.widgets: WeakValueDictionary[str, "StitchWidget"] = WeakValueDictionary()
         self.last_widget_key = ""
-        self.last_widget: Optional[ReferenceType["StitchWidget"]] = None
-        self.last_trace_id: Optional[int] = None
-        self._last_cell_session_id: Optional[str] = None
+        self.last_widget: ReferenceType["StitchWidget"] | None = None
+        self.last_trace_id: int | None = None
+        self._last_cell_session_id: str | None = None
 
         self._trace_handler = trace_handler
         self._completed = False
@@ -521,7 +521,7 @@ class JupyterWidgetRenderer(Renderer):
         self._debug_messages = []
         logger.info("Debug messages cleared")
 
-    def get_debug_data(self) -> Optional[str]:
+    def get_debug_data(self) -> str | None:
         """Get debug data as a JSON string.
 
         Returns:

--- a/guidance/visual/_trace.py
+++ b/guidance/visual/_trace.py
@@ -27,7 +27,7 @@ def trace_node_to_html(node: TraceNode, prettify_roles=False) -> str:
     """
     buffer = []
     node_path = list(node.path())
-    active_role: Optional[TraceNode] = None
+    active_role: TraceNode | None = None
 
     for node in node_path:
         # Check if any input is a role opener or closer

--- a/guidance/visual/_trace.py
+++ b/guidance/visual/_trace.py
@@ -2,7 +2,6 @@
 
 import html
 import json
-from typing import Optional
 
 from ..trace import (
     ImageOutput,

--- a/packages/python/stitch/stitch/tests/test_example.py
+++ b/packages/python/stitch/stitch/tests/test_example.py
@@ -4,7 +4,6 @@
 # Copyright (c) Guidance Contributors.
 # Distributed under the terms of the Modified BSD License.
 
-import pytest
 
 from ..stitch import StitchWidget
 

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -10,7 +10,7 @@ from ..utils import slowdown
 BASE_NB_PATH = pathlib.Path("./notebooks").absolute()
 
 
-def run_notebook(notebook_path: pathlib.Path, params: Optional[dict[str, Any]] = None):
+def run_notebook(notebook_path: pathlib.Path, params: dict[str, Any] | None = None):
     assert notebook_path.exists(), f"Checking for: {notebook_path}"
     output_nb = notebook_path.stem + ".papermill_out" + notebook_path.suffix
     output_path = notebook_path.parent / output_nb

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Any, Optional
+from typing import Any
 
 import papermill as pm
 import pytest

--- a/tests/unit/library/json/utils.py
+++ b/tests/unit/library/json/utils.py
@@ -2,7 +2,7 @@ import json
 from functools import partial
 from json import dumps as json_dumps
 from json import loads as json_loads
-from typing import Any, Optional, Union
+from typing import Any
 
 from jsonschema import validate
 

--- a/tests/unit/library/json/utils.py
+++ b/tests/unit/library/json/utils.py
@@ -16,8 +16,8 @@ from ....utils import generate_and_check as _generate_and_check
 
 def generate_and_check(
     target_obj: Any,
-    schema_obj: Union[str, JSONSchema],
-    desired_temperature: Optional[float] = None,
+    schema_obj: str | JSONSchema,
+    desired_temperature: float | None = None,
 ):
     if isinstance(schema_obj, str):
         schema_obj = json_loads(schema_obj)
@@ -44,10 +44,10 @@ def generate_and_check(
 def check_match_failure(
     *,
     bad_string: str,
-    good_bytes: Optional[bytes] = None,
-    failure_byte: Optional[bytes] = None,
-    allowed_bytes: Optional[set[bytes]] = None,
-    schema_obj: Union[str, JSONSchema],
+    good_bytes: bytes | None = None,
+    failure_byte: bytes | None = None,
+    allowed_bytes: set[bytes] | None = None,
+    schema_obj: str | JSONSchema,
 ):
     grammar = gen_json(schema=schema_obj)
 

--- a/tests/unit/library/test_pydantic.py
+++ b/tests/unit/library/test_pydantic.py
@@ -24,7 +24,7 @@ def json_dumps(target: Any) -> str:
 
 def validate_obj(
     target_obj: Any,
-    pydantic_model: Union[type[pydantic.BaseModel], pydantic.TypeAdapter],
+    pydantic_model: type[pydantic.BaseModel] | pydantic.TypeAdapter,
 ):
     if inspect.isclass(pydantic_model) and issubclass(pydantic_model, pydantic.BaseModel):
         return pydantic_model.model_validate(target_obj, strict=True)
@@ -35,7 +35,7 @@ def validate_obj(
 
 def validate_string(
     target_str: Any,
-    pydantic_model: Union[type[pydantic.BaseModel], pydantic.TypeAdapter],
+    pydantic_model: type[pydantic.BaseModel] | pydantic.TypeAdapter,
 ):
     if inspect.isclass(pydantic_model) and issubclass(pydantic_model, pydantic.BaseModel):
         return pydantic_model.model_validate_json(target_str, strict=True)
@@ -46,7 +46,7 @@ def validate_string(
 
 def generate_and_check(
     target_obj: Any,
-    pydantic_model: Union[type[pydantic.BaseModel], pydantic.TypeAdapter],
+    pydantic_model: type[pydantic.BaseModel] | pydantic.TypeAdapter,
 ):
     # Sanity check what we're being asked
     target_obj = validate_obj(target_obj, pydantic_model)
@@ -63,7 +63,7 @@ def check_match_failure(
     good_bytes: bytes,
     failure_byte: bytes,
     allowed_bytes: set[bytes],
-    pydantic_model: Union[type[pydantic.BaseModel], pydantic.TypeAdapter],
+    pydantic_model: type[pydantic.BaseModel] | pydantic.TypeAdapter,
 ):
     bad_string = json_dumps(bad_obj)
     grammar = gen_json(schema=pydantic_model)
@@ -115,7 +115,7 @@ def test_model_with_optional(has_A):
 
     class B(pydantic.BaseModel):
         b_str: str = pydantic.Field(default="Some string")
-        my_A: Union[A, None] = pydantic.Field(default=None)
+        my_A: A | None = pydantic.Field(default=None)
 
     if has_A:
         my_obj = B(my_A=A(my_str="a long string or two"))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 import os
 import random
 import time
-from typing import Optional, Protocol
+from typing import Protocol
 
 import pytest
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,9 +125,9 @@ def check_match_success_with_guards(grammar, test_string: str):
 def check_match_failure(
     *,
     bad_string: str,
-    good_bytes: Optional[bytes] = None,
-    failure_byte: Optional[bytes] = None,
-    allowed_bytes: Optional[set[bytes]] = None,
+    good_bytes: bytes | None = None,
+    failure_byte: bytes | None = None,
+    allowed_bytes: set[bytes] | None = None,
     grammar: GrammarNode,
 ):
     """


### PR DESCRIPTION
Rewrites `Union[X, Y]` as `X | Y` and `Optional[X]` as `X | None`.

@riedgar-ms we could add UP007 and UP045 to the extend-select if you'd like to enforce this moving forward, but for now, I just wanted to modernize what we have a little bit 😉 