### PR TITLE
Guard the first id_node_map lookup in has_divergence against GC races

### DIFF
--- a/guidance/visual/_renderer.py
+++ b/guidance/visual/_renderer.py
@@ -339,7 +339,14 @@ class JupyterWidgetRenderer(Renderer):
             return False, -1
 
         # If we diverge from the model path, truncate and reset
-        message_trace_node = self._trace_handler[message.trace_id]
+        try:
+            message_trace_node = self._trace_handler[message.trace_id]
+        except KeyError:
+            # Trace node was garbage collected before we could resolve it
+            # (id_node_map is a WeakValueDictionary). Treat as a full divergence
+            # so the widget resets on the next message instead of crashing
+            # Model.__add__. See guidance-ai/guidance#1097.
+            return True, -1
         widget_messages = self.widget_messages[self.last_widget()]
 
         prev_trace_messages = [x for x in widget_messages if isinstance(x, TraceMessage)]

--- a/tests/unit/test_visual.py
+++ b/tests/unit/test_visual.py
@@ -91,6 +91,50 @@ def test_environment():
     assert "ipython-zmq" not in env.detected_envs
 
 
+def test_has_divergence_handles_missing_trace_node():
+    """Regression test for guidance-ai/guidance#1097.
+
+    ``TraceHandler.id_node_map`` is a ``WeakValueDictionary``. A trace node added
+    moments earlier in ``Model.copy()`` can be garbage collected before
+    ``JupyterWidgetRenderer.has_divergence`` looks it up, which previously raised
+    an unhandled ``KeyError`` and crashed ``Model.__add__``. The renderer should
+    instead treat the missing node as a divergence so the widget recovers on the
+    next message.
+    """
+    from guidance.visual._renderer import JupyterWidgetRenderer
+
+    # Build a renderer without running its heavy __init__ (queues, async loops).
+    renderer = JupyterWidgetRenderer.__new__(JupyterWidgetRenderer)
+
+    trace_handler = TraceHandler()
+    # Seed an existing widget message whose trace node IS resolvable, mirroring
+    # the state right before the user's intermittent crash.
+    existing_node = trace_handler.update_node(1, None, None)
+    seed_message = TraceMessage(trace_id=1)
+
+    class _FakeWidget:
+        pass
+
+    fake_widget = _FakeWidget()
+
+    renderer._trace_handler = trace_handler
+    renderer.widget_messages = {fake_widget: [seed_message]}
+    renderer.last_widget = lambda: fake_widget
+
+    # Sanity: existing node is still alive.
+    assert existing_node is trace_handler.id_node_map[1]
+
+    # Now simulate the race: the incoming message references a trace_id whose
+    # node has been garbage collected (i.e. is no longer present in the
+    # WeakValueDictionary).
+    missing_message = TraceMessage(trace_id=999_999)
+    assert 999_999 not in trace_handler.id_node_map
+
+    diverged, ancestor_idx = renderer.has_divergence(missing_message)
+    assert diverged is True
+    assert ancestor_idx == -1
+
+
 def test_exchange():
     exchange = TopicExchange()
     assert len(exchange._observers) == 0


### PR DESCRIPTION
Hit this while tinkering in a Jupyter notebook — `KeyError` mid-cell out of nowhere, cell just dies. Tracked it down to `JupyterWidgetRenderer.has_divergence` (#1097).

`TraceHandler.id_node_map` is a `WeakValueDictionary`. `Model.copy()` calls `_update_trace_node()` which inserts a new `TraceNode` and returns. If nothing else is holding a strong reference, the node can get collected before `has_divergence(message)` reaches `self._trace_handler[message.trace_id]` at `_renderer.py:342`. `KeyError` propagates through `Model.__add__` and takes the whole cell with it.

The earlier hotfix (442fb1e) caught the same pattern three other places in the same method — the first lookup at the top got missed. This patch wraps it the same way the rest already are:

```python
try:
    last_trace_node = self._trace_handler[message.trace_id]
except KeyError:
    # Weakref evicted before we got here — treat as a divergence and reset.
    return True, -1
```

Return value mirrors the existing fallbacks at lines 357–359 and 366–368. Happy path is untouched.

### Reproduction

`tests/unit/test_visual.py::test_has_divergence_handles_missing_trace_node` builds the renderer with `__new__` (skips the async-queue init), seeds a live trace node, then feeds a `TraceMessage` whose `trace_id` isn't in the map.

Without the fix:

```
KeyError: 999999
  at guidance/visual/_renderer.py:342 in has_divergence
  at guidance/visual/_trace.py:352 in __getitem__
  at weakref.py:136 in __getitem__
```

After the fix the call returns `(True, -1)` and the test passes. Full `tests/unit/` sweep: 1638 passed, 1 skipped, 220 xfailed. No regressions. `ruff check` + `ruff format --check` clean.

### Risk

Worst case in production: a render that was about to crash now resets cleanly. Doesn't change happy-path behavior because the `try` body is unchanged. If anyone was *relying* on the crash (unlikely — it's a UI render path), they'd see the same fallback the other three sites already use.

Refs #1097