### PR TITLE
fix: preserve temperature=0.0 and max_tokens=0 in subgrammar() factory

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -189,9 +189,9 @@ def subgrammar(
     capture_name = name
     name = name or (body.name if isinstance(body, RuleNode) else "subgrammar")
     node = RuleNode(name=name or "subgrammar", value=SubgrammarNode(body=body, skip_regex=skip_regex))
-    if max_tokens:
+    if max_tokens is not None:
         node = token_limit(node, max_tokens)
-    if temperature:
+    if temperature is not None:
         node = with_temperature(node, temperature)
     if capture_name:
         node = capture(node, capture_name)

--- a/tests/unit/library/test_subgrammar.py
+++ b/tests/unit/library/test_subgrammar.py
@@ -1,6 +1,88 @@
 import pytest
 
+from guidance._ast import GrammarNode, RuleNode
 from guidance.library._subgrammar import lexeme, subgrammar
+
+
+def _collect_temperatures(node: GrammarNode) -> set[float]:
+    """Walk a grammar tree and collect every non-None RuleNode.temperature."""
+    found: set[float] = set()
+    seen: set[int] = set()
+
+    def _walk(n: GrammarNode) -> None:
+        if not isinstance(n, GrammarNode) or id(n) in seen:
+            return
+        seen.add(id(n))
+        if isinstance(n, RuleNode) and n.temperature is not None:
+            found.add(n.temperature)
+        for c in n.children():
+            _walk(c)
+
+    _walk(node)
+    return found
+
+
+class TestSubgrammarFactoryTemperature:
+    """Regression tests for silently-dropped ``temperature=0.0`` in
+    ``guidance._grammar.subgrammar``.
+
+    ``temperature=0.0`` is the canonical way to request deterministic / greedy
+    sampling and must not be dropped by a ``if temperature:`` truthiness check.
+    """
+
+    def test_temperature_zero_is_preserved(self):
+        node = subgrammar(lexeme(r"\d+"), temperature=0.0)
+        observed = _collect_temperatures(node)
+        assert 0.0 in observed, f"temperature=0.0 was dropped by subgrammar(); observed={observed}"
+
+    def test_temperature_nonzero_still_works(self):
+        node = subgrammar(lexeme(r"\d+"), temperature=0.5)
+        assert 0.5 in _collect_temperatures(node)
+
+    def test_temperature_none_sets_nothing(self):
+        node = subgrammar(lexeme(r"\d+"))
+        assert _collect_temperatures(node) == set()
+
+
+def _collect_max_tokens(node: GrammarNode) -> set[int]:
+    """Walk a grammar tree and collect every non-None RuleNode.max_tokens."""
+    found: set[int] = set()
+    seen: set[int] = set()
+
+    def _walk(n: GrammarNode) -> None:
+        if not isinstance(n, GrammarNode) or id(n) in seen:
+            return
+        seen.add(id(n))
+        if isinstance(n, RuleNode) and n.max_tokens is not None:
+            found.add(n.max_tokens)
+        for c in n.children():
+            _walk(c)
+
+    _walk(node)
+    return found
+
+
+class TestSubgrammarFactoryMaxTokens:
+    """Regression tests for silently-dropped ``max_tokens=0`` in
+    ``guidance._grammar.subgrammar``.
+
+    Same falsy-truthiness class of bug as ``temperature=0.0``: ``if max_tokens:``
+    dropped the valid value ``0``. Guarding the two limits together prevents
+    a one-line regression to either from slipping past the suite.
+    """
+
+    def test_max_tokens_zero_is_preserved(self):
+        node = subgrammar(lexeme(r"\d+"), max_tokens=0)
+        observed = _collect_max_tokens(node)
+        assert 0 in observed, f"max_tokens=0 was dropped by subgrammar(); observed={observed}"
+
+    def test_max_tokens_nonzero_still_works(self):
+        node = subgrammar(lexeme(r"\d+"), max_tokens=16)
+        assert 16 in _collect_max_tokens(node)
+
+    def test_max_tokens_none_sets_nothing(self):
+        node = subgrammar(lexeme(r"\d+"))
+        assert _collect_max_tokens(node) == set()
 
 
 class TestEndingLexemeAmbiguous:


### PR DESCRIPTION
## Summary

`guidance._grammar.subgrammar()` used `if temperature:` / `if max_tokens:` to decide whether to attach those kwargs to the built `RuleNode`. Because `0.0` and `0` are falsy in Python, callers passing `temperature=0.0` (the canonical way to ask for deterministic / greedy sampling) or `max_tokens=0` had their values silently dropped — the resulting grammar had no `RuleNode.temperature` or `RuleNode.max_tokens` set.

Every other factory in the codebase (`guidance.json`, `guidance._grammar.gen`) already uses `is not None` for the same kwargs, so `subgrammar()` was the only inconsistent path.

## Root cause

```python
# guidance/_grammar.py (before)
if max_tokens:          # wrong: 0 is valid
    body = token_limit(body, max_tokens=max_tokens)
if temperature:         # wrong: 0.0 is valid
    body = with_temperature(body, temperature=temperature)
```

Python treats `0` and `0.0` as falsy, so the guards silently drop the valid-but-falsy values before they reach the `RuleNode`.

## Fix

Two-line change in `guidance/_grammar.py`: swap both guards for `is not None`, matching the rest of the codebase:

```python
if max_tokens is not None:
    body = token_limit(body, max_tokens=max_tokens)
if temperature is not None:
    body = with_temperature(body, temperature=temperature)
```

## Tests

`tests/unit/library/test_subgrammar.py` adds two parallel test classes:

- `TestSubgrammarFactoryTemperature`: verifies `temperature=0.0` propagates (RED on `main`), `temperature=0.5` still works, `temperature=None` sets nothing.
- `TestSubgrammarFactoryMaxTokens`: same three cases for `max_tokens=0` / `max_tokens=16` / `max_tokens=None`.

A helper walks the resulting grammar tree via `GrammarNode.children()` and collects every `RuleNode.temperature` (or `max_tokens`) that is not `None`.

Locally on `darwin/arm64`:
- `pytest tests/unit/library/test_subgrammar.py` → 14 passed.
- Full unit suite → 1582 passed, 1 skipped, 220 xfailed (all pre-existing; no new failures).
- `ruff check` clean.

## Risk notes

- Behaviour change: callers who were passing `temperature=0.0` or `max_tokens=0` expecting them to be ignored will now see them forwarded to `llguidance`. `llguidance` accepts `max_tokens=0` cleanly (verified locally via `LLMatcher` smoke test) — `max_tokens=0` is also already the honoured value in `gen()` / `json()` / `lark()` per `_ast.py` serialization, so this just brings `subgrammar()` in line.
- `None` (the documented default) still means "unset" and sets no limit. That invariant is covered by the `_none_sets_nothing` tests.
- No API shape change.

Related to the long-standing observation in #600 that temperature can be silently dropped on certain call paths; this PR addresses the `subgrammar()` path specifically.