### PR TITLE
fix: warn when vLLM grammar output does not match grammar

### DIFF
--- a/guidance/models/experimental/_litellm.py
+++ b/guidance/models/experimental/_litellm.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, Any, ContextManager, Iterator
 
 from guidance._schema import SamplingParams
@@ -225,9 +226,16 @@ class LiteLLMInterpreter(BaseOpenAIInterpreter):
             enforce_max_tokens=False,
         )
         if matches is None:
-            # TODO: should probably raise...
-            # raise ValueError("vLLM failed to constrain the grammar")
-            pass
+            warnings.warn(
+                f"vLLM failed to match the generated output against the grammar. "
+                f"Named captures (variables) will not be accessible. "
+                f"Generated output: {buffer!r[:200]}{'...' if len(buffer) > 200 else ''}. "
+                f"This can occur when vLLM's guided decoding does not fully enforce the grammar "
+                f"(e.g. due to backtracking limitations). Consider simplifying the grammar or "
+                f"checking vLLM version compatibility.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         else:
             for name, value in matches.captures.items():
                 log_probs = matches.log_probs[name]

--- a/guidance/models/experimental/_vllm.py
+++ b/guidance/models/experimental/_vllm.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Iterator
 
 from guidance._schema import SamplingParams
@@ -53,9 +54,16 @@ class VLLMInterpreter(BaseOpenAIInterpreter):
             enforce_max_tokens=False,
         )
         if matches is None:
-            # TODO: should probably raise...
-            # raise ValueError("vLLM failed to constrain the grammar")
-            pass
+            warnings.warn(
+                f"vLLM failed to match the generated output against the grammar. "
+                f"Named captures (variables) will not be accessible. "
+                f"Generated output: {buffer!r[:200]}{'...' if len(buffer) > 200 else ''}. "
+                f"This can occur when vLLM's guided decoding does not fully enforce the grammar "
+                f"(e.g. due to backtracking limitations). Consider simplifying the grammar or "
+                f"checking vLLM version compatibility.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         else:
             for name, value in matches.captures.items():
                 log_probs = matches.log_probs[name]


### PR DESCRIPTION
Fixes #1383

## Problem

When using the `VLLMModel` or `LiteLLM` model with grammar constraints, vLLM's guided decoding sometimes produces output that doesn't fully match the guidance grammar (e.g. due to backtracking limitations). In this case, `node.match()` returns `None` and the code silently fell through with a `pass`, leaving named captures (variables) unset.

This caused a confusing `KeyError` when users tried to access captured variables (e.g. `lm['response']`), with no indication of why the variable was missing or what went wrong during generation.

## Solution

Replace the silent `pass` (with a `TODO: should probably raise...` comment) with a `RuntimeWarning` that:
- Clearly states that the grammar match failed and captures will not be accessible
- Shows the first 200 characters of the generated output for debugging
- Explains possible causes (vLLM guided decoding backtracking limitations, version incompatibility)
- Suggests remediation steps (simplify grammar, check vLLM version)

This fix is applied consistently to both `VLLMInterpreter._grammar_vllm` and `LiteLLMInterpreter._grammar_vllm`, which share the same pattern.

## Testing

The underlying backtracking issue requires a vLLM server to reproduce. The warning path is triggered when `node.match()` returns `None`, which happens when vLLM generates text that does not satisfy the grammar constraints.