### PR TITLE
Update code_generation notebook

### DIFF
--- a/notebooks/tutorials/code_generation.ipynb
+++ b/notebooks/tutorials/code_generation.ipynb
@@ -27,24 +27,34 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f8b1336752ea4f2c857f9bbf53ef11c2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/338 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-12-05 21:22:33.078594: I tensorflow/core/util/port.cc:110] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
-      "2023-12-05 21:22:33.148003: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-      "To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
+      "gpustat is not installed, run `pip install gpustat` to collect GPU stats.\n"
      ]
     }
    ],
    "source": [
     "from guidance import models, gen\n",
-    "from guidance.library._gen import will_gen\n",
-    "from guidance import capture, one_or_more, any_char, zero_or_more, commit_point, select\n",
     "import guidance\n",
     "import re\n",
-    "base_path = '/home/marcotcr_google_com/work/models/'\n",
-    "model_path = base_path + 'mistral-7b-codealpaca-lora.Q8_0.gguf'\n",
-    "mistral = models.LlamaCpp(model_path, n_gpu_layers=-1, n_ctx=4096)"
+    "\n",
+    "model = models.Transformers(\"Qwen/Qwen2.5-Coder-1.5B\")"
    ]
   },
   {
@@ -81,10 +91,10 @@
     "import guidance\n",
     "@guidance\n",
     "def baseline(lm, prompt):\n",
-    "    r = re.findall('def (.*?)\\(', prompt)\n",
+    "    r = re.findall(r'def (.*?)\\(', prompt)\n",
     "    name = r[-1]\n",
     "    lm += f'Here is an implementation of {name}:\\n'\n",
-    "    lm += '```python\\n' + prompt + gen(max_tokens=800, stop=['```', 'if __name__', 'def test'], name='program')\n",
+    "    lm += '```python\\n' + prompt + gen(max_tokens=200, stop_regex=r'```|if __name__|def test|\\n[^\\s]', name='program')\n",
     "    lm = lm.set('program', prompt + lm['program'])\n",
     "    return lm   "
    ]
@@ -96,29 +106,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>Here is an implementation of solution:\n",
-       "```python\n",
-       "\n",
-       "def solution(lst):\n",
-       "    &quot;&quot;&quot;Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n",
-       "    \n",
-       "\n",
-       "    Examples\n",
-       "    solution([5, 8, 7, 1]) ==&gt; 12\n",
-       "    solution([3, 3, 3, 3, 3]) ==&gt; 9\n",
-       "    solution([30, 13, 24, 321]) ==&gt;0\n",
-       "    &quot;&quot;&quot;<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>   </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> return</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> sum</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>lst</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>[</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>i]</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> for</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>i in</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> range</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> len</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>lst</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>),</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>if l</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>st</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>[</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>i]</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> %</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> !=</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>#</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> test</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> the</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> function</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>print</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>olution</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>([</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>5</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>8</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>7</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>]))</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> #</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> shoul</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>d print</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>print</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>olution</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>([</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>]))</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> #</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> shoul</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>d print</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>9</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>print</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>olution</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>([</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>4</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>]))</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> #</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> shoul</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>d print</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span></pre>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebfe8bdbc40e441cbc40a3322b610c00",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
       ]
      },
      "metadata": {},
