### PR TITLE
fix: add AzureOpenAI class to guidance.models

### DIFF
--- a/guidance/models/__init__.py
+++ b/guidance/models/__init__.py
@@ -1,5 +1,5 @@
 from . import experimental
-from ._azureai import create_azure_aifoundry_model, create_azure_openai_model
+from ._azureai import AzureOpenAI, create_azure_aifoundry_model, create_azure_openai_model
 from ._base import Model
 from ._llama_cpp import LlamaCpp
 from ._mock import Mock
@@ -8,6 +8,7 @@ from ._openai import OpenAI
 from ._transformers import Transformers
 
 __all__ = [
+    "AzureOpenAI",
     "LlamaCpp",
     "Mock",
     "Model",

--- a/guidance/models/_azureai.py
+++ b/guidance/models/_azureai.py
@@ -73,6 +73,81 @@ class AzureOpenAIImageInterpreter(OpenAIImageMixin, AzureOpenAIInterpreter):
     pass
 
 
+class AzureOpenAI(Model):
+    def __init__(
+        self,
+        model: str,
+        azure_endpoint: str,
+        azure_deployment: str,
+        sampling_params: SamplingParams | None = None,
+        echo: bool = True,
+        *,
+        api_version: str | None = None,
+        api_key: str | None = None,
+        azure_ad_token: str | None = None,
+        azure_ad_token_provider: Callable[[], str] | None = None,
+        has_audio_support: bool = False,
+        has_image_support: bool = False,
+        reasoning_effort: str | None = None,
+        **kwargs,
+    ):
+        """Build a new AzureOpenAI model object that represents a model in a given state.
+
+        Parameters
+        ----------
+        model : str
+            The name of the Azure OpenAI model to use (e.g. gpt-4o-mini).
+        azure_endpoint : str
+            The endpoint which holds the OpenAI model deployment. It will probably be
+            https://<AZURE OPENAI RESOURCE NAME>.openai.azure.com/
+        azure_deployment : str
+            The Azure deployment name to use for the model. The Azure AI portal will
+            default this to being the model name, but it can be different.
+        echo : bool
+            If true the final result of creating this model state will be displayed (as HTML in a notebook).
+        api_version : str | None
+            The API version to use for the Azure OpenAI service.
+        api_key : str | None
+            The API key to use for the Azure OpenAI service.
+        azure_ad_token : str | None
+            The Azure AD token to use for authentication.
+        azure_ad_token_provider : Callable[[], str] | None
+            A callable that returns an Azure AD token for authentication.
+        has_audio_support : bool
+            Indicates if the deployed model has support for audio.
+        has_image_support : bool
+            Indicates if the deployed model has support for images.
+        **kwargs :
+            All extra keyword arguments are passed directly to the `openai.AzureOpenAI` constructor.
+        """
+        if has_audio_support and has_image_support:
+            raise ValueError("No known models have both audio and image support")
+
+        interpreter_cls: type[AzureOpenAIInterpreter]
+        if (model and "audio-preview" in model) or has_audio_support:
+            interpreter_cls = AzureOpenAIAudioInterpreter
+        elif (model and (model.startswith("gpt-4o") or model.startswith("o1"))) or has_image_support:
+            interpreter_cls = AzureOpenAIImageInterpreter
+        else:
+            interpreter_cls = AzureOpenAIInterpreter
+
+        super().__init__(
+            interpreter=interpreter_cls(
+                azure_endpoint=azure_endpoint,
+                model_name=model,
+                azure_deployment=azure_deployment,
+                api_version=api_version,
+                api_key=api_key,
+                azure_ad_token=azure_ad_token,
+                azure_ad_token_provider=azure_ad_token_provider,
+                reasoning_effort=reasoning_effort,
+                **kwargs,
+            ),
+            sampling_params=SamplingParams() if sampling_params is None else sampling_params,
+            echo=echo,
+        )
+
+
 def create_azure_openai_model(
     azure_endpoint: str,
     azure_deployment: str,


### PR DESCRIPTION
Fixes #1205

## Problem
`guidance.models.AzureOpenAI` does not exist as a public API, causing an `AttributeError` when users try to use it as documented in the [AzureOpenAI example notebook](https://github.com/guidance-ai/guidance/blob/main/notebooks/api_examples/models/AzureOpenAI.ipynb). Users familiar with the `guidance.models.OpenAI` class pattern expect a similar `AzureOpenAI` class.

## Solution
Add an `AzureOpenAI` class to `guidance/models/_azureai.py` that follows the same pattern as the existing `OpenAI` class:
- Takes `model` as the first positional argument (consistent with `OpenAI`)
- Requires `azure_endpoint` and `azure_deployment` arguments
- Supports `api_version`, `api_key`, `azure_ad_token`, `azure_ad_token_provider`, and other keyword arguments
- Automatically selects the appropriate interpreter based on model name (audio/image support detection mirrors `create_azure_openai_model`)
- Exports `AzureOpenAI` from `guidance.models.__init__`

The existing `create_azure_openai_model` factory function is preserved unchanged for backward compatibility.

## Usage after this fix
```python
from guidance import models

azureai_model = models.AzureOpenAI(
    model="gpt-4o-mini",
    azure_endpoint="https://my-resource.openai.azure.com/",
    azure_deployment="my-deployment",
    api_version="2024-02-15-preview",
    azure_ad_token_provider=token_provider,
)
```

## Testing
Verified that:
- `AzureOpenAI` class is importable from `guidance.models`
- Syntax is correct (AST parse passes)
- Existing `create_azure_openai_model` tests remain unaffected
- The new class delegates to the same `AzureOpenAIInterpreter` classes as the factory function