### PR TITLE
Do not rely on asyncio.get_event_loop() implicitly creating a loop

### DIFF
--- a/tests/unit/test_visual.py
+++ b/tests/unit/test_visual.py
@@ -1,6 +1,6 @@
 import asyncio
-from base64 import b64encode
 import sys
+from base64 import b64encode
 
 import pytest
 


### PR DESCRIPTION
On python 3.14 and newer, `asyncio.get_event_loop()` no longer implicitly starts an event loop if one hasn't yet been started. Instead, it raises a `RuntimeError`:

```
>>> asyncio.get_event_loop()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    asyncio.get_event_loop()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/goldbaum/.pyenv/versions/3.14.0/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
                       % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.
```

See the [asyncio section](https://docs.python.org/3/whatsnew/3.14.html#id10) of the Python 3.14 changelog for a little more background.

Triggering the `RuntimeError` is more-or-less the same thing as asserting the loop on the main thread is not the loop on the spawned thread. Let me know if you'd prefer a different way to handle this.