@@ -128,7 +122,8 @@
    "source": [
     "idx = 121\n",
     "prompt = dataset['test']['prompt'][idx]\n",
-    "lm = mistral + baseline(prompt)"
+    "lm = model + baseline(prompt)\n",
+    "baseline_program = lm['program']"
    ]
   },
   {
@@ -140,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +147,8 @@
     "        # Executes the function definition\n",
     "        exec(program, globals())\n",
     "    except Exception as e:\n",
-    "        # Program not valid\n",
+    "        print(\"Program not valid\")\n",
+    "        print(e)\n",
     "        return False\n",
     "    name = dataset['test']['entry_point'][i]\n",
     "    try:\n",
@@ -160,32 +156,52 @@
     "        eval('check(%s)' % name)\n",
     "        # If we get here, we passed the tests\n",
     "        return True\n",
-    "    except:\n",
-    "        # The program ran, but the failed the unit test, or ran into some other exception\n",
+    "    except Exception as e:\n",
+    "        print(\"Program ran, but hit exception\")\n",
+    "        print(e)\n",
     "        return False"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"\\ndef triangle_area(a, b, c):\\n    '''\\n    Given the lengths of the three sides of a triangle. Return the area of\\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \\n    Otherwise return -1\\n    Three sides make a valid triangle when the sum of any two sides is greater \\n    than the third side.\\n    Example:\\n    triangle_area(3, 4, 5) == 6.00\\n    triangle_area(1, 2, 10) == -1\\n    '''\\n    # Check if the three sides form a valid triangle\\n    if a + b <= c or a + c <= b or b + c <= a:\\n        return -1\\n    # Calculate the semi-perimeter\\n    s = (a + b + c) / 2\\n    # Calculate the area using Heron's formula\\n    area = (s * (s - a) * (s - b) * (s - c)) ** 0.5\\n    # Return the area rounded to 2 decimal points\\n    return round(area, 2)\\n    \""
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lm['program']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "12\n",
-      "9\n",
-      "0\n"
+      "Program ran, but hit exception\n",
+      "name 'check' is not defined\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "True"
+       "False"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -216,30 +232,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>Here is an implementation of triangle_area:\n",
-       "```python\n",
-       "\n",
-       "def triangle_area(a, b, c):\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    Given the lengths of the three sides of a triangle. Return the area of\n",
-       "    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n",
-       "    Otherwise return -1\n",
-       "    Three sides make a valid triangle when the sum of any two sides is greater \n",
-       "    than the third side.\n",
-       "    Example:\n",
-       "    triangle_area(3, 4, 5) == 6.00\n",
-       "    triangle_area(1, 2, 10) == -1\n",
-       "    &#x27;&#x27;&#x27;<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>   </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>if a</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> +</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> b</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> &gt;</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> c</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> an</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>d a</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> +</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> c</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> &gt;</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> b</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> an</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>d b</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> +</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> c</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> &gt;</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> a</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>:</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>       </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> =</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> (</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>a</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> +</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> b</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> +</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> c</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> /</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>       </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> return</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> roun</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>d(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> *</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> (</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> a</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> *</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> (</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> b</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> *</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> (</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>s</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> c</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>),</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>   </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> else</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>:</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>       </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> return</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span></pre>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "00f8d2dc3c224f969ebe922307299c34",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
       ]
      },
      "metadata": {},
