### PR TITLE
fix: handle vocab size mismatch between model logits and tokenizer mask

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -597,6 +597,13 @@ class Engine(ABC):
         masked_probs: NDArray | None = None
         if mask is not None:
             np_mask = np.frombuffer(mask, dtype=np.uint8)
+            # Handle vocab size mismatch between model logits and tokenizer mask.
+            # Some models (e.g. Gemma) output logits with a different vocab size
+            # than the tokenizer reports, causing a shape broadcast error.
+            if len(np_mask) != len(logits):
+                min_size = min(len(np_mask), len(logits))
+                np_mask = np_mask[:min_size]
+                logits = logits[:min_size]
             masked_logits = np.where(np_mask != 0, logits, -np.inf)
             # TODO: if temp is 0, we only need to apply the params that affect argmax, e.g. repetition penalty
             filtered_masked_logits = apply_temp_and_sampling_params(


### PR DESCRIPTION
Fixes #1175

## Problem

Some models (notably Gemma variants and MedGemma) output logits with a vocabulary size that differs from what the tokenizer reports. When the engine applies the token mask in `get_next_token_with_top_k`, it does:

```python
np_mask = np.frombuffer(mask, dtype=np.uint8)
masked_logits = np.where(np_mask != 0, logits, -np.inf)
```

If `len(np_mask) != len(logits)`, numpy raises:
```
ValueError: operands could not be broadcast together with shapes (262144,) (262145,)
```

This affects any model where the transformer's output logit dimension doesn't exactly match the HuggingFace tokenizer's reported vocab size.

## Solution

Before applying the mask, align the two arrays to the same length by truncating to `min(len(np_mask), len(logits))`:

- If `logits` is larger: the extra logit positions correspond to tokens not present in the tokenizer vocabulary, so they should never be sampled anyway.
- If `np_mask` is larger: the extra mask positions have no corresponding logit and can be dropped.

Note: `_transformers.py` already applies a similar truncation (`logits[:self.tokenizer._vocab_size]`) for the transformers backend, but this doesn't cover all cases (e.g. when the tokenizer's reported vocab is larger than the model output, or when using other backends).

## Testing

Manually verified against the reproduction case from the issue using a Gemma-based model. The shape mismatch no longer raises a `ValueError`.

The existing test suite passes unchanged.