### PR TITLE
fix: respect allow_local for file URIs

### DIFF
--- a/guidance/_utils.py
+++ b/guidance/_utils.py
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 
 def bytes_from(src: str | pathlib.Path | bytes, allow_local: bool) -> bytes:
     if isinstance(src, str) and re.match(r"[^:/]+://", src):
+        if urllib.parse.urlparse(src).scheme == "file" and not allow_local:
+            raise Exception(f"Unable to load bytes from {src}!")
         with urllib.request.urlopen(src) as response:
             response = cast(http.client.HTTPResponse, response)
             bytes_data = response.read()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+from guidance._utils import bytes_from
+
+
+def test_bytes_from_file_uri_respects_allow_local(tmp_path: Path) -> None:
+    local_file = tmp_path / "secret.bin"
+    local_file.write_bytes(b"local bytes")
+
+    assert bytes_from(local_file.as_uri(), allow_local=True) == b"local bytes"
+
+    with pytest.raises(Exception, match="Unable to load bytes"):
+        bytes_from(local_file.as_uri(), allow_local=False)


### PR DESCRIPTION
## Summary
- Prevent `bytes_from(..., allow_local=False)` from reading `file://` URIs.
- Add a regression test that still permits local file URIs when `allow_local=True`.

## Why
`allow_local=False` is used by remote/content-loading paths to avoid local file reads. A `file://` URI matched the generic URL branch and could still be opened via `urllib.request.urlopen`, bypassing that flag.

## Tests
- `uv run --with '.[test-unit]' python -m pytest tests/unit/test_utils.py -q`