@@ -249,7 +248,8 @@
    "source": [
     "idx = 71\n",
     "prompt = dataset['test']['prompt'][idx]\n",
-    "lm = mistral + baseline(prompt)"
+    "lm = model + baseline(prompt)\n",
+    "baseline_program = lm['program']"
    ]
   },
   {
@@ -288,7 +288,7 @@
     {
      "data": {
       "text/plain": [
-       "36.0"
+       "6.0"
       ]
      },
      "execution_count": 10,
@@ -311,32 +311,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guidance import any_char_but, regex\n",
-    "@guidance(stateless=True)\n",
-    "def test(lm, fn_name):\n",
-    "    \"\"\"Only allows assert fn_name(args) == expected\"\"\"\n",
-    "    return lm + '   assert ' + fn_name + '(' + capture(zero_or_more(any_char_but(['\\n'])), name='args') + commit_point(select([') == ', ') is ', ')' + regex('\\s\\s?\\s?\\s?') + '== '])) + capture(one_or_more(any_char()), name='result') + commit_point('\\n')\n",
-    "\n",
     "@guidance\n",
     "def write_tests(lm, prompt):\n",
-    "    r = re.findall('def (.*?)\\(', prompt)\n",
+    "    r = re.findall(r'def (.*?)\\(', prompt)\n",
     "    name = r[-1]\n",
     "    lm += '```python\\n' + prompt + '    pass\\n'\n",
     "    lm += f'\\ndef test_{name}():\\n'\n",
     "    lm += '    \"\"\"Turns the example(s) in the docstring above into asserts\"\"\"\\n'\n",
+    "    examples = re.findall(rf'{re.escape(name)}\\((.*?)\\)\\s*(?:==|=>)\\s*([^\\n]+)', prompt)\n",
+    "    if not examples:\n",
+    "        raise ValueError(f'Could not find docstring examples for {name}')\n",
     "    args = []\n",
     "    expected = []\n",
-    "    # Write at most 10 tests, but stop when the model wants to stop\n",
-    "    for i in range(10):\n",
-    "        lm += test(name)\n",
-    "        args.append(lm['args'])\n",
-    "        expected.append(lm['result'])\n",
-    "        if not lm.will_gen('assert', ignore_spaces=True):\n",
-    "            break\n",
+    "    for arg, result in examples:\n",
+    "        arg = arg.strip()\n",
+    "        result = result.strip()\n",
+    "        lm += f'   assert {name}({arg}) == {result}\\n'\n",
+    "        args.append(arg)\n",
+    "        expected.append(result)\n",
     "    lm = lm.set('args', args)\n",
     "    lm = lm.set('expected', expected)\n",
     "    return lm"
@@ -344,38 +340,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>```python\n",
-       "\n",
-       "def triangle_area(a, b, c):\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    Given the lengths of the three sides of a triangle. Return the area of\n",
-       "    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n",
-       "    Otherwise return -1\n",
-       "    Three sides make a valid triangle when the sum of any two sides is greater \n",
-       "    than the third side.\n",
-       "    Example:\n",
-       "    triangle_area(3, 4, 5) == 6.00\n",
-       "    triangle_area(1, 2, 10) == -1\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    pass\n",
-       "\n",
-       "def test_triangle_area():\n",
-       "    &quot;&quot;&quot;Turns the example(s) in the docstring above into asserts&quot;&quot;&quot;\n",
-       "   assert triangle_area<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>4</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>5</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> ==</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>6</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>.</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span>   assert triangle_area<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> ==</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span>   assert triangle_area<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>4</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>7</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> ==</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span>   assert triangle_area<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>3</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> ==</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>.</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>0</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span>   assert triangle_area<span style='background-color: rgba(0.0, 165.0, 0, 0.15); border-radius: 3px;' title='1.0'>(</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>,</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> </span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>2</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>)</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> ==</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'> -</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>1</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>\n",
-       "</span></pre>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ab79cb01dad9403cb56112cfce558ff6",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
       ]
      },
      "metadata": {},
@@ -383,7 +359,7 @@
     }
    ],
    "source": [
-    "lm = mistral + write_tests(prompt)\n",
+    "lm = model + write_tests(prompt)\n",
     "args = lm['args']\n",
     "expected = lm['expected']"
    ]
@@ -398,20 +374,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[('3, 4, 5', '6.00'),\n",
-       " ('1, 2, 10', '-1'),\n",
-       " ('3, 4, 7', '-1'),\n",
-       " ('3, 3, 3', '0.00'),\n",
-       " ('1, 1, 2', '-1')]"
+       "[('3, 4, 5', '6.00'), ('1, 2, 10', '-1')]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,20 +423,43 @@
     "    lm += reconstruct_tests(name, args, expected) + '```\\n'\n",
     "    return lm\n",
     "\n",
-    "@guidance\n",
-    "def baseline_and_tests(lm, prompt):\n",
-    "    lm2 = lm + baseline(prompt)\n",
-    "    r = re.findall('def (.*?)\\(', prompt)\n",
+    "def format_program_and_tests(name, program, args, expected):\n",
+    "    tests = ''.join(f'   assert {name}({arg}) == {e}\\n' for arg, e in zip(args, expected))\n",
+    "    return f'Here is an implementation of {name}:\\n```python\\n{program}\\ndef test_{name}():\\n{tests}```\\n'\n",
+    "\n",
+    "def baseline_and_tests(lm, prompt, program, args, expected):\n",
+    "    r = re.findall(r'def (.*?)\\(', prompt)\n",
     "    name = r[-1]\n",
-    "    program = lm2['program']\n",
-    "    lm2 = lm + write_tests(prompt)\n",
-    "    args, expected = lm2['args'], lm2['expected']\n",
-    "    lm = lm.set('program', program)\n",
-    "    lm = lm.set('args', args)\n",
-    "    lm = lm.set('expected', expected)\n",
-    "    lm = lm.set('name', name)\n",
-    "    lm += add_program_and_tests(name, program, args, expected)\n",
-    "    return lm"
+    "    lm2 = lm.set('args', args)\n",
+    "    lm2 = lm2.set('expected', expected)\n",
+    "    lm2 = lm2.set('program', program)\n",
+    "    lm2 = lm2.set('name', name)\n",
+    "    lm2 += format_program_and_tests(name, program, args, expected)\n",
+    "    return lm2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "db37fa4d76184bfe92e70b64f71330e1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lm = baseline_and_tests(model, prompt, baseline_program, args, expected)"
    ]
   },
   {
@@ -474,61 +469,11 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>Here is an implementation of triangle_area:\n",
-       "```python\n",
-       "\n",
-       "def triangle_area(a, b, c):\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    Given the lengths of the three sides of a triangle. Return the area of\n",
-       "    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n",
-       "    Otherwise return -1\n",
-       "    Three sides make a valid triangle when the sum of any two sides is greater \n",
-       "    than the third side.\n",
-       "    Example:\n",
-       "    triangle_area(3, 4, 5) == 6.00\n",
-       "    triangle_area(1, 2, 10) == -1\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    if a + b &gt; c and a + c &gt; b and b + c &gt; a:\n",
-       "        s = (a + b + c) / 2\n",
-       "        return round(s * (s - a) * (s - b) * (s - c), 2)\n",
-       "    else:\n",
-       "        return -1\n",
-       "\n",
-       "def test_triangle_area():\n",
-       "   assert triangle_area(3, 4, 5) == 6.00\n",
-       "   assert triangle_area(1, 2, 10) == -1\n",
-       "   assert triangle_area(3, 4, 7) == -1\n",
-       "   assert triangle_area(3, 3, 3) == 0.00\n",
-       "   assert triangle_area(1, 1, 2) == -1\n",
-       "```\n",
-       "</pre>"
-      ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "(['3, 4, 5', '1, 2, 10'], ['6.00', '-1'])"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "lm = mistral + baseline_and_tests(prompt)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(['3, 4, 5', '1, 2, 10', '3, 4, 7', '3, 3, 3', '1, 1, 2'],\n",
-       " ['6.00', '-1', '-1', '0.00', '-1'])"
-      ]
-     },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -546,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,45 +547,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>Running the test(s) above gives:\n",
-       "assert triangle_area(3, 4, 5) == 6.00\n",
-       "Assertion failed.\n",
-       "Expected: 6.00\n",
-       "Actual: 36.0\n",
-       "---\n",
-       "assert triangle_area(1, 2, 10) == -1\n",
-       "Assertion passed.\n",
-       "---\n",
-       "assert triangle_area(3, 4, 7) == -1\n",
-       "Assertion passed.\n",
-       "---\n",
-       "assert triangle_area(3, 3, 3) == 0.00\n",
-       "Assertion failed.\n",
-       "Expected: 0.00\n",
-       "Actual: 15.19\n",
-       "---\n",
-       "assert triangle_area(1, 1, 2) == -1\n",
-       "Assertion passed.\n",
-       "---\n",
-       "</pre>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6949151f8924977aa37276ba1e7d53d",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<guidance.models._llama_cpp.LlamaCpp at 0x7fb18eae7a30>"
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
       ]
      },
