### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 
 ## Install
-Guidance is available through PyPI and supports a variety of backends (Transformers, llama.cpp, OpenAI, etc.).
+Guidance is available through PyPI and supports a variety of backends (Transformers, llama.cpp, OpenAI, MiniMax, etc.).
 If you already have the backend required for your model, you can simply run
 ```bash
 pip install guidance

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,6 +39,7 @@ models
 
     guidance.models.Model
     guidance.models.LlamaCpp
+    guidance.models.MiniMax
     guidance.models.Transformers
     guidance.models.Anthropic
     guidance.models.AzureOpenAI

--- a/guidance/models/__init__.py
+++ b/guidance/models/__init__.py
@@ -2,6 +2,7 @@ from . import experimental
 from ._azureai import create_azure_aifoundry_model, create_azure_openai_model
 from ._base import Model
 from ._llama_cpp import LlamaCpp
+from ._minimax import MiniMax
 from ._mock import Mock
 from ._onnxruntime import OnnxRuntimeGenAI
 from ._openai import OpenAI
@@ -9,6 +10,7 @@ from ._transformers import Transformers
 
 __all__ = [
     "LlamaCpp",
+    "MiniMax",
     "Mock",
     "Model",
     "OnnxRuntimeGenAI",

--- a/guidance/models/_minimax.py
+++ b/guidance/models/_minimax.py
@@ -41,7 +41,7 @@ class MiniMaxInterpreter(OpenAIRuleMixin, OpenAIJSONMixin, OpenAIRegexMixin, Bas
 class MiniMax(Model):
     def __init__(
         self,
-        model: str = "MiniMax-M2.5",
+        model: str = "MiniMax-M2.7",
         sampling_params: SamplingParams | None = None,
         echo: bool = True,
         *,
@@ -57,7 +57,9 @@ class MiniMax(Model):
         ----------
         model : str
             The name of the MiniMax model to use. Available models:
-            - ``MiniMax-M2.5`` (default): Peak Performance, 204K context window.
+            - ``MiniMax-M2.7`` (default): Latest flagship model with enhanced reasoning and coding.
+            - ``MiniMax-M2.7-highspeed``: High-speed version of M2.7 for low-latency scenarios.
+            - ``MiniMax-M2.5``: Peak Performance, 204K context window.
             - ``MiniMax-M2.5-highspeed``: Same performance, faster and more agile, 204K context window.
         echo : bool
             If true the final result of creating this model state will be displayed (as HTML in a notebook).

--- a/guidance/models/_minimax.py
+++ b/guidance/models/_minimax.py
@@ -1,0 +1,77 @@
+import os
+
+from guidance._schema import SamplingParams
+
+from ._base import Model
+from ._openai_base import (
+    BaseOpenAIInterpreter,
+    OpenAIClientWrapper,
+    OpenAIJSONMixin,
+    OpenAIRegexMixin,
+    OpenAIRuleMixin,
+)
+
+MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMaxInterpreter(OpenAIRuleMixin, OpenAIJSONMixin, OpenAIRegexMixin, BaseOpenAIInterpreter):
+    def __init__(
+        self,
+        model: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        **kwargs,
+    ):
+        try:
+            import openai
+        except ImportError as ie:
+            raise Exception(
+                "Please install the openai package version >= 1 using `pip install openai -U` in order to use guidance.models.MiniMax!"
+            ) from ie
+
+        if api_key is None:
+            api_key = os.environ.get("MINIMAX_API_KEY")
+        if base_url is None:
+            base_url = os.environ.get("MINIMAX_API_BASE", MINIMAX_DEFAULT_BASE_URL)
+
+        client = openai.OpenAI(api_key=api_key, base_url=base_url, **kwargs)
+        super().__init__(model=model, client=OpenAIClientWrapper(client))
+
+
+class MiniMax(Model):
+    def __init__(
+        self,
+        model: str = "MiniMax-M2.5",
+        sampling_params: SamplingParams | None = None,
+        echo: bool = True,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        **kwargs,
+    ):
+        """Build a new MiniMax model object that represents a model in a given state.
+
+        MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1.
+
+        Parameters
+        ----------
+        model : str
+            The name of the MiniMax model to use. Available models:
+            - ``MiniMax-M2.5`` (default): Peak Performance, 204K context window.
+            - ``MiniMax-M2.5-highspeed``: Same performance, faster and more agile, 204K context window.
+        echo : bool
+            If true the final result of creating this model state will be displayed (as HTML in a notebook).
+        api_key : None or str
+            The MiniMax API key. If not provided, falls back to the ``MINIMAX_API_KEY`` environment variable.
+        base_url : None or str
+            The MiniMax API base URL. Defaults to ``https://api.minimax.io/v1``.
+            The China endpoint is ``https://api.minimaxi.com/v1``.
+
+        **kwargs :
+            All extra keyword arguments are passed directly to the ``openai.OpenAI`` constructor.
+        """
+        super().__init__(
+            interpreter=MiniMaxInterpreter(model, api_key=api_key, base_url=base_url, **kwargs),
+            sampling_params=SamplingParams() if sampling_params is None else sampling_params,
+            echo=echo,
+        )

--- a/guidance/models/_minimax.py
+++ b/guidance/models/_minimax.py
@@ -41,7 +41,7 @@ class MiniMaxInterpreter(OpenAIRuleMixin, OpenAIJSONMixin, OpenAIRegexMixin, Bas
 class MiniMax(Model):
     def __init__(
         self,
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         sampling_params: SamplingParams | None = None,
         echo: bool = True,
         *,
@@ -57,10 +57,9 @@ class MiniMax(Model):
         ----------
         model : str
             The name of the MiniMax model to use. Available models:
-            - ``MiniMax-M2.7`` (default): Latest flagship model with enhanced reasoning and coding.
+            - ``MiniMax-M3`` (default): 512K context window, up to 128K output, image input supported.
+            - ``MiniMax-M2.7``: Previous flagship model with enhanced reasoning and coding.
             - ``MiniMax-M2.7-highspeed``: High-speed version of M2.7 for low-latency scenarios.
-            - ``MiniMax-M2.5``: Peak Performance, 204K context window.
-            - ``MiniMax-M2.5-highspeed``: Same performance, faster and more agile, 204K context window.
         echo : bool
             If true the final result of creating this model state will be displayed (as HTML in a notebook).
         api_key : None or str

--- a/tests/need_credentials/test_minimax.py
+++ b/tests/need_credentials/test_minimax.py
@@ -12,7 +12,7 @@ def minimax_model() -> Model:
     slowdown()
 
     api_key = env_or_skip("MINIMAX_API_KEY")
-    model_name = "MiniMax-M2.5"
+    model_name = "MiniMax-M2.7"
 
     lm = MiniMax(model_name, api_key=api_key)
     assert isinstance(lm, Model)

--- a/tests/need_credentials/test_minimax.py
+++ b/tests/need_credentials/test_minimax.py
@@ -1,0 +1,51 @@
+import pytest
+
+from guidance import assistant, gen, system, user
+from guidance.models import MiniMax, Model
+
+from ..model_specific import common_chat_testing
+from ..utils import env_or_skip, slowdown
+
+
+@pytest.fixture(scope="function")
+def minimax_model() -> Model:
+    slowdown()
+
+    api_key = env_or_skip("MINIMAX_API_KEY")
+    model_name = "MiniMax-M2.5"
+
+    lm = MiniMax(model_name, api_key=api_key)
+    assert isinstance(lm, Model)
+    print(f"{type(lm._interpreter)=}")
+
+    return lm
+
+
+def test_minimax_chat_smoke(minimax_model: Model):
+    common_chat_testing.smoke_chat(minimax_model)
+
+
+def test_minimax_chat_json(minimax_model: Model):
+    common_chat_testing.json_output_smoke(minimax_model)
+
+
+def test_minimax_chat_multi_turn(minimax_model: Model):
+    lm = minimax_model
+    with system():
+        lm += "You are a helpful assistant."
+
+    with user():
+        lm += "What is 1 + 1?"
+
+    with assistant():
+        lm += gen(max_tokens=10, name="answer1")
+
+    assert len(lm["answer1"]) > 0
+
+    with user():
+        lm += "Now add 3 to that result."
+
+    with assistant():
+        lm += gen(max_tokens=10, name="answer2")
+
+    assert len(lm["answer2"]) > 0

--- a/tests/need_credentials/test_minimax.py
+++ b/tests/need_credentials/test_minimax.py
@@ -12,7 +12,7 @@ def minimax_model() -> Model:
     slowdown()
 
     api_key = env_or_skip("MINIMAX_API_KEY")
-    model_name = "MiniMax-M2.7"
+    model_name = "MiniMax-M3"
 
     lm = MiniMax(model_name, api_key=api_key)
     assert isinstance(lm, Model)


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`MiniMax-M2.5`/`MiniMax-M2.5-highspeed`)
- Update related unit tests

## Why
MiniMax-M3 is the latest model, with a 512K context window, up to 128K output, and image input support.

## Testing
- Unit tests updated and passing
- Integration tested with MiniMax API