### PR TITLE
fix(tools): catch Exception instead of BaseException in Tool.call

### DIFF
--- a/guidance/_tools.py
+++ b/guidance/_tools.py
@@ -84,10 +84,13 @@ class Tool(BaseModel):
     def call(self, *args, **kwargs) -> Any:
         try:
             return self.callable(*args, **kwargs)
-        except BaseException as e:  # noqa: BLE001
-            # Skip the current stack frame to make sure our traceback starts inside of self.callable
-            tb = e.__traceback__.tb_next
-            assert tb is not None  # must exist
+        except Exception as e:
+            # Skip the current stack frame to make sure our traceback starts inside of
+            # self.callable, if it got far enough to have its own frame. When the call
+            # itself fails before entering self.callable (e.g. self.callable isn't
+            # actually callable), there's no inner frame to skip, so fall back to the
+            # exception's own traceback instead of asserting on a None tb_next.
+            tb = e.__traceback__.tb_next or e.__traceback__
             if self.exc_formatter is None:
                 return "".join(traceback.format_exception(type(e), e, tb))
             return self.exc_formatter(type(e), e, tb)

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,56 @@
+import pytest
+
+from guidance._tools import FunctionTool, Tool
+
+
+def _make_tool(callable) -> Tool:
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    return Tool(
+        name="add",
+        description="add two numbers",
+        tool=FunctionTool.from_callable(add),
+        callable=callable,
+    )
+
+
+class TestToolCall:
+    def test_normal_exception_is_formatted(self):
+        def raises(*args, **kwargs):
+            raise ValueError("bad input")
+
+        tool = _make_tool(raises)
+        result = tool.call(1, 2)
+        assert "ValueError" in result
+        assert "bad input" in result
+
+    def test_keyboard_interrupt_propagates(self):
+        # BaseException subclasses like KeyboardInterrupt/SystemExit must not
+        # be caught and silently turned into tool-output strings.
+        def raises_kb(*args, **kwargs):
+            raise KeyboardInterrupt()
+
+        tool = _make_tool(raises_kb)
+        with pytest.raises(KeyboardInterrupt):
+            tool.call()
+
+    def test_system_exit_propagates(self):
+        def raises_exit(*args, **kwargs):
+            raise SystemExit()
+
+        tool = _make_tool(raises_exit)
+        with pytest.raises(SystemExit):
+            tool.call()
+
+    def test_call_signature_mismatch_does_not_crash(self):
+        # An arity mismatch is detected by the interpreter's argument-binding
+        # check before the callable's own frame is ever entered, so
+        # e.__traceback__.tb_next is None. This must not raise AssertionError.
+        class Callback:
+            def __call__(self, x):
+                return x
+
+        tool = _make_tool(Callback())
+        result = tool.call(1, 2)  # Callback.__call__ only takes one positional arg
+        assert "TypeError" in result


### PR DESCRIPTION
Fixes #1485.

`Tool.call` caught `BaseException`, which also matches `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. These were silently swallowed and turned into tool-output strings instead of propagating - hitting Ctrl+C during a tool call just looked like a weird tool response rather than actually interrupting.

Separately, the traceback-skipping step assumed the callable's own frame is always present:

```python
tb = e.__traceback__.tb_next
assert tb is not None  # must exist
```

That's only true if execution actually made it into `self.callable`'s body. If `self.callable` raises before that - e.g. an arity mismatch on a callable object, where the interpreter's argument-binding check fails before any frame of the callable is entered - `tb_next` is `None` and the assert crashes with a bare `AssertionError` instead of producing a tool-facing error message.

## Fix

- `except Exception` instead of `except BaseException` - `KeyboardInterrupt`/`SystemExit`/`GeneratorExit` now propagate normally.
- `tb = e.__traceback__.tb_next or e.__traceback__` - falls back to the exception's own traceback when there's no inner frame to skip, since the exception always has at least one frame.

## Testing

Added `tests/unit/test_tools.py` covering: a normal exception still gets formatted the same as before, `KeyboardInterrupt` and `SystemExit` both propagate instead of being swallowed, and a callable-object arity mismatch (the `tb_next is None` case) returns a formatted `TypeError` instead of crashing.

I reproduced both bugs against the pre-fix code first (via `git stash`) to confirm they're real before writing the fix - `AssertionError` on the arity-mismatch case and swallowed `KeyboardInterrupt` on the first case, both as expected. All 4 new tests pass against the patched code, and I also ran `tests/unit/test_decorator.py` alongside it as a smoke check on adjacent code - no regressions. I wasn't able to get the full `tests/unit/` suite through in my sandbox in a reasonable time (some of the grammar/llguidance tests are slow), so flagging that rather than claiming broader coverage than I actually ran.