### PR TITLE
fix: sandbox chat template rendering to prevent RCE via poisoned models

### DIFF
--- a/guidance/models/_engine/_engine.py
+++ b/guidance/models/_engine/_engine.py
@@ -6,7 +6,8 @@ from abc import ABC, abstractmethod
 from typing import Any, Generator, TypedDict
 
 import numpy as np
-from jinja2 import BaseLoader, Environment
+from jinja2 import BaseLoader
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from numpy.typing import NDArray
 
 from ..._parser import TokenParser
@@ -673,7 +674,7 @@ class Engine(ABC):
 
         # Render the messages
         chat_template = self.get_chat_template().template_str
-        rtemplate = Environment(loader=BaseLoader).from_string(chat_template)
+        rtemplate = ImmutableSandboxedEnvironment(loader=BaseLoader).from_string(chat_template)
         rendered_prompt = rtemplate.render(add_generation_prompt=True, messages=messages, tools=tools, **tokens)
 
         # Load into a State object

--- a/tests/unit/test_chat_template_sandbox.py
+++ b/tests/unit/test_chat_template_sandbox.py
@@ -1,0 +1,81 @@
+"""Tests for chat template rendering sandbox.
+
+Chat templates are loaded from model files (HuggingFace Hub, local paths) and
+may be attacker-controlled. The rendering must use a sandboxed Jinja2
+environment to prevent server-side template injection (SSTI) → arbitrary code
+execution via poisoned model files.
+
+See: https://github.com/guidance-ai/guidance/pull/<TBD>
+"""
+
+import pytest
+from jinja2 import BaseLoader
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+
+def test_sandbox_blocks_attribute_access_ssti():
+    """A malicious chat template that chains __init__.__globals__.__builtins__
+    to reach os.popen must be blocked by the sandboxed environment."""
+    malicious_template = "{{ self.__init__.__globals__.__builtins__.__import__('os').popen('id').read() }}"
+    env = ImmutableSandboxedEnvironment(loader=BaseLoader)
+    rtemplate = env.from_string(malicious_template)
+    with pytest.raises(Exception):
+        rtemplate.render(messages=[], tools=None, add_generation_prompt=True)
+
+
+def test_sandbox_blocks_class_attribute_access():
+    """The classic Jinja SSTI via __class__ chaining must be blocked."""
+    malicious_template = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    env = ImmutableSandboxedEnvironment(loader=BaseLoader)
+    rtemplate = env.from_string(malicious_template)
+    with pytest.raises(Exception):
+        rtemplate.render(messages=[], tools=None, add_generation_prompt=True)
+
+
+def test_sandbox_renders_normal_chat_template():
+    """Normal chat templates (loops, conditionals, variable access) must render
+    correctly under the sandbox — no false positives."""
+    normal_template = "{% for message in messages %}<|{{ message.role }}|>{{ message.content }}{% endfor %}"
+    env = ImmutableSandboxedEnvironment(loader=BaseLoader)
+    rtemplate = env.from_string(normal_template)
+    result = rtemplate.render(
+        messages=[{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}],
+        tools=None,
+        add_generation_prompt=True,
+    )
+    assert "<|user|>Hello" in result
+    assert "<|assistant|>Hi" in result
+
+
+def test_sandbox_renders_template_with_tojson_filter():
+    """The tojson filter (used in many real chat templates for tool
+    definitions) must work under the sandbox."""
+    template = "{{ tools | tojson }}"
+    env = ImmutableSandboxedEnvironment(loader=BaseLoader)
+    rtemplate = env.from_string(template)
+    result = rtemplate.render(messages=[], tools=[{"name": "calc", "params": {"x": 1}}], add_generation_prompt=True)
+    assert "calc" in result
+
+
+def test_sandbox_renders_llama3_style_template():
+    """A simplified Llama 3-style template with conditionals, loops, and
+    variable interpolation must render correctly (the most common real-world
+    template shape)."""
+    template = (
+        "{{ bos_token }}"
+        "{% for message in messages %}"
+        "{{ '<|start_header_id|>' + message.role + '<|end_header_id|>\\n\\n' }}"
+        "{{ message.content | trim + '<|eot_id|>' }}"
+        "{% endfor %}"
+    )
+    env = ImmutableSandboxedEnvironment(loader=BaseLoader)
+    rtemplate = env.from_string(template)
+    result = rtemplate.render(
+        messages=[{"role": "user", "content": "  Hello  "}],
+        tools=None,
+        add_generation_prompt=True,
+        bos_token="<|begin_of_text|>",
+    )
+    assert "<|begin_of_text|>" in result
+    assert "<|start_header_id|>user<|end_header_id|>" in result
+    assert "Hello<|eot_id|>" in result  # trim removes leading/trailing spaces


### PR DESCRIPTION
# fix: sandbox chat template rendering to prevent RCE via poisoned models

## Summary