-     "execution_count": 19,
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<guidance.models._transformers.Transformers at 0x128c89250>"
+      ]
+     },
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mistral + run_tests(lm['name'], lm['program'], lm['args'], lm['expected'])"
+    "model + run_tests(lm['name'], lm['program'], lm['args'], lm['expected'])"
    ]
   },
   {
@@ -652,13 +588,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@guidance\n",
-    "def run_tests_and_fix(lm, prompt):\n",
-    "    lm2 = lm + baseline_and_tests(prompt)\n",
+    "def run_tests_and_fix(lm, prompt, program, args, expected):\n",
+    "    lm2 = baseline_and_tests(lm, prompt, program, args, expected)\n",
     "    name, program, args, expected = lm2['name'], lm2['program'], lm2['args'], lm2['expected']\n",
     "    i = 0\n",
     "    # Try this at most 3 times\n",
@@ -674,11 +609,11 @@
     "        lm2 += f'In order to fix it, I need to''' + gen(stop='\\n') + '\\n'\n",
     "        lm2 += f'Here is a fixed implementation:\\n'\n",
     "        # Write a new program\n",
-    "        lm2 += '```python\\n' + prompt + gen(max_tokens=800, stop_regex='\\n[^\\s]', name='program')\n",
+    "        lm2 += '```python\\n' + prompt + gen(max_tokens=200, stop_regex=r'```|if __name__|def test|\\n[^\\s]', name='program')\n",
     "        lm2 += '```\\n'\n",
     "        # Reset the slate, start over with new program\n",
     "        program = prompt + lm2['program']\n",
-    "        lm2 = lm + add_program_and_tests(name, program, args, expected)\n",
+    "        lm2 = lm + format_program_and_tests(name, program, args, expected)\n",
     "        lm2 = lm2.set('program', program)\n",
     "        lm + 'ae' + gen(max_tokens=10)\n",
     "    return lm2"
@@ -691,70 +626,13 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>...<span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>----------------</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>----------------</span><span style='background-color: rgba(165.0, 0.0, 0, 0.15); border-radius: 3px;' title='0.0'>----------------</span></pre>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf75f6171ee5492ca3d38e9b11d3b75d",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<guidance.models._llama_cpp.LlamaCpp at 0x7fb18d6e33a0>"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mistral + '...' + gen(max_tokens=3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style='margin: 0px; padding: 0px; padding-left: 8px; margin-left: -8px; border-radius: 0px; border-left: 1px solid rgba(127, 127, 127, 0.2); white-space: pre-wrap; font-family: ColfaxAI, Arial; font-size: 15px; line-height: 23px;'>Here is an implementation of triangle_area:\n",
-       "```python\n",
-       "\n",
-       "def triangle_area(a, b, c):\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    Given the lengths of the three sides of a triangle. Return the area of\n",
-       "    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n",
-       "    Otherwise return -1\n",
-       "    Three sides make a valid triangle when the sum of any two sides is greater \n",
-       "    than the third side.\n",
-       "    Example:\n",
-       "    triangle_area(3, 4, 5) == 6.00\n",
-       "    triangle_area(1, 2, 10) == -1\n",
-       "    &#x27;&#x27;&#x27;\n",
-       "    # Check if the sides form a valid triangle\n",
-       "    if a + b &gt; c and a + c &gt; b and b + c &gt; a:\n",
-       "        # Calculate the semi-perimeter\n",
-       "        s = (a + b + c) / 2\n",
-       "        # Check if the triangle is right-angled\n",
-       "        if a**2 + b**2 == c**2:\n",
-       "            # Use Gauss&#x27;s formula for the area of a right-angled triangle\n",
-       "            area = ((s * (s - a) * (s - b) * (s - c)) ** 0.5)\n",
-       "        else:\n",
-       "            # Use Heron&#x27;s formula for the area of a general triangle\n",
-       "            area = ((s * (s - a) * (s - b) * (s - c)) ** 0.5)\n",
-       "        return round(area, 2)\n",
-       "    else:\n",
-       "        return -1\n",
-       "\n",
-       "def test_triangle_area():\n",
-       "   assert triangle_area(3, 4, 5) == 6.00\n",
-       "   assert triangle_area(1, 2, 10) == -1\n",
-       "   assert triangle_area(3, 4, 7) == -1\n",
-       "   assert triangle_area(1, 1, 2) == -1\n",
-       "   assert triangle_area(12, 5, 13) == 17.71\n",
-       "```\n",
-       "</pre>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "StitchWidget(initial_height='auto', initial_width='100%', srcdoc='<!doctype html>\\n<html lang=\"en\">\\n<head>\\n …"
       ]
      },
      "metadata": {},
@@ -762,12 +640,12 @@
     }
    ],
    "source": [
-    "lm = mistral + run_tests_and_fix(prompt)"
+    "lm = run_tests_and_fix(model, prompt, baseline_program, args, expected)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -795,16 +673,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "True"
+       "False"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -825,7 +703,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "guidance_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -839,9 +717,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/tutorials/code_generation.ipynb
+++ b/notebooks/tutorials/code_generation.ipynb
@@ -23,32 +23,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f8b1336752ea4f2c857f9bbf53ef11c2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading weights:   0%|          | 0/338 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
-      "gpustat is not installed, run `pip install gpustat` to collect GPU stats.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from guidance import models, gen\n",
     "import guidance\n",
@@ -107,7 +84,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ebfe8bdbc40e441cbc40a3322b610c00",
+       "model_id": "6a39a4b2de6345d0b39383d3b7f5c4c1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -135,17 +112,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Returns True if it passes the evaluation tests, False otherwise\n",
     "def eval_program(program, i):\n",
+    "    namespace = {}\n",
     "    # Loads the `check` function\n",
-    "    exec(dataset['test']['test'][i])\n",
+    "    exec(dataset['test']['test'][i], namespace)\n",
     "    try:\n",
     "        # Executes the function definition\n",
-    "        exec(program, globals())\n",
+    "        exec(program, namespace)\n",
     "    except Exception as e:\n",
     "        print(\"Program not valid\")\n",
     "        print(e)\n",
@@ -153,7 +131,7 @@
     "    name = dataset['test']['entry_point'][i]\n",
     "    try:\n",
     "        # Run the unit tests\n",
-    "        eval('check(%s)' % name)\n",
+    "        namespace['check'](namespace[name])\n",
     "        # If we get here, we passed the tests\n",
     "        return True\n",
     "    except Exception as e:\n",
@@ -164,16 +142,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"\\ndef triangle_area(a, b, c):\\n    '''\\n    Given the lengths of the three sides of a triangle. Return the area of\\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \\n    Otherwise return -1\\n    Three sides make a valid triangle when the sum of any two sides is greater \\n    than the third side.\\n    Example:\\n    triangle_area(3, 4, 5) == 6.00\\n    triangle_area(1, 2, 10) == -1\\n    '''\\n    # Check if the three sides form a valid triangle\\n    if a + b <= c or a + c <= b or b + c <= a:\\n        return -1\\n    # Calculate the semi-perimeter\\n    s = (a + b + c) / 2\\n    # Calculate the area using Heron's formula\\n    area = (s * (s - a) * (s - b) * (s - c)) ** 0.5\\n    # Return the area rounded to 2 decimal points\\n    return round(area, 2)\\n    \""
+       "'\\ndef solution(lst):\\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\\n    \\n\\n    Examples\\n    solution([5, 8, 7, 1]) ==> 12\\n    solution([3, 3, 3, 3, 3]) ==> 9\\n    solution([30, 13, 24, 321]) ==>0\\n    \"\"\"\\n    # Initialize the sum to 0\\n    sum = 0\\n    \\n    # Iterate over the list\\n    for i in range(len(lst)):\\n        # Check if the element is odd and in an even position\\n        if lst[i] % 2 != 0 and i % 2 == 0:\\n            # Add the element to the sum\\n            sum += lst[i]\\n    \\n    # Return the sum\\n    return sum\\n'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,38 +162,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Program ran, but hit exception\n",
-      "name 'check' is not defined\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "eval_program(lm['program'], idx)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you run this prompt on all of HumanEval, you get 54.9\\% accuracy.  \n",
-    "The model generates valid code (i.e. code that doesn't trip up the python interpreter) on 96\\% of examples, but the code only executes without exceptions in 93\\% of examples."
    ]
   },
   {
@@ -233,7 +195,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "00f8d2dc3c224f969ebe922307299c34",
+       "model_id": "2009a10de2de4d09b6f9a104ea20be11",
        "version_major": 2,
        "version_minor": 0
       },
