### PR TITLE
Allow bare dict / Dict[Any, ...] fields in json() schema generation

### DIFF
--- a/guidance/library/_pydantic.py
+++ b/guidance/library/_pydantic.py
@@ -17,8 +17,14 @@ class GenerateJsonSchemaSafe(pydantic.json_schema.GenerateJsonSchema):
 
     def generate_inner(self, schema):
         if schema["type"] == "dict":
-            key_type = schema["keys_schema"]["type"]
-            if key_type != "str":
+            # A dict with no key type (bare ``dict``, ``Dict[Any, ...]``) has an
+            # ``"any"`` keys_schema. In JSON that maps to an unconstrained object
+            # (JSON object keys are always strings), which is a valid, supported
+            # schema, so it must not be rejected as "non-string keys". Only key
+            # types that genuinely can't be represented as JSON strings (``int``,
+            # ``float``, ...) are rejected.
+            key_type = schema.get("keys_schema", {}).get("type", "any")
+            if key_type not in ("str", "any"):
                 raise TypeError(f"JSON does not support non-string keys, got type {key_type}")
         return super().generate_inner(schema)
 

--- a/tests/unit/library/test_pydantic.py
+++ b/tests/unit/library/test_pydantic.py
@@ -170,6 +170,28 @@ class TestDict:
             generate_and_check({1: 2}, model)
         assert exc_info.value.args[0] == "JSON does not support non-string keys, got type int"
 
+    def test_any_keys_allowed(self):
+        """
+        A dict with no key type (bare ``dict``, ``Dict[Any, ...]``) maps to an
+        unconstrained JSON object and must not be rejected as "non-string keys":
+        JSON object keys are always strings, and the resulting ``{"type":
+        "object"}`` schema is supported by the backend.
+        """
+        for model in (
+            pydantic.TypeAdapter(dict),
+            pydantic.TypeAdapter(dict[str, Any]),
+            pydantic.TypeAdapter(dict[Any, Any]),
+        ):
+            generate_and_check({"a": 1, "b": 2}, model)
+
+    def test_any_keys_allowed_as_model_field(self):
+        # The common "arbitrary JSON metadata" pattern: a bare dict field.
+        class Config(pydantic.BaseModel):
+            name: str
+            metadata: dict
+
+        generate_and_check({"name": "x", "metadata": {"k": 1}}, Config)
+
 
 class TestComposite:
     class Simple(pydantic.BaseModel):


### PR DESCRIPTION
Closes #1493.

## What

`GenerateJsonSchemaSafe.generate_inner` (in `guidance/library/_pydantic.py`) rejected any dict whose key type wasn't exactly `"str"`. That correctly catches genuinely non-string keys like `dict[int, int]`, but it also caught a bare `dict` / `Dict[Any, ...]` field, whose `keys_schema` type is `"any"`. Those map to an unconstrained JSON object, which is valid (JSON object keys are always strings) and is accepted by the backend, so rejecting them with `TypeError: JSON does not support non-string keys, got type any` is a false positive with a misleading message.

## Reproduction (before)

```python
from pydantic import BaseModel
from guidance import json

class Config(BaseModel):
    name: str
    metadata: dict   # arbitrary JSON object

json(schema=Config)
# TypeError: JSON does not support non-string keys, got type any
```

The schema a bare dict produces is supported end to end; only the pre-check blocked it:

```python
from pydantic import TypeAdapter
from guidance import json
json(schema={'type': 'object'})               # accepted
json(schema=TypeAdapter(dict).json_schema())  # accepted ({'additionalProperties': True, 'type': 'object'})
```

## Fix

Allow the `"any"` key type alongside `"str"`, and read `keys_schema`/`type` defensively:

```python
key_type = schema.get("keys_schema", {}).get("type", "any")
if key_type not in ("str", "any"):
    raise TypeError(f"JSON does not support non-string keys, got type {key_type}")
```

`int`/`float`/etc. keys stay rejected.

## Tests

- `TestDict.test_any_keys_allowed`: bare `dict`, `Dict[str, Any]`, `Dict[Any, Any]` all accepted.
- `TestDict.test_any_keys_allowed_as_model_field`: a model with a bare-dict field is accepted.
- The existing `TestDict.test_prevent_non_string_keys` (int keys still rejected) is unchanged and passes.

RED/GREEN verified: the two new tests fail on `main` (the `TypeError` fires) and pass with the fix; `TestDict` is green (4 passed).

## Not included

`dict[Literal["x", "y"], int]` (string-literal keys) stays rejected. Those keys are strings, but that schema uses `propertyNames`, which the backend reports as `Unimplemented keys: ["propertyNames"]`, so it's genuinely unsupported today. I left it rejected rather than push an unsupported schema downstream; noted in #1493 for visibility.
