### PR TITLE
feat(chat): add friendly name aliases for chat templates (fixes #976)

### DIFF
--- a/guidance/chat.py
+++ b/guidance/chat.py
@@ -49,7 +49,8 @@ def load_template_class(chat_template=None):
 
     Order of precedence:
     - If it's a chat template class, use it directly
-    - If it's a string, check the cache of popular model templates
+    - If it's a string, check the friendly name alias map (case-insensitive)
+    - If it's a string, check the cache of popular model templates (full Jinja2 template strings)
     - If it's a string and not in the cache, try to create a class dynamically
     - [TODO] If it's a string and can't be created, default to ChatML and raise a warning
     - If it's None, default to ChatML and raise a warning
@@ -60,9 +61,11 @@ def load_template_class(chat_template=None):
         return chat_template
 
     elif isinstance(chat_template, str):
-        # First check the cache of popular model types
-        # TODO: Expand keys of cache to include aliases for popular model types (e.g. "llama2, phi3")
-        # Can possibly accomplish this with an "aliases" dictionary that maps all aliases to the canonical key in cache
+        # Check the friendly name alias map first (case-insensitive, ignores spaces/dashes/underscores/dots)
+        normalized = chat_template.lower().replace(" ", "").replace("-", "").replace("_", "").replace(".", "")
+        if normalized in CHAT_TEMPLATE_NAME_MAP:
+            return CHAT_TEMPLATE_NAME_MAP[normalized]
+        # Fall through to the full Jinja2 template string cache
         if chat_template in CHAT_TEMPLATE_CACHE:
             return CHAT_TEMPLATE_CACHE[chat_template]
         # TODO: Add logic here to try to auto-create class dynamically via _template_class_from_string method
@@ -71,7 +74,7 @@ def load_template_class(chat_template=None):
     if chat_template is not None:
         warnings.warn(
             f"""Chat template {chat_template} was unable to be loaded directly into guidance.
-                        Defaulting to the ChatML format which may not be optimal for the selected model. 
+                        Defaulting to the ChatML format which may not be optimal for the selected model.
                         For best results, create and pass in a `guidance.ChatTemplate` subclass for your model.""",
             stacklevel=2,
         )
@@ -398,3 +401,43 @@ class Llama3dot2ChatTemplate(ChatTemplate):
 
 
 CHAT_TEMPLATE_CACHE[llama3dot2_template] = Llama3dot2ChatTemplate
+
+
+# --------------------------------------------------
+# Friendly name alias map for load_template_class()
+# --------------------------------------------------
+# Maps normalized names (lowercase, no spaces/dashes/underscores) to template classes.
+# This lets users pass short friendly names like "llama2" or "ChatML" instead of full Jinja2
+# template strings. Keys are pre-normalized so lookup is O(1).
+CHAT_TEMPLATE_NAME_MAP: dict[str, type[ChatTemplate]] = {
+    # ChatML
+    "chatml": ChatMLTemplate,
+    # Llama 2
+    "llama2": Llama2ChatTemplate,
+    # Llama 3
+    "llama3": Llama3ChatTemplate,
+    # Phi-3 Mini
+    "phi3mini": Phi3MiniChatTemplate,
+    "phi3": Phi3MiniChatTemplate,
+    # Phi-3 Small / Medium
+    "phi3small": Phi3SmallMediumChatTemplate,
+    "phi3medium": Phi3SmallMediumChatTemplate,
+    # Phi-4 Mini
+    "phi4mini": Phi4MiniChatTemplate,
+    "phi4": Phi4MiniChatTemplate,
+    # Mistral 7B Instruct
+    "mistral": Mistral7BInstructChatTemplate,
+    "mistral7b": Mistral7BInstructChatTemplate,
+    "mistral7binstruct": Mistral7BInstructChatTemplate,
+    # Gemma 2 9B Instruct
+    "gemma2": Gemma29BInstructChatTemplate,
+    "gemma29b": Gemma29BInstructChatTemplate,
+    # Qwen 2.5
+    "qwen25": Qwen2dot5ChatTemplate,
+    "qwen2dot5": Qwen2dot5ChatTemplate,
+    # Qwen 3
+    "qwen3": Qwen3ChatTemplate,
+    # Llama 3.2
+    "llama32": Llama3dot2ChatTemplate,
+    "llama3dot2": Llama3dot2ChatTemplate,
+}

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -1,0 +1,113 @@
+"""Tests for guidance.chat module — focusing on load_template_class() name lookup."""
+
+import warnings
+
+import pytest
+
+from guidance.chat import (
+    CHAT_TEMPLATE_NAME_MAP,
+    ChatMLTemplate,
+    ChatTemplate,
+    Gemma29BInstructChatTemplate,
+    Llama2ChatTemplate,
+    Llama3ChatTemplate,
+    Llama3dot2ChatTemplate,
+    Mistral7BInstructChatTemplate,
+    Phi3MiniChatTemplate,
+    Phi3SmallMediumChatTemplate,
+    Phi4MiniChatTemplate,
+    Qwen2dot5ChatTemplate,
+    Qwen3ChatTemplate,
+    load_template_class,
+)
+
+
+class TestLoadTemplateClassByName:
+    """load_template_class() should resolve friendly names case-insensitively."""
+
+    @pytest.mark.parametrize(
+        "name,expected_class",
+        [
+            # ChatML variants
+            ("chatml", ChatMLTemplate),
+            ("ChatML", ChatMLTemplate),
+            ("CHATML", ChatMLTemplate),
+            ("chat-ml", ChatMLTemplate),
+            ("chat_ml", ChatMLTemplate),
+            # Llama 2
+            ("llama2", Llama2ChatTemplate),
+            ("Llama2", Llama2ChatTemplate),
+            ("llama-2", Llama2ChatTemplate),
+            ("llama_2", Llama2ChatTemplate),
+            # Llama 3
+            ("llama3", Llama3ChatTemplate),
+            ("Llama3", Llama3ChatTemplate),
+            # Phi-3
+            ("phi3", Phi3MiniChatTemplate),
+            ("phi3mini", Phi3MiniChatTemplate),
+            ("Phi3Mini", Phi3MiniChatTemplate),
+            ("phi-3-mini", Phi3MiniChatTemplate),
+            ("phi3small", Phi3SmallMediumChatTemplate),
+            ("phi3medium", Phi3SmallMediumChatTemplate),
+            # Phi-4
+            ("phi4mini", Phi4MiniChatTemplate),
+            ("phi4", Phi4MiniChatTemplate),
+            # Mistral
+            ("mistral", Mistral7BInstructChatTemplate),
+            ("mistral7b", Mistral7BInstructChatTemplate),
+            ("Mistral", Mistral7BInstructChatTemplate),
+            # Gemma 2
+            ("gemma2", Gemma29BInstructChatTemplate),
+            ("gemma29b", Gemma29BInstructChatTemplate),
+            ("Gemma2", Gemma29BInstructChatTemplate),
+            # Qwen 2.5
+            ("qwen25", Qwen2dot5ChatTemplate),
+            ("qwen2dot5", Qwen2dot5ChatTemplate),
+            ("Qwen25", Qwen2dot5ChatTemplate),
+            # Qwen 3
+            ("qwen3", Qwen3ChatTemplate),
+            ("Qwen3", Qwen3ChatTemplate),
+            # Llama 3.2
+            ("llama32", Llama3dot2ChatTemplate),
+            ("llama3dot2", Llama3dot2ChatTemplate),
+            ("Llama32", Llama3dot2ChatTemplate),
+            ("llama-3.2", Llama3dot2ChatTemplate),
+            ("Llama 3.2", Llama3dot2ChatTemplate),
+        ],
+    )
+    def test_friendly_name_lookup(self, name, expected_class):
+        result = load_template_class(name)
+        assert result is expected_class
+
+    def test_none_returns_chatml(self):
+        result = load_template_class(None)
+        assert result is ChatMLTemplate
+
+    def test_class_passed_directly(self):
+        result = load_template_class(Llama2ChatTemplate)
+        assert result is Llama2ChatTemplate
+
+    def test_base_class_raises(self):
+        with pytest.raises(Exception, match="base ChatTemplate class"):
+            load_template_class(ChatTemplate)
+
+    def test_unknown_name_warns_and_falls_back(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = load_template_class("totally_unknown_model_xyz")
+        assert result is ChatMLTemplate
+        assert len(caught) == 1
+        assert "totally_unknown_model_xyz" in str(caught[0].message)
+
+    def test_name_map_keys_are_normalized(self):
+        """All keys in CHAT_TEMPLATE_NAME_MAP must already be normalized (lowercase, no separators/dots)."""
+        for key in CHAT_TEMPLATE_NAME_MAP:
+            normalized = key.lower().replace(" ", "").replace("-", "").replace("_", "").replace(".", "")
+            assert key == normalized, f"Key {key!r} is not normalized — should be {normalized!r}"
+
+    def test_name_map_values_are_chat_template_subclasses(self):
+        """All values in CHAT_TEMPLATE_NAME_MAP must be ChatTemplate subclasses."""
+        for key, cls in CHAT_TEMPLATE_NAME_MAP.items():
+            assert isinstance(cls, type) and issubclass(cls, ChatTemplate), (
+                f"Value for key {key!r} is not a ChatTemplate subclass"
+            )


### PR DESCRIPTION
## Summary

Closes #976.

Users currently cannot pass friendly names like `"llama2"` or `"ChatML"` to the `chat_template` parameter — they must supply the full Jinja2 template string. This PR implements the alias system that was explicitly called out in two TODO comments in `chat.py`:

> `TODO [HN]: Add an alias system so we can instantiate with other simple keys (e.g. "llama2" instead of the full template string)`

### Changes

- **`guidance/chat.py`** — updates `load_template_class()` to check a new `CHAT_TEMPLATE_NAME_MAP` dictionary before falling through to the Jinja2 template string cache. Lookup is case-insensitive and strips spaces, dashes, underscores, and dots, so all of these work:
  ```python
  model = Transformers("meta-llama/Llama-2-7b-chat-hf", chat_template="llama2")
  model = Transformers("meta-llama/Llama-2-7b-chat-hf", chat_template="Llama2")
  model = Transformers("meta-llama/Llama-2-7b-chat-hf", chat_template="llama-2")
  model = Transformers("meta-llama/Llama-3.2-1B-Instruct", chat_template="Llama 3.2")
  model = Transformers("Qwen/Qwen3-8B", chat_template="qwen3")
  ```

- **`CHAT_TEMPLATE_NAME_MAP`** — a new module-level dict mapping normalized alias keys to template classes. Covers all templates currently defined in the module: ChatML, Llama 2/3/3.2, Phi-3 mini/small/medium, Phi-4 mini, Mistral 7B Instruct, Gemma 2 9B, Qwen 2.5, and Qwen 3.

- **`tests/unit/test_chat.py`** (new) — unit tests covering all alias variants, case-insensitivity, separator stripping, `None` fallback, unknown-name warning, and map-key normalization invariant.

### Backwards compatibility

Existing code that passes full Jinja2 template strings continues to work unchanged — the name map check only runs first; if no alias matches, the code falls through to `CHAT_TEMPLATE_CACHE` exactly as before.