### PR TITLE
[Linting] use `select` rather than `extend-select` in ruff.lint settings

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -42,8 +42,8 @@ jobs:
         run: |
           # This is separate from formatting. See:
           # https://docs.astral.sh/ruff/formatter/#sorting-imports
-          if ! ruff check --select I --select RUF022; then
-            echo "::warning title=ruff import::Files need import sorting (run 'ruff check --select I --select RUF022' locally)"
+          if ! ruff check --select I,RUF022; then
+            echo "::warning title=ruff import::Files need import sorting (run 'ruff check --select I,RUF022 --fix' locally to auto-fix)"
             exit 78  # no longer works in github, but would mark action step with a warning
           fi
       - name: Mark step with a warning
@@ -61,7 +61,7 @@ jobs:
               completed_at: new Date().toISOString(),
               output: {
                 title: 'ruff found violations',
-                summary: 'Run `ruff format . and `ruff check --select I` locally and push the changes.'
+                summary: 'Run `ruff format . and `ruff check --select I,RUF022 --fix` locally and push the changes.'
               }
             })
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ To install the correct version, run `pip install -e .[dev]`.
 You can then run `ruff format /path/to/modified/file.py` to format the code.
 The path can also be an entire directory, or omitted entirely to format all files beneath the current directory.
 There are (rare) cases where manual formatting is preferable; for these [`ruff` provides pragmas for suppression](https://docs.astral.sh/ruff/formatter/#format-suppression).
-To sort imports, use `ruff check --select I /path/to/modified/file.py`.
+To sort imports, use `ruff check --select I /path/to/modified/file.py --fix`.
 These commands are run (but not enforced *yet*) in the build.
 
 

--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -598,7 +598,7 @@ class JsonNode(BaseSubgrammarNode):
         else:
             # this will warn about oneOf coercion, and any other unsupported features if lenient is enabled
             for message in messages:
-                warnings.warn(message)
+                warnings.warn(message, stacklevel=2)
 
 
 @dataclass(frozen=True, eq=False)

--- a/guidance/_parser.py
+++ b/guidance/_parser.py
@@ -101,7 +101,7 @@ class TokenParser:
         #       else prompt_tokens
         #   ) + ff_tokens
         backtrack = len(prompt_tokens)
-        for old, new in zip(prompt_tokens, new_prompt_tokens):
+        for old, new in zip(prompt_tokens, new_prompt_tokens, strict=False):
             if old != new:
                 break
             backtrack -= 1

--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -72,7 +72,7 @@ def load_template_class(chat_template=None):
         warnings.warn(
             f"""Chat template {chat_template} was unable to be loaded directly into guidance.
                         Defaulting to the ChatML format which may not be optimal for the selected model. 
-                        For best results, create and pass in a `guidance.ChatTemplate` subclass for your model."""
+                        For best results, create and pass in a `guidance.ChatTemplate` subclass for your model.""", stacklevel=2
         )
 
     # By default, use the ChatML Template. Warnings to user will happen downstream only if they use chat roles.

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -128,7 +128,7 @@ def gen(
         stop_regex = [quote_regex(s) for s in stop]
         stop = None
     if isinstance(stop_regex, list):
-        stop_regex = "|".join([r for r in stop_regex])
+        stop_regex = "|".join(list(stop_regex))
 
     if save_stop_text is False:
         save_stop_name = None

--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -305,7 +305,7 @@ class Model:
     def __getattribute__(self, name):
         if name == "engine":
             # For legacy model.engine access (mostly for tests...)
-            return getattr(self._interpreter, "engine")
+            return self._interpreter.engine
         return super().__getattribute__(name)
 
     def _get_usage(self) -> TokenUsage:

--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -437,7 +437,7 @@ class Engine(ABC):
                 is_generated=True,
                 is_masked=mask is not None and bool(mask[token_id] == 0),
             )
-            for token_id, token_bytes in zip(top_k, top_k_token_bytes)
+            for token_id, token_bytes in zip(top_k, top_k_token_bytes, strict=True)
         ]
 
         return GenTokenExtra(

--- a/guidance/models/_engine/_interpreter.py
+++ b/guidance/models/_engine/_interpreter.py
@@ -125,7 +125,7 @@ class EngineInterpreter(Interpreter[EngineState]):
                 if isinstance(values, list):
                     assert isinstance(log_probs, list)
                     assert len(values) == len(log_probs)
-                    for value, log_prob in zip(values, log_probs):
+                    for value, log_prob in zip(values, log_probs, strict=True):
                         yield self.state.apply_capture(name, value.decode("utf-8"), log_prob=log_prob, is_append=True)
                 else:
                     assert isinstance(log_probs, float)

--- a/guidance/models/_mock.py
+++ b/guidance/models/_mock.py
@@ -165,14 +165,15 @@ class MockEngine(Engine):
 class Mock(Model):
     def __init__(
         self,
-        byte_patterns=[],
+        byte_patterns=None,
         sampling_params: SamplingParams | None = None,
         echo=False,
         force=False,
         **kwargs,
     ):
         """Build a new Mock model object that represents a model in a given state."""
-
+        if byte_patterns is None:
+            byte_patterns = []
         # Our tokens are all bytes and all lowercase letter pairs
         all_lc_pairs = [bytes([i, j]) for i in range(ord("a"), ord("z")) for j in range(ord("a"), ord("z"))]
         all_bytes = [bytes([i]) for i in range(256)]

--- a/guidance/models/_transformers.py
+++ b/guidance/models/_transformers.py
@@ -339,7 +339,7 @@ class TransformersTokenizer(Tokenizer):
                 cs.append(256 + n)
                 n += 1
         cs = [chr(n) for n in cs]
-        return dict(zip(bs, cs))
+        return dict(zip(bs, cs, strict=True))
 
 
 class TransformersEngine(Engine):

--- a/guidance/models/broken_models/_vertexai.py
+++ b/guidance/models/broken_models/_vertexai.py
@@ -199,10 +199,10 @@ class VertexAIChatEngine(VertexAIEngine):
                 if end_pos < 0:
                     break
                 messages.append(
-                    dict(
-                        role="user",
-                        content=prompt[pos : pos + end_pos].decode("utf8"),
-                    )
+                    {
+                        "role": "user",
+                        "content": prompt[pos : pos + end_pos].decode("utf8"),
+                    }
                 )
                 pos += end_pos + len(role_end)
             elif prompt[pos:].startswith(assistant_start):
@@ -212,10 +212,10 @@ class VertexAIChatEngine(VertexAIEngine):
                     valid_end = True
                     break
                 messages.append(
-                    dict(
-                        role="assistant",
-                        content=prompt[pos : pos + end_pos].decode("utf8"),
-                    )
+                    {
+                        "role": "assistant",
+                        "content": prompt[pos : pos + end_pos].decode("utf8"),
+                    }
                 )
                 pos += end_pos + len(role_end)
             else:

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -160,7 +160,7 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
         if "extra_body" not in kwargs:
             kwargs["extra_body"] = {}
 
-        kwargs["extra_body"].update(dict(guided_decoding_backend="guidance", guided_regex=node.regex))
+        kwargs["extra_body"].update({"guided_decoding_backend": "guidance", "guided_regex": node.regex})
 
         buffer: str = ""
         for attr in self._run(**kwargs):
@@ -211,7 +211,7 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
         if "extra_body" not in kwargs:
             kwargs["extra_body"] = {}
 
-        kwargs["extra_body"].update(dict(guided_decoding_backend="guidance", guided_grammar=node.ll_grammar()))
+        kwargs["extra_body"].update({"guided_decoding_backend": "guidance", "guided_grammar": node.ll_grammar()})
 
         buffer: str = ""
         for attr in self._run(**kwargs):

--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -234,7 +234,7 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
                 if isinstance(value, list):
                     assert isinstance(log_probs, list)
                     assert len(value) == len(log_probs)
-                    for v, l in zip(value, log_probs):
+                    for v, l in zip(value, log_probs, strict=True):
                         yield self.state.apply_capture(name=name, value=v, log_prob=l, is_append=True)
                 else:
                     yield self.state.apply_capture(name=name, value=value, log_prob=log_probs, is_append=False)

--- a/guidance/models/experimental/_sglang.py
+++ b/guidance/models/experimental/_sglang.py
@@ -31,9 +31,9 @@ class SglangInterpreter(BaseOpenAIInterpreter):
 
         # Disable this check for now as all the supported endpoints have 'stop' support.
         if node.suffix:
-            raise ValueError(f"suffix not yet supported for sglang endpoint")
+            raise ValueError("suffix not yet supported for sglang endpoint")
         if node.stop_capture:
-            raise ValueError(f"stop_capture not yet supported for sglang endpoint")
+            raise ValueError("stop_capture not yet supported for sglang endpoint")
 
         kwargs = kwargs.copy()
         if node.temperature:

--- a/guidance/models/experimental/_sglang.py
+++ b/guidance/models/experimental/_sglang.py
@@ -67,7 +67,7 @@ class SglangInterpreter(BaseOpenAIInterpreter):
         if "extra_body" not in kwargs:
             kwargs["extra_body"] = {}
 
-        kwargs["extra_body"].update(dict(regex=node.regex))
+        kwargs["extra_body"].update({"regex": node.regex})
 
         buffer: str = ""
         for attr in self._run(**kwargs):

--- a/guidance/models/experimental/_sglang.py
+++ b/guidance/models/experimental/_sglang.py
@@ -123,7 +123,7 @@ class SglangInterpreter(BaseOpenAIInterpreter):
                 if isinstance(value, list):
                     assert isinstance(log_probs, list)
                     assert len(value) == len(log_probs)
-                    for v, l in zip(value, log_probs):
+                    for v, l in zip(value, log_probs, strict=True):
                         yield self.state.apply_capture(name=name, value=v, log_prob=l, is_append=True)
                 else:
                     yield self.state.apply_capture(name=name, value=value, log_prob=log_probs, is_append=False)

--- a/guidance/models/experimental/_vllm.py
+++ b/guidance/models/experimental/_vllm.py
@@ -56,7 +56,7 @@ class VLLMInterpreter(BaseOpenAIInterpreter):
                 if isinstance(value, list):
                     assert isinstance(log_probs, list)
                     assert len(value) == len(log_probs)
-                    for v, l in zip(value, log_probs):
+                    for v, l in zip(value, log_probs, strict=True):
                         yield self.state.apply_capture(name=name, value=v, log_prob=l, is_append=True)
                 else:
                     yield self.state.apply_capture(name=name, value=value, log_prob=log_probs, is_append=False)

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -451,7 +451,7 @@ class JupyterWidgetRenderer(Renderer):
 
             # Redraw
             display(widget)
-            logger.debug(f"RENDERER:widget displayed")
+            logger.debug("RENDERER:widget displayed")
 
             self._last_cell_session_id = last_cell_session_id
             self._running = True

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -607,7 +607,7 @@ class AutoRenderer(Renderer):
             self._renderer = DoNothingRenderer(trace_handler=trace_handler)
         else:  # pragma: no cover
             logger.error("Env detection has failed. This is a bug.")
-            warn("Env detection has failed. No renderer will be provided.")
+            warn("Env detection has failed. No renderer will be provided.", stacklevel=2)
             self._renderer = DoNothingRenderer(trace_handler=trace_handler)
 
         super().__init__()

--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -150,7 +150,7 @@ def _on_cell_completion(renderer_weakref: ReferenceType["JupyterWidgetRenderer"]
             is_err=info.error_in_exec is not None,
         )
         renderer.update(message)
-    except Exception:
+    except Exception:  # noqa: BLE001
         logger.error(f"CELL_COMPLETE:{traceback.format_exc()}")
 
 
@@ -192,7 +192,7 @@ async def _handle_recv_messages(
                 get_exchange().publish(ClientReadyAckMessage(), VISUAL_TOPIC)
 
             renderer.recv_queue.task_done()
-        except Exception as _:
+        except Exception as _:  # noqa: BLE001
             logger.error(f"RECV:err:{traceback.format_exc()}")
 
 
@@ -234,7 +234,7 @@ async def _handle_send_messages(
             else:
                 logger.debug("SEND:jupyter:send but no widget")
             renderer.send_queue.task_done()
-        except Exception as _:
+        except Exception as _:  # noqa: BLE001
             logger.error(f"SEND:err:{traceback.format_exc()}")
 
 

--- a/guidance/visual/_trace.py
+++ b/guidance/visual/_trace.py
@@ -119,8 +119,8 @@ def trace_node_to_str(node: TraceNode) -> str:
         Output as string.
     """
     buffer = []
-    for node in node.path():
-        for output_attr in node.output:
+    for subnode in node.path():
+        for output_attr in subnode.output:
             if isinstance(output_attr, TextOutput):
                 buffer.append(str(output_attr))
     return "".join(buffer)
@@ -144,6 +144,6 @@ def display_trace_tree(trace_handler: TraceHandler) -> None:
         trace_viz_map[node] = viz_node
     viz_root = trace_viz_map[root]
 
-    for pre, fill, node in RenderTree(viz_root):
+    for pre, _fill, node in RenderTree(viz_root):
         tree_str = "%s%s" % (pre, node.name)
         print(tree_str)

--- a/guidance/visual/_trace.py
+++ b/guidance/visual/_trace.py
@@ -93,7 +93,7 @@ def trace_node_to_html(node: TraceNode, prettify_roles=False) -> str:
                 # Check if any input in active role is a RoleCloserInput
                 has_role_closer = any(isinstance(inp, RoleCloserInput) for inp in active_role.input)
                 if has_role_closer and prettify_roles:
-                    buffer.append(f"</div></div>")
+                    buffer.append("</div></div>")
                 active_role = None
             elif isinstance(output_attr, ImageOutput):
                 buffer.append(

--- a/packages/python/stitch/stitch/__init__.py
+++ b/packages/python/stitch/stitch/__init__.py
@@ -7,6 +7,8 @@
 from ._version import __version__, version_info
 from .stitch import StitchWidget
 
+__all__ = ["StitchWidget", "__version__", "_jupyter_labextension_paths", "_jupyter_nbextension_paths", "version_info"]
+
 
 def _jupyter_labextension_paths():
     """Called by Jupyter Lab Server to detect if it is a valid labextension and

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [lint]
 select = [
-  # "B",        # flake8-bugbear
+  "B",        # flake8-bugbear
   "I",        # isort
   # "ARG",      # flake8-unused-arguments
   "C4",       # flake8-comprehensions

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,6 +22,6 @@ select = [
   # "F541",     # flake8 f-string without any placeholders
   "BLE001",   # No bare 'except' clauses
   "RUF022",   # Sort __all__
-  # "UP007",    # PEP 604 Union[X, Y] -> X | Y
-  # "UP045",    # PEP 604 Optional[X] -> X | None
+  "UP007",    # PEP 604 Union[X, Y] -> X | Y
+  "UP045",    # PEP 604 Optional[X] -> X | None
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,13 +15,13 @@ exclude = [
 [lint]
 select = [
   # "B",        # flake8-bugbear
-  # "I",        # isort
+  "I",        # isort
   # "ARG",      # flake8-unused-arguments
   # "C4",       # flake8-comprehensions
   # "F401",     # flake8-unused-imports
   # "F541",     # flake8 f-string without any placeholders
   # "BLE001",   # No bare 'except' clauses
-  # "RUF022",   # Sort __all__
+  "RUF022",   # Sort __all__
   # "UP007",    # PEP 604 Union[X, Y] -> X | Y
   # "UP045",    # PEP 604 Optional[X] -> X | None
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,14 +14,14 @@ exclude = [
 
 [lint]
 select = [
-  "B",        # flake8-bugbear
-  "I",        # isort
-  "ARG",      # flake8-unused-arguments
-  "C4",       # flake8-comprehensions
-  "F401",     # flake8-unused-imports
-  "F541",     # flake8 f-string without any placeholders
-  "BLE001",   # No bare 'execpt' clauses
-  "RUF022",   # Sort __all__
-  "UP007",    # PEP 604 Union[X, Y] -> X | Y
-  "UP045",    # PEP 604 Optional[X] -> X | None
+  # "B",        # flake8-bugbear
+  # "I",        # isort
+  # "ARG",      # flake8-unused-arguments
+  # "C4",       # flake8-comprehensions
+  # "F401",     # flake8-unused-imports
+  # "F541",     # flake8 f-string without any placeholders
+  # "BLE001",   # No bare 'except' clauses
+  # "RUF022",   # Sort __all__
+  # "UP007",    # PEP 604 Union[X, Y] -> X | Y
+  # "UP045",    # PEP 604 Optional[X] -> X | None
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,7 +18,7 @@ select = [
   # "B",        # flake8-bugbear
   "I",        # isort
   # "ARG",      # flake8-unused-arguments
-  # "C4",       # flake8-comprehensions
+  "C4",       # flake8-comprehensions
   "F401",     # flake8-unused-imports
   "F541",     # flake8 f-string without any placeholders
   "BLE001",   # No bare 'except' clauses

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,7 +19,7 @@ select = [
   # "ARG",      # flake8-unused-arguments
   # "C4",       # flake8-comprehensions
   # "F401",     # flake8-unused-imports
-  # "F541",     # flake8 f-string without any placeholders
+  "F541",     # flake8 f-string without any placeholders
   "BLE001",   # No bare 'except' clauses
   "RUF022",   # Sort __all__
   "UP007",    # PEP 604 Union[X, Y] -> X | Y

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [lint]
-extend-select = [
+select = [
   "B",        # flake8-bugbear
   "I",        # isort
   "ARG",      # flake8-unused-arguments

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,6 +8,7 @@ line-length = 120
 # Because notebooks are tougher
 include = [ "*.py", "*.pyi", "pyproject.toml" ]
 exclude = [
+    "docs",
     ".eggs",
     ".git",
 ]
@@ -18,7 +19,7 @@ select = [
   "I",        # isort
   # "ARG",      # flake8-unused-arguments
   # "C4",       # flake8-comprehensions
-  # "F401",     # flake8-unused-imports
+  "F401",     # flake8-unused-imports
   "F541",     # flake8 f-string without any placeholders
   "BLE001",   # No bare 'except' clauses
   "RUF022",   # Sort __all__

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,7 +20,7 @@ select = [
   # "C4",       # flake8-comprehensions
   # "F401",     # flake8-unused-imports
   # "F541",     # flake8 f-string without any placeholders
-  # "BLE001",   # No bare 'except' clauses
+  "BLE001",   # No bare 'except' clauses
   "RUF022",   # Sort __all__
   # "UP007",    # PEP 604 Union[X, Y] -> X | Y
   # "UP045",    # PEP 604 Optional[X] -> X | None

--- a/tests/model_integration/test_model.py
+++ b/tests/model_integration/test_model.py
@@ -75,10 +75,10 @@ def test_stream_propagate_errors(selected_model):
 
     @guidance
     def my_function(lm):
-        raise Exception()
+        raise AssertionError("test error")
 
     lm += my_function()
-    with pytest.raises(Exception):
+    with pytest.raises(AssertionError, match="test error"):
         list(lm)
 
 

--- a/tests/model_specific/test_transformers.py
+++ b/tests/model_specific/test_transformers.py
@@ -121,7 +121,7 @@ def test_phi3_chat_basic(phi3_model: models.Model):
 def test_phi3_chat_unrolled(phi3_model: models.Model):
     lm = phi3_model
     # Manually convert the chat format into completions style
-    lm += f"""<|user|>\nYou are a counting bot. Just keep counting numbers.<|end|>\n<|assistant|>\n1,2,3,4,"""
+    lm += """<|user|>\nYou are a counting bot. Just keep counting numbers.<|end|>\n<|assistant|>\n1,2,3,4,"""
     lm += gen("five", max_tokens=10)
 
     assert "5" in lm["five"]
@@ -158,7 +158,7 @@ def test_phi3_unstable_tokenization(phi3_model: models.Model):
 def test_phi3_basic_completion_badtokens(phi3_model: models.Model):
     lm = phi3_model
     # Bad user tokens, but we should still generate /something/
-    lm += f"""<|use\n\nYou are a counting bot. Just keep counting numbers.<|end|><|assistant|>1,2,3,4,"""
+    lm += """<|use\n\nYou are a counting bot. Just keep counting numbers.<|end|><|assistant|>1,2,3,4,"""
     lm += gen("five", max_tokens=10)
 
     assert len(lm["five"]) > 0

--- a/tests/model_specific/test_visual.py
+++ b/tests/model_specific/test_visual.py
@@ -9,7 +9,7 @@ def test_repeat_simple_model():
 
     trace_handler = get_trace_handler()
     original_renderer = get_renderer()
-    for i in range(2):
+    for _ in range(2):
         set_renderer(JupyterWidgetRenderer(trace_handler))
 
         lm = Transformers("gpt2")

--- a/tests/need_credentials/test_cohere.py
+++ b/tests/need_credentials/test_cohere.py
@@ -11,7 +11,7 @@ def test_lite_llm_basic():
         pytest.skip("Skipping Cohere test because we can't load the model!")
     lm += "Count to 20: 1,2,3,4,"
     nl = "\n"
-    lm += f"""\
+    lm += """\
 5,6,7"""
     lm += f"""{gen(max_tokens=1, suffix=nl)}aaaaaa"""
     assert str(lm)[-5:] == "aaaaa"

--- a/tests/need_credentials/test_lite_llm.py
+++ b/tests/need_credentials/test_lite_llm.py
@@ -11,7 +11,7 @@ def test_lite_llm_basic_openai():
         pytest.skip("Skipping LiteLLM test because we can't load the model!")
     lm += "Count to 20: 1,2,3,4,"
     nl = "\n"
-    lm += f"""\
+    lm += """\
 5,6,7"""
     lm += f"""{gen(max_tokens=1, suffix=nl)}aaaaaa"""
     assert str(lm)[-5:] == "aaaaa"
@@ -24,7 +24,7 @@ def test_lite_llm_basic_cohere():
         pytest.skip("Skipping LiteLLM test because we can't load the model!")
     lm += "Count to 20: 1,2,3,4,"
     nl = "\n"
-    lm += f"""\
+    lm += """\
 5,6,7"""
     lm += f"""{gen(max_tokens=1, suffix=nl)}aaaaaa"""
     assert str(lm)[-5:] == "aaaaa"

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -24,7 +24,7 @@ def test_guarantee_valid_syntax():
     nb_path = BASE_NB_PATH / "guaranteeing_valid_syntax.ipynb"
     run_notebook(
         nb_path,
-        params=dict(call_delay_secs=call_delay_secs, requested_log_level=logging.DEBUG),
+        params={"call_delay_secs": call_delay_secs, "requested_log_level": logging.DEBUG},
     )
 
 
@@ -34,7 +34,7 @@ def test_anachronism():
     nb_path = BASE_NB_PATH / "anachronism.ipynb"
     run_notebook(
         nb_path,
-        params=dict(call_delay_secs=call_delay_secs, requested_log_level=logging.DEBUG),
+        params={"call_delay_secs": call_delay_secs, "requested_log_level": logging.DEBUG},
     )
 
 
@@ -43,7 +43,7 @@ def test_engine_chat_completion():
     nb_path = BASE_NB_PATH / "engine_chat_completion.ipynb"
     run_notebook(
         nb_path,
-        params=dict(call_delay_secs=call_delay_secs, requested_log_level=logging.DEBUG),
+        params={"call_delay_secs": call_delay_secs, "requested_log_level": logging.DEBUG},
     )
 
 
@@ -57,7 +57,7 @@ class TestTutorials:
         nb_path = TestTutorials.BASE_TUTORIAL_PATH / "chat.ipynb"
         run_notebook(
             nb_path,
-            params=dict(call_delay_secs=call_delay_secs, requested_log_level=logging.DEBUG),
+            params={"call_delay_secs": call_delay_secs, "requested_log_level": logging.DEBUG},
         )
 
     def test_regex_constraints(self):
@@ -79,7 +79,7 @@ class TestModels:
     def test_azure_openai(self):
         call_delay_secs = slowdown()
         nb_path = TestModels.BASE_MODEL_PATH / "AzureOpenAI.ipynb"
-        run_notebook(nb_path, params=dict(call_delay_secs=call_delay_secs))
+        run_notebook(nb_path, params={"call_delay_secs": call_delay_secs})
 
     def test_openai(self):
         nb_path = TestModels.BASE_MODEL_PATH / "OpenAI.ipynb"
@@ -107,4 +107,4 @@ class TestArtOfPromptDesign:
         call_delay_secs = slowdown()
 
         nb_path = TestArtOfPromptDesign.BASE_APD_PATH / "use_clear_syntax.ipynb"
-        run_notebook(nb_path, params=dict(call_delay_secs=call_delay_secs))
+        run_notebook(nb_path, params={"call_delay_secs": call_delay_secs})

--- a/tests/unit/library/json/test_json.py
+++ b/tests/unit/library/json/test_json.py
@@ -585,7 +585,7 @@ class TestSimpleObject:
             "required": ["a"]
         }
     """
-        target_obj = dict(a=1)
+        target_obj = {"a": 1}
 
         # First sanity check what we're setting up
         schema_obj = json.loads(schema)
@@ -610,7 +610,7 @@ class TestSimpleObject:
             "required": ["a", "b", "c", "d", "e", "f", "g", "h"]
         }
     """
-        target_obj = dict(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8)
+        target_obj = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8}
 
         # First sanity check what we're setting up
         schema_obj = json.loads(schema)
@@ -642,7 +642,7 @@ class TestSimpleObject:
             "required": ["name", "info"]
         }
     """
-        target_obj = dict(name="my product", info=dict(a=1, b=2))
+        target_obj = {"name": "my product", "info": {"a": 1, "b": 2}}
 
         # First sanity check what we're setting up
         schema_obj = json.loads(schema)
@@ -833,7 +833,7 @@ class TestSimpleArray:
 
     @pytest.mark.parametrize(
         "target_obj",
-        [[], [dict(a=1)], [dict(a=2), dict(a=3)], [dict(a=4), dict(a=5), dict(a=6)]],
+        [[], [{"a": 1}], [{"a": 2}, {"a": 3}], [{"a": 4}, {"a": 5}, {"a": 6}]],
     )
     @pytest.mark.parametrize("temperature", [None, 0.1, 1])
     def test_object_list(self, target_obj, temperature):
@@ -1242,8 +1242,8 @@ class TestAnyOf:
     @pytest.mark.parametrize(
         "target_obj",
         [
-            dict(my_val=dict(my_int=1)),
-            dict(my_val=dict(my_str="Some long string or other")),
+            {"my_val": {"my_int": 1}},
+            {"my_val": {"my_str": "Some long string or other"}},
         ],
     )
     @pytest.mark.parametrize("temperature", [None, 0.1, 1])
@@ -1361,7 +1361,7 @@ class TestAllOf:
         }
         """
 
