### PR TITLE
[Fix] expose chat_template and restore chat template tests

### DIFF
--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import warnings
 
 
@@ -16,17 +17,18 @@ class ChatTemplateCache:
     def __init__(self) -> None:
         self._cache: dict[str, ChatTemplate] = {}
 
+    @staticmethod
+    def _normalize_key(key: str) -> str:
+        return re.sub(r"\s+", "", key)
+
     def __getitem__(self, key: str) -> ChatTemplate:
-        key_compact = key.replace(" ", "")
-        return self._cache[key_compact]
+        return self._cache[self._normalize_key(key)]
 
     def __setitem__(self, key: str, value):
-        key_compact = key.replace(" ", "")
-        self._cache[key_compact] = value
+        self._cache[self._normalize_key(key)] = value
 
     def __contains__(self, key: str):
-        key_compact = key.replace(" ", "")
-        return key_compact in self._cache
+        return self._normalize_key(key) in self._cache
 
 
 # Feels weird having to instantiate this, but it's a singleton for all purposes

--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -318,6 +318,19 @@ class Model:
             return self._interpreter.engine
         return super().__getattribute__(name)
 
+    @property
+    def chat_template(self):
+        """Get the chat template used by this model."""
+        return getattr(self._interpreter, "chat_template", None)
+
+    @chat_template.setter
+    def chat_template(self, value):
+        """Set the chat template used by this model."""
+        if hasattr(self._interpreter, "chat_template"):
+            self._interpreter.chat_template = value
+        else:
+            raise AttributeError("This model's interpreter does not support chat templates")
+
     def _get_usage(self) -> TokenUsage:
         """Get the token usage for this model."""
         # TODO(hudson): make this public API once we stabilize the data structure

--- a/tests/need_credentials/test_chat_templates.py
+++ b/tests/need_credentials/test_chat_templates.py
@@ -13,6 +13,7 @@ from ..utils import env_or_skip
         ("microsoft/Phi-3-mini-4k-instruct", True),  # Phi-3-Mini
         ("microsoft/Phi-3-small-8k-instruct", True),  # Phi-3-Small
         ("microsoft/Phi-3-medium-4k-instruct", True),  # Phi-3-Medium
+        ("microsoft/Phi-4-mini-instruct", True),  # Phi-4-Mini
         ("meta-llama/Meta-Llama-3-8B-Instruct", True),  # Llama-3
         ("meta-llama/Llama-2-7b-chat-hf", True),  # Llama-2
         ("mistralai/Mistral-7B-Instruct-v0.2", True),  # Mistral-7B-Instruct-v0.2
@@ -40,13 +41,13 @@ def test_popular_models_in_cache(model_id: str, should_pass: bool):
 # once I hook up the new ChatTemplate to guidance.models.Transformers and guidance.models.LlamaCPP, we can do this
 
 
-@pytest.mark.skip(reason="Is this supposed to work still? See issue 1196")
 @pytest.mark.parametrize(
     "model_id",
     [
         "microsoft/Phi-3-mini-4k-instruct",
         "microsoft/Phi-3-small-8k-instruct",
         "microsoft/Phi-3-medium-4k-instruct",
+        "microsoft/Phi-4-mini-instruct",
         "meta-llama/Meta-Llama-3-8B-Instruct",
         "meta-llama/Llama-2-7b-chat-hf",
         "mistralai/Mistral-7B-Instruct-v0.2",
@@ -76,11 +77,11 @@ def test_chat_format_smoke(model_id: str):
     assert str(lm) in tokeniser_render
 
 
-@pytest.mark.skip(reason="Is this supposed to work still? See issue 1196")
 @pytest.mark.parametrize(
     "model_id",
     [
         "microsoft/Phi-3-mini-4k-instruct",
+        "microsoft/Phi-4-mini-instruct",
         "meta-llama/Meta-Llama-3-8B-Instruct",
         "Qwen/Qwen2.5-0.5B",
         "Qwen/Qwen2.5-0.5B-Instruct",


### PR DESCRIPTION
## Summary
- Add `Model.chat_template` getter/setter to support setting templates on mock models
- Re-enable chat template smoke tests and add Phi-4-mini-instruct coverage
- Normalize chat template cache keys to ignore whitespace differences

## Testing
- Not run (requires `HF_TOKEN`).
