### PR TITLE
fix: update adding_new_models tutorial to use current API

### DIFF
--- a/notebooks/tutorials/adding_new_models.ipynb
+++ b/notebooks/tutorials/adding_new_models.ipynb
@@ -3,14 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Adding support for a new models\n",
-    "\n",
-    "# NOTE: This notebook is now out of date and needs to be rewritten to account for ChatTemplates.\n",
-    "\n",
-    "\n",
-    "Different models are tuned with different role prompt formats. If the model you are using is not already a subclass of `guidance.Model`, you can define your own new subclass with whatever role prompt format you want. Then you can use the guidance role tags and they will get translated into the correct prompt format."
-   ]
+   "source": "# Adding support for a new model\n\nDifferent models are fine-tuned with different chat prompt formats. You can support any prompt format by defining a custom `ChatTemplate` subclass and passing it when loading the model. Then you can use the standard guidance role tags (`system`, `user`, `assistant`) and they will be translated into the correct prompt format for your model."
   },
   {
    "cell_type": "markdown",
@@ -28,39 +21,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Define a new OrcaChat class"
-   ]
+   "source": "### Define a custom OrcaChatTemplate"
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from guidance import models\n",
-    "\n",
-    "# this is our new chat model that inherits from the TransformersChat model and redefines role starts and ends\n",
-    "class OrcaChat(models.transformers.TransformersChat):\n",
-    "    def get_role_start(self, role_name, **kwargs):\n",
-    "        if role_name == \"system\":\n",
-    "            return \"### System:\\n\"\n",
-    "        elif role_name == \"user\":\n",
-    "            if str(self).endswith(\"\\n\\n### User:\\n\"):\n",
-    "                return \"\" # we don't need to start anything if we are starting with a top level unnested system tag\n",
-    "            else:\n",
-    "                return \"### System:\\n\"\n",
-    "        else:\n",
-    "            return \" \"\n",
-    "\n",
-    "    def get_role_end(self, role_name=None):\n",
-    "        if role_name == \"system\":\n",
-    "            return \"\\n\\n### User:\\n\"\n",
-    "        elif role_name == \"user\":\n",
-    "            return \"\\n\\n### Response:\\n\"\n",
-    "        else:\n",
-    "            return \" \""
-   ]
+   "source": "from guidance.chat import ChatTemplate, UnsupportedRoleException\n\n\nclass OrcaChatTemplate(ChatTemplate):\n    \"\"\"Chat template for Orca Mini (pankajmathur/orca_mini_3b).\n\n    Prompt format:\n        ### System:\n        {system}\n\n        ### User:\n        {instruction}\n\n        ### Response:\n        {response}\n    \"\"\"\n\n    def get_role_start(self, role_name):\n        if role_name == \"system\":\n            return \"### System:\\n\"\n        elif role_name == \"user\":\n            return \"### User:\\n\"\n        elif role_name == \"assistant\":\n            return \"### Response:\\n\"\n        else:\n            raise UnsupportedRoleException(role_name, self)\n\n    def get_role_end(self, role_name=None):\n        return \"\\n\\n\""
   },
   {
    "cell_type": "markdown",
@@ -71,94 +39,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama.LlamaTokenizer'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thouroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3e2eb7c444ba4d92a5f29593faa919e9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import torch\n",
-    "\n",
-    "orca = OrcaChat('pankajmathur/orca_mini_3b', torch_dtype=torch.float16, device_map='auto')\n",
-    "# orca = OrcaChat('gpt2', device_map='auto') # Can use a small mock model while iterating on the prompt"
-   ]
+   "outputs": [],
+   "source": "import torch\nfrom guidance import models\n\norca = models.Transformers(\n    'pankajmathur/orca_mini_3b',\n    chat_template=OrcaChatTemplate,\n    torch_dtype=torch.float16,\n    device_map='auto',\n)\n# orca = models.Transformers('gpt2', chat_template=OrcaChatTemplate)  # small mock model for iteration"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Check output without indentation formatting\n",
-    "\n",
-    "When you designing the prompt format you will want to see exactly how roles are going into the mode without any pretty indentation. Setting `indent=False` allows you to do this (and so is useful during role format development)."
-   ]
+   "source": "### Verify the prompt format\n\nWhen designing a prompt format, you can verify the exact role tags by printing the string representation of the model after running it. This shows the raw text that gets sent to the model."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>### System:\n",
-       "</span>You are a cat expert.<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>\n",
-       "\n",
-       "### User:\n",
-       "</span><span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'></span>What are the smallest cats?<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>\n",
-       "\n",
-       "### Response:\n",
-       "</span><span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'> </span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>The</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> smallest</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> cats</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> are</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> the</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> dwar</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>f</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> cats</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>,</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> which</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> include</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> the</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> following</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> bre</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>eds</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>:</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>1</span><span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'> </span></pre>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from guidance import gen, system, user, assistant, indent_roles\n",
-    "\n",
-    "with indent_roles(False):\n",
-    "    with system():\n",
-    "        lm = orca + \"You are a cat expert.\"\n",
-    "\n",
-    "    with user():\n",
-    "        lm += \"What are the smallest cats?\"\n",
-    "\n",
-    "    with assistant():\n",
-    "        lm += gen(\"answer\", stop=\".\", max_tokens=20)"
-   ]
+   "outputs": [],
+   "source": "from guidance import gen, system, user, assistant\n\nwith system():\n    lm = orca + \"You are a cat expert.\"\n\nwith user():\n    lm += \"What are the smallest cats?\"\n\nwith assistant():\n    lm += gen(\"answer\", stop=\".\", max_tokens=20)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Note that you can also just print the string representation of the model for a truely raw view of the model's context:"
-   ]
+   "source": "Print the string representation to see exactly how the roles are formatted in the model's context:"
   },
   {
    "cell_type": "code",
@@ -189,84 +90,26 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "You can also change just a single role tag:"
-   ]
+   "source": "### Normal use\n\nOnce you are satisfied with the role formatting, you can use the model just like any other guidance model:"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>### System:\n",
-       "</span>You are a cat expert.<span style='background-color: rgba(255, 180, 0, 0.3); border-radius: 3px;'>\n",
-       "\n",
-       "### User:\n",
-       "</span><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>user</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>What are the smallest cats?</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>assistant</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>The</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> smallest</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> cats</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> are</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> the</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> dwar</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>f</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> cats</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>,</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> which</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> include</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> the</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> following</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> bre</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>eds</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>:</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>1</span></div></div></pre>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "with indent_roles(False), system():\n",
-    "    lm = orca + \"You are a cat expert.\"\n",
-    "\n",
-    "with user():\n",
-    "    lm += \"What are the smallest cats?\"\n",
-    "\n",
-    "with assistant():\n",
-    "    lm += gen(\"answer\", stop=\".\", max_tokens=20)"
-   ]
+   "outputs": [],
+   "source": "with system():\n    lm = orca + \"You are a cat expert.\"\n\nwith user():\n    lm += \"What are the smallest cats?\"\n\nwith assistant():\n    lm += gen(\"answer\", stop=\".\", max_tokens=20)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Normal use\n",
-    "\n",
-    "When you are satisfied with the correctness of your role formatting you can then use the model like normal:"
-   ]
+   "source": "You can access captured variables directly from the model object:"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; vertical-align: middle; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>system</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>You are a cat expert.</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>user</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'>What are the smallest cats?</div></div><div style='display: flex; border-bottom: 1px solid rgba(127, 127, 127, 0.2);  justify-content: center; align-items: center;'><div style='flex: 0 0 80px; opacity: 0.5;'>assistant</div><div style='flex-grow: 1; padding: 5px; padding-top: 10px; padding-bottom: 10px; margin-top: 0px; white-space: pre-wrap; margin-bottom: 0px;'><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>The</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> smallest</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> cats</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> are</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> the</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> dwar</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>f</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> cats</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>,</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> which</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> include</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> the</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> following</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'> bre</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>eds</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>:</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>1</span></div></div></pre>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "with system():\n",
-    "    lm = orca + \"You are a cat expert.\"\n",
-    "\n",
-    "with user():\n",
-    "    lm += \"What are the smallest cats?\"\n",
-    "\n",
-    "with assistant():\n",
-    "    lm += gen(\"answer\", stop=\".\", max_tokens=20)"
-   ]
+   "outputs": [],
+   "source": "print(lm[\"answer\"])"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Fixes #1402

## Problem
The `adding_new_models.ipynb` tutorial uses the outdated API where custom model support was implemented by subclassing `TransformersChat`. This API no longer exists in v0.3.x.

The old approach:
```python
class OrcaChat(models.transformers.TransformersChat):
    def get_role_start(self, role_name, **kwargs): ...
    def get_role_end(self, role_name=None): ...

orca = OrcaChat('pankajmathur/orca_mini_3b', ...)
```

## Solution
Update the notebook to use the current `ChatTemplate` API:
- Replace `OrcaChat(TransformersChat)` with `OrcaChatTemplate(ChatTemplate)` 
- Use `models.Transformers(..., chat_template=OrcaChatTemplate)` to load with a custom template
- Import `UnsupportedRoleException` for proper error handling on unsupported roles
- Remove stale cell outputs and update explanations to reflect the new architecture

## Testing
The updated code is self-contained and follows the same pattern used in the existing guidance documentation and codebase (e.g., `guidance/chat.py`).