-        target_obj = dict(my_cat=dict(name="Sampson"))
+        target_obj = {"my_cat": {"name": "Sampson"}}
         # First sanity check what we're setting up
         schema_obj = json.loads(schema)
         validate(instance=target_obj, schema=schema_obj)
@@ -1850,9 +1850,9 @@ class TestRecursiveStructures:
     @pytest.mark.parametrize(
         "target_obj",
         [
-            dict(my_list=None),
-            dict(my_list=dict(my_str="a", next=None)),
-            dict(my_list=dict(my_str="a", next=dict(my_str="b", next=None))),
+            {"my_list": None},
+            {"my_list": {"my_str": "a", "next": None}},
+            {"my_list": {"my_str": "a", "next": {"my_str": "b", "next": None}}},
         ],
     )
     def test_linked_list(self, target_obj):

--- a/tests/unit/library/test_block.py
+++ b/tests/unit/library/test_block.py
@@ -36,7 +36,7 @@ def test_grammar_closer():
             model += regex(r".")
     except:
         return  # we expect an exception
-    assert False, "We should have thrown an exception using a context (prompt) based grammar in the closer!"
+    raise AssertionError("We should have thrown an exception using a context (prompt) based grammar in the closer!")
 
 
 def test_block_name_capture():

--- a/tests/unit/library/test_regex.py
+++ b/tests/unit/library/test_regex.py
@@ -408,7 +408,7 @@ class TestAlternations:
                 "ae",
                 b"a",
                 b"e",