Chat templates loaded from model files (HuggingFace Hub, local paths) were
rendered with an unsandboxed `jinja2.Environment`, enabling **server-side
template injection (SSTI)**. A poisoned model file with a crafted
`chat_template` in its `tokenizer_config.json` achieves **arbitrary code
execution** when loaded by guidance.

HuggingFace's `transformers` library uses `ImmutableSandboxedEnvironment` for
the same operation precisely because chat templates from model files are
untrusted. Guidance extracted the template string and re-rendered it outside
HF's sandbox, bypassing that protection.

**Fix:** Replace `Environment` with `ImmutableSandboxedEnvironment` (one-line
change). This is the same class HuggingFace uses for chat template rendering.

## The vulnerability

```python
# guidance/models/_engine/_engine.py:676 (before)
from jinja2 import BaseLoader, Environment

chat_template = self.get_chat_template().template_str
rtemplate = Environment(loader=BaseLoader).from_string(chat_template)  # ← UNSANDBOXED
rendered_prompt = rtemplate.render(...)
```

`Environment` (not sandboxed) allows full access to Python internals via
Jinja's template object chain. A malicious template executes arbitrary Python.

Guidance does not import or use any Jinja sandbox anywhere in the codebase
(confirmed: `grep -rn "SandboxedEnvironment" guidance/` returns empty).

## Reproduction

```python
from jinja2 import Environment, BaseLoader

# A malicious chat_template (embedded in a poisoned model's tokenizer_config.json)
malicious_template = """{{ self.__init__.__globals__.__builtins__.__import__('os').popen('id').read() }}"""

# This is guidance's rendering code at _engine.py:676
rtemplate = Environment(loader=BaseLoader).from_string(malicious_template)
result = rtemplate.render(messages=[], tools=None, add_generation_prompt=True)

print(result)
# Output: uid=501(user) gid=20(staff) groups=...  ← arbitrary command execution
```

After the fix, the same template raises `SecurityError: access to attribute
'__init__' of 'TemplateReference' object is unsafe`.

## Supply-chain attack scenario

1. Attacker uploads a model to HuggingFace Hub with a crafted
   `tokenizer_config.json` containing a malicious `chat_template` field
2. Victim loads the model: `model = guidance.models.Transformers("attacker/model")`
3. When the victim sends a chat message, guidance renders the chat template
   via the unsandboxed `Environment`
4. The template executes arbitrary Python on the victim's machine
5. The attacker has RCE on the developer's workstation

The victim does nothing wrong — loading a model from HuggingFace Hub is the
normal usage pattern.

## Why this bypasses HuggingFace's protection

HuggingFace's `transformers` renders chat templates via `apply_chat_template()`,
which uses `ImmutableSandboxedEnvironment` internally. Guidance does NOT call
`apply_chat_template()`. Instead, it extracts the template string
(`self.get_chat_template().template_str`, sourced from
`hf_tokenizer.chat_template` at `_transformers.py:85`) and re-renders it with
its own unsandboxed `Environment`. This re-rendering bypasses the sandbox that
HuggingFace applies to the same template.

## The fix

```python
# after
from jinja2 import BaseLoader
from jinja2.sandbox import ImmutableSandboxedEnvironment

rtemplate = ImmutableSandboxedEnvironment(loader=BaseLoader).from_string(chat_template)
```

One-line change. `ImmutableSandboxedEnvironment` is the same class HuggingFace
uses. It blocks attribute access to Python internals (`__init__`, `__globals__`,
`__builtins__`, `__class__`) while rendering normal templates correctly.

## Tests

5 tests in `tests/unit/test_chat_template_sandbox.py`:

- **`test_sandbox_blocks_attribute_access_ssti`**: the `__init__.__globals__`
  chain that achieves RCE is blocked
- **`test_sandbox_blocks_class_attribute_access`**: the `__class__.__mro__`
  chain is blocked
- **`test_sandbox_renders_normal_chat_template`**: normal templates (loops,
  conditionals, variable access) render correctly (no false positive)
- **`test_sandbox_renders_template_with_tojson_filter`**: the `tojson` filter
  (used in real chat templates for tool definitions) works under the sandbox
- **`test_sandbox_renders_llama3_style_template`**: a Llama 3-style template
  with bos_token, header tokens, and trim filter renders correctly

```
$ python -m pytest tests/unit/test_chat_template_sandbox.py -v
============================== 5 passed in 0.01s ==============================
```

No regression: 30 existing unit tests pass unchanged.

## Impact

- **Arbitrary code execution**: a poisoned model file achieves RCE on any
  machine that loads it via guidance and sends a chat message
- **Supply-chain vector**: HuggingFace Hub hosts user-uploaded models
- **Severity**: Critical — RCE via the model-loading supply chain

## Scope

Two files: `guidance/models/_engine/_engine.py` (the fix) and
`tests/unit/test_chat_template_sandbox.py` (new test file). Diff: +84/−2.
