### PR TITLE
fix: set additionalProperties: false for pydantic models with extra='ignore'

### DIFF
--- a/guidance/library/_pydantic.py
+++ b/guidance/library/_pydantic.py
@@ -13,6 +13,12 @@ class GenerateJsonSchemaSafe(pydantic.json_schema.GenerateJsonSchema):
     so we need to raise an exception if users attempt to specify non-string
     keys through pydantic. Otherwise, they may get unexpected output from
     model generation.
+
+    Additionally, when a model uses the default ``extra="ignore"`` configuration,
+    this generator adds ``additionalProperties: false`` to the JSON schema so that
+    LLMs do not waste tokens generating fields that would be silently discarded.
+    Models with ``extra="allow"`` retain flexible schemas, while ``extra="forbid"``
+    is already handled by pydantic itself.
     """
 
     def generate_inner(self, schema):
@@ -21,6 +27,19 @@ class GenerateJsonSchemaSafe(pydantic.json_schema.GenerateJsonSchema):
             if key_type != "str":
                 raise TypeError(f"JSON does not support non-string keys, got type {key_type}")
         return super().generate_inner(schema)
+
+    def model_schema(self, schema):
+        result = super().model_schema(schema)
+        config = schema.get("config", {})
+        # extra_fields_behavior is "allow", "forbid", or "ignore" when explicitly configured,
+        # and None when the model uses the default (which is "ignore").
+        # Pydantic already sets additionalProperties: false for extra="forbid".
+        # We mirror that for extra="ignore" (both explicit and default) so the LLM does
+        # not waste tokens generating fields that would otherwise be silently discarded.
+        extra_fields_behavior = config.get("extra_fields_behavior") if config else None
+        if extra_fields_behavior in (None, "ignore") and "additionalProperties" not in result:
+            result["additionalProperties"] = False
+        return result
 
 
 def pydantic_to_json_schema(schema: Union[type["pydantic.BaseModel"], "pydantic.TypeAdapter[Any]"]) -> dict[str, Any]:

--- a/tests/unit/library/test_pydantic.py
+++ b/tests/unit/library/test_pydantic.py
@@ -276,3 +276,54 @@ class TestDiscriminatedUnion:
             allowed_bytes={b","},  # expect a comma to continue the object with "barks"
             pydantic_model=self.Model,
         )
+
+
+class TestAdditionalProperties:
+    """Tests that pydantic models with default/explicit extra="ignore" get additionalProperties: false."""
+
+    def test_default_extra_rejects_additional_properties(self):
+        """Models with default extra='ignore' should not allow extra fields."""
+
+        class MyModel(pydantic.BaseModel):
+            a: str
+
+        grammar = gen_json(schema=MyModel)
+        # Valid: only declared property
+        assert grammar.match('{"a": "hello"}') is not None
+        # Invalid: extra property should be rejected
+        assert grammar.match('{"a": "hello", "extra": "value"}') is None
+
+    def test_explicit_extra_ignore_rejects_additional_properties(self):
+        """Models with explicit extra='ignore' should not allow extra fields."""
+
+        class MyModel(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(extra="ignore")
+            a: str
+
+        grammar = gen_json(schema=MyModel)
+        assert grammar.match('{"a": "hello"}') is not None
+        assert grammar.match('{"a": "hello", "extra": "value"}') is None
+
+    def test_extra_allow_permits_additional_properties(self):
+        """Models with extra='allow' should still permit additional fields."""
+
+        class MyModel(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(extra="allow")
+            a: str
+
+        grammar = gen_json(schema=MyModel)
+        assert grammar.match('{"a": "hello"}') is not None
+        assert grammar.match('{"a": "hello", "extra": "value"}') is not None
+
+    def test_nested_model_default_extra_rejects_additional_properties(self):
+        """Nested models with default extra should also reject extra fields."""
+
+        class Inner(pydantic.BaseModel):
+            x: int
+
+        class Outer(pydantic.BaseModel):
+            inner: Inner
+
+        grammar = gen_json(schema=Outer)
+        assert grammar.match('{"inner": {"x": 1}}') is not None
+        assert grammar.match('{"inner": {"x": 1, "extra": true}}') is None


### PR DESCRIPTION
Fixes #1050
Related: #1125

## Problem

When using a pydantic `BaseModel` (with the default `extra='ignore'` or explicit `extra='ignore'`) as the schema for `guidance.json()`, the generated JSON grammar allows the LLM to produce arbitrary additional fields that pydantic would silently discard during validation.

This behaviour wastes tokens and surprises users who expect only the declared fields to be generated, as reported in #1050 and #1125.

## Solution

Override `model_schema()` in `GenerateJsonSchemaSafe` to add `"additionalProperties": false` whenever the model's `extra_fields_behavior` is:
- `None` — the implicit pydantic default, which behaves as `extra='ignore'`
- `"ignore"` — explicitly set

Models with `extra='allow'` retain flexible schemas (pydantic sets `additionalProperties: true`).
Models with `extra='forbid'` already receive `additionalProperties: false` from pydantic itself.

The fix applies recursively to nested pydantic models within `$defs`, since each model's `model_schema()` is called independently.

## Before / After

```python
from pydantic import BaseModel
from guidance import json as gen_json

class MyModel(BaseModel):
    name: str
    age: int

grammar = gen_json(schema=MyModel)

# Before this fix:
grammar.match('{"name": "Alice", "age": 30, "extra": true}')  # -> Match (allowed!)

# After this fix:
grammar.match('{"name": "Alice", "age": 30, "extra": true}')  # -> None (rejected)
grammar.match('{"name": "Alice", "age": 30}')                 # -> Match (correct)
```

## Testing

Added `TestAdditionalProperties` to `tests/unit/library/test_pydantic.py` covering:
- Default `extra` rejects additional properties
- Explicit `extra='ignore'` rejects additional properties
- `extra='allow'` still permits additional properties
- Nested models also reject additional properties