-                {b"c", b"c"},
+                {b"c"},
             ),  # Neither 'ac' nor 'bc' nor 'd'
             (
                 r"(a|b)+",

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -157,7 +157,7 @@ def test_inconsistent_indentation():
 def test_exception_on_repeat_calls():
     @guidance(stateless=True, dedent=False)
     def raises(lm):
-        assert False
+        raise AssertionError()
 
     with pytest.raises(AssertionError):
         raises()

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -9,80 +9,80 @@ from guidance._parser import ByteParser
 def test_one_or_more():
     g = one_or_more("a")
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"a"])
+    assert parser.valid_next_bytes() == {b"a"}
     parser.consume_bytes(b"a")
-    assert parser.valid_next_bytes() == set([b"a"])
+    assert parser.valid_next_bytes() == {b"a"}
 
 
 def test_zero_or_more_and_one_or_more():
     g = zero_or_more("a") + one_or_more("b")
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"a", b"b"])
+    assert parser.valid_next_bytes() == {b"a", b"b"}
     parser.consume_bytes(b"a")
-    assert parser.valid_next_bytes() == set([b"a", b"b"])
+    assert parser.valid_next_bytes() == {b"a", b"b"}
     parser.consume_bytes(b"b")
-    assert parser.valid_next_bytes() == set([b"b"])
+    assert parser.valid_next_bytes() == {b"b"}
 
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"a", b"b"])
+    assert parser.valid_next_bytes() == {b"a", b"b"}
     parser.consume_bytes(b"b")
