### PR TITLE
fix: handle llama_cpp/llguidance version incompatibility gracefully

### DIFF
--- a/guidance/models/_llama_cpp.py
+++ b/guidance/models/_llama_cpp.py
@@ -15,14 +15,14 @@ from ..chat import ChatTemplate
 from ._base import Model
 from ._engine import Engine, EngineInterpreter, LogitsOutput, Tokenizer
 
+is_llama_cpp = False
 try:
     import llama_cpp
+    import llguidance.llamacpp
 
     is_llama_cpp = True
-except ModuleNotFoundError:
-    is_llama_cpp = False
-else:
-    import llguidance.llamacpp
+except (ModuleNotFoundError, ImportError, AttributeError):
+    pass
 
 if TYPE_CHECKING:
     from llama_cpp.llama import Llama


### PR DESCRIPTION
Fixes #1384

## Problem

When `llama_cpp` is installed but at a version incompatible with `llguidance.llamacpp`
(e.g. `llama-cpp-python==0.2.x` with `llguidance>=1.5.0`), the module-level
`import llguidance.llamacpp` raises an `AttributeError` (e.g. `module 'llama_cpp'
has no attribute 'llama_vocab_p'`) that crashes the **entire** `guidance` import.

This makes the library completely unusable even for users who are not using LlamaCpp
at all, since `guidance/models/__init__.py` imports from `_llama_cpp.py` at module level.

Verified on: `llama-cpp-python==0.2.7` + `llguidance==1.5.0`:
```
ImportError while loading conftest ...
guidance/models/_llama_cpp.py:25: in <module>
    import llguidance.llamacpp
AttributeError: module 'llama_cpp' has no attribute 'llama_vocab_p'
```

## Solution

Consolidate both `import llama_cpp` and `import llguidance.llamacpp` into a single
`try/except` block that catches `ModuleNotFoundError`, `ImportError`, and
`AttributeError`. When either package is missing or incompatible, `is_llama_cpp`
is set to `False` and the rest of guidance loads normally.

Users who attempt to instantiate `LlamaCpp` will still receive a clear error message
at instantiation time (the existing check at the top of `LlamaCppEngine.__init__`).

## Testing

- Verified `import guidance` succeeds with `llama-cpp-python==0.2.7` installed
- Unit tests pass: `pytest tests/unit/library/test_gen.py tests/unit/test_decorator.py`
  (44 passed, 1 xfailed)