### PR TITLE
[Linting] Ruff `ARG`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -17,7 +17,7 @@ exclude = [
 select = [
   "B",        # flake8-bugbear
   "I",        # isort
-  # "ARG",      # flake8-unused-arguments
+  "ARG",      # flake8-unused-arguments
   "C4",       # flake8-comprehensions
   "F401",     # flake8-unused-imports
   "F541",     # flake8 f-string without any placeholders


### PR DESCRIPTION
Test PR to see what happens when we add an unfixed lint to `select` (may fix later)
Supersedes #1375 (on branch rather than fork)