-    assert parser.valid_next_bytes() == set([b"b"])
+    assert parser.valid_next_bytes() == {b"b"}
     parser.consume_bytes(b"b")
-    assert parser.valid_next_bytes() == set([b"b"])
+    assert parser.valid_next_bytes() == {b"b"}
 
 
 def test_zero_or_more_and_one_or_more_mixed():
     g = zero_or_more("a") + "test" + one_or_more("b")
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"a", b"t"])
+    assert parser.valid_next_bytes() == {b"a", b"t"}
     parser.consume_bytes(b"t")
     parser.consume_bytes(b"e")
     parser.consume_bytes(b"s")
-    assert parser.valid_next_bytes() == set([b"t"])
+    assert parser.valid_next_bytes() == {b"t"}
     parser.consume_bytes(b"t")
-    assert parser.valid_next_bytes() == set([b"b"])
+    assert parser.valid_next_bytes() == {b"b"}
 
 
 def test_select():
     g = select(["bob", "bill", "sue"])
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"b", b"s"])
+    assert parser.valid_next_bytes() == {b"b", b"s"}
     parser.consume_bytes(b"s")
-    assert parser.valid_next_bytes() == set([b"u"])
+    assert parser.valid_next_bytes() == {b"u"}
     parser.consume_bytes(b"u")