@@ -260,7 +222,7 @@
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
      "execution_count": 9,
@@ -276,8 +238,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that this time the generated program doesn't pass the evaluation tests.  \n",
-    "But it's worse than that: the program doesn't even pass the first example in the docstring:"
+    "Let's manually check the basic example from the docstring:"
    ]
   },
   {
@@ -346,7 +307,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab79cb01dad9403cb56112cfce558ff6",
+       "model_id": "503eaffdc955410b8d24f1b5190e4b1b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -446,7 +407,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db37fa4d76184bfe92e70b64f71330e1",
+       "model_id": "3dd44b5b89c64d0aa69b6de57560a916",
        "version_major": 2,
        "version_minor": 0
       },
@@ -553,7 +514,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6949151f8924977aa37276ba1e7d53d",
+       "model_id": "64175c242cba4fdb9dd1356875354149",
        "version_major": 2,
        "version_minor": 0
       },
@@ -567,7 +528,7 @@
     {
      "data": {
       "text/plain": [
-       "<guidance.models._transformers.Transformers at 0x128c89250>"
+       "<guidance.models._transformers.Transformers at 0x12af1d760>"
       ]
      },
      "execution_count": 18,
@@ -621,13 +582,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf75f6171ee5492ca3d38e9b11d3b75d",
+       "model_id": "5f093203f41441a49ff4766f65e3b4bc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -645,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -673,16 +634,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -695,9 +656,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Yes. Indeed, this simple prompt modification raises accuracy from 54.9% to 57.3% for this model (we've seen bigger gains with larger models)\n",
+    "Yes indeed.\n",
     "\n",
-    "Anyway, the point of this notebook is just to illustrate how easy it is to guide generation depending on what previous generations are (e.g. the test results depend on the current version of the code.)"
+    "In conclusion, this notebook illustrates how easy it is to guide generation depending on what previous generations are (e.g. the test results depend on the current version of the code.)"
    ]
   }
  ],

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -47,6 +47,10 @@ class TestTutorials:
             params={"call_delay_secs": call_delay_secs, "requested_log_level": logging.DEBUG},
         )
 
