### PR TITLE
fix: add chat_template property to Model for setting chat templates

### DIFF
--- a/guidance/models/_base/_model.py
+++ b/guidance/models/_base/_model.py
@@ -209,6 +209,16 @@ class Model:
         obj._update_trace_node(obj._id, obj._parent_id, None)
         return obj
 
+    @property
+    def chat_template(self):
+        """Get the chat template used for role-based formatting."""
+        return getattr(self._interpreter, "chat_template", None)
+
+    @chat_template.setter
+    def chat_template(self, value):
+        """Set the chat template used for role-based formatting."""
+        self._interpreter.chat_template = value
+
     def __str__(self) -> str:
         return str(self._interpreter.state)
 

--- a/tests/need_credentials/test_chat_templates.py
+++ b/tests/need_credentials/test_chat_templates.py
@@ -40,7 +40,6 @@ def test_popular_models_in_cache(model_id: str, should_pass: bool):
 # once I hook up the new ChatTemplate to guidance.models.Transformers and guidance.models.LlamaCPP, we can do this
 
 
-@pytest.mark.skip(reason="Is this supposed to work still? See issue 1196")
 @pytest.mark.parametrize(
     "model_id",
     [
@@ -76,7 +75,6 @@ def test_chat_format_smoke(model_id: str):
     assert str(lm) in tokeniser_render
 
 
-@pytest.mark.skip(reason="Is this supposed to work still? See issue 1196")
 @pytest.mark.parametrize(
     "model_id",
     [


### PR DESCRIPTION
Fixes #1196

## Problem
The chat template smoke tests in `tests/need_credentials/test_chat_templates.py` were disabled with `@pytest.mark.skip` because the tests set `lm.chat_template = ...` on Mock model objects, but the `Model` base class had no `chat_template` property. As a result, setting `lm.chat_template` only set a plain attribute on the model instance, rather than updating the interpreter's chat template that is actually used for role-based formatting.

## Solution
Add a `chat_template` property (getter and setter) to the `Model` base class in `guidance/models/_base/_model.py`:

- **Getter**: returns `self._interpreter.chat_template` if the interpreter supports it (via `getattr` with `None` as default for interpreters that do not have this attribute)
- **Setter**: sets `self._interpreter.chat_template = value`, which is then preserved across `deepcopy` when the model is copied during `__add__` operations

This allows tests (and users) to configure the chat template on a model object directly:
```python
lm = guidance.models.Mock("")
lm.chat_template = CHAT_TEMPLATE_CACHE[model_chat_template]()
# Now role blocks use the specified chat template
with guidance.user():
    lm += "Hello!"
```

Re-enable the two previously-skipped smoke tests: `test_chat_format_smoke` and `test_chat_format_smoke_with_system`.

## Testing
The tests require `HF_TOKEN` and download actual HuggingFace models, so they run in the `need_credentials` suite. The fix is mechanically verified: `lm.chat_template = value` now properly sets `lm._interpreter.chat_template = value`, and subsequent `deepcopy` of the interpreter (triggered by model copy during `__add__`) preserves the new template.