-    assert parser.valid_next_bytes() == set([b"e"])
+    assert parser.valid_next_bytes() == {b"e"}
 
 
 def test_select_nested():
     g = select(["bob", "bill", select(["mark", "mary"])])
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"b", b"m"])
+    assert parser.valid_next_bytes() == {b"b", b"m"}
     parser.consume_bytes(b"m")
-    assert parser.valid_next_bytes() == set([b"a"])
+    assert parser.valid_next_bytes() == {b"a"}
     parser.consume_bytes(b"a")
-    assert parser.valid_next_bytes() == set([b"r"])
+    assert parser.valid_next_bytes() == {b"r"}
     parser.consume_bytes(b"r")
-    assert parser.valid_next_bytes() == set([b"k", b"y"])
+    assert parser.valid_next_bytes() == {b"k", b"y"}
 
 
 def test_select_joined():
     g = select(["bob", "bill"]) + select(["mark", "mary"])
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b"b"])
+    assert parser.valid_next_bytes() == {b"b"}
     parser.consume_bytes(b"b")
-    assert parser.valid_next_bytes() == set([b"o", b"i"])
+    assert parser.valid_next_bytes() == {b"o", b"i"}
     parser.consume_bytes(b"i")
-    assert parser.valid_next_bytes() == set([b"l"])
+    assert parser.valid_next_bytes() == {b"l"}
     parser.consume_bytes(b"l")
