### PR TITLE
Fix unmatched token and its bytes representation when finishing early

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -325,6 +325,7 @@ class Engine(ABC):
                 # Type checker needs some help
                 assert self.tokenizer.eos_token_id is not None
                 issued_token.token_id = self.tokenizer.eos_token_id
+                issued_token.bytes = self.tokenizer.decode([self.tokenizer.eos_token_id])
 
             if usage.ttft_ms == 0:
                 usage.ttft_ms += (time.monotonic() - t0) * 1000


### PR DESCRIPTION
@hudson-ai running below code in a notebook, it displays incorrect last character. 
When we can exit early, we set the issue_token to EOS, but we don't set the bytes representation of EOS, it still has the value of non-EOS token

```
def run_lark_grammar(lm):
    lark_grammar = """
start: "Capital: " CAPITAL ", Population: " INT
CAPITAL: /[A-Z][a-z]+/
INT: /[0-9]+/
"""

    with guidance.user():
        lm += "What is the capital of France? and its population?"

    with guidance.assistant():
        lm += guidance.lark(lark_grammar=lark_grammar, name="answer")
        print(lm["answer"])

run_lark_grammar(base_lm)
```