+    def test_code_generation(self):
+        nb_path = TestTutorials.BASE_TUTORIAL_PATH / "code_generation.ipynb"
+        run_notebook(nb_path)
+
     def test_regex_constraints(self):
         nb_path = TestTutorials.BASE_TUTORIAL_PATH / "regex_constraints.ipynb"
         run_notebook(nb_path)


### PR DESCRIPTION
The `code_generation` notebook became stale and needed a refresh. Several old APIs were still imported, hard coded model file paths were used, and some of the remarks in the notebook needed generalization or clarification.

First, the main fix addresses https://github.com/guidance-ai/guidance/issues/1402 and https://github.com/guidance-ai/guidance/pull/1437 by removing the `will_gen` function that no longer exists.

Next, the hard coded path to Mistral 7B quantized model was changed to `model = models.Transformers("Qwen/Qwen2.5-Coder-1.5B")`. This should make the notebook run cleanly for almost everyone, as well as make it easy to swap models and experiment.

Finally, some of the comments in the notebook referenced specific percentages and scores for the specific Mistral 7B model that was used in the past. I tweaked the language a bit to make the notebook easier to update in the future by focusing less on specific statistics and more on the general techniques being used.

This notebook could still use some more work in the future. Modern models have improved so much that the examples no longer highlight failure modes related to problem solving itself. The notebook has been edited slightly to emphasize using Guidance to steer generation and extract output instead of efficacy on prompt engineering for coding, given HumanEval is pretty much saturated at this point anyway.