-    assert parser.valid_next_bytes() == set([b"l"])
+    assert parser.valid_next_bytes() == {b"l"}
     parser.consume_bytes(b"l")
-    assert parser.valid_next_bytes() == set([b"m"])
+    assert parser.valid_next_bytes() == {b"m"}
     parser.consume_bytes(b"m")
-    assert parser.valid_next_bytes() == set([b"a"])
+    assert parser.valid_next_bytes() == {b"a"}
     parser.consume_bytes(b"a")
-    assert parser.valid_next_bytes() == set([b"r"])
+    assert parser.valid_next_bytes() == {b"r"}
     parser.consume_bytes(b"r")
-    assert parser.valid_next_bytes() == set([b"k", b"y"])
+    assert parser.valid_next_bytes() == {b"k", b"y"}
 
 
 def test_char_set():
@@ -130,9 +130,9 @@ def test_string_utf8():
     b = bytes("¶", encoding="utf8")
     g = string("¶")
     parser = ByteParser(g.ll_grammar())
-    assert parser.valid_next_bytes() == set([b[:1]])
+    assert parser.valid_next_bytes() == {b[:1]}
     parser.consume_bytes(b[:1])
-    assert parser.valid_next_bytes() == set([b[1:]])
+    assert parser.valid_next_bytes() == {b[1:]}
     parser.consume_bytes(b[1:])
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -201,4 +201,4 @@ def check_run_with_temperature(lm: models.Model, desired_temperature: float):
         # Check that all temperatures were 0 or the desired temperature
         # If there has been a forced byte, then get_logits() is
         # called with a temperature of zero
-        assert all([(x == desired_temperature or x == 0) for x in lm.engine.called_temperatures])
+        assert all((x == desired_temperature or x == 0) for x in lm.engine.called_temperatures)


### PR DESCRIPTION
See https://docs.astral.sh/ruff/linter/#rule-selection to understand why I changed `extend_select` to `select`.

Additionally fixes some code in order to make these pass. @riedgar-ms note that all of the selected lints pass `ruff check` as of right now (I had to comment out ARG, as it was non-trivial to fix in some cases -- we can do that on a separate pass).

I would actually recommend that we start reporting failure to users in the PR gate (even as a neutral check) so that we can maintain a "ratchet". Your decision though.