### PR TITLE
Keep the first ttft/ttfm measurement when accumulating TokenUsage

### DIFF
--- a/guidance/_schema.py
+++ b/guidance/_schema.py
@@ -76,8 +76,11 @@ class TokenUsage(BaseModel):
         else:
             ff_tokens = (self.ff_tokens or 0) + (other.ff_tokens or 0)
 
-        ttft_ms = other.ttft_ms
-        ttfm_ms = other.ttfm_ms
+        # "time to first token/mask" is a property of the first measurement in the sequence, not the
+        # last. The producers set these once and guard with `if usage.ttft_ms == 0`, so 0.0 means
+        # "not measured here" rather than "measured as zero"; keep the earliest non-zero value.
+        ttft_ms = self.ttft_ms or other.ttft_ms
+        ttfm_ms = self.ttfm_ms or other.ttfm_ms
 
         return TokenUsage(
             ff_tokens=ff_tokens,

--- a/tests/unit/test_token_usage.py
+++ b/tests/unit/test_token_usage.py
@@ -1,0 +1,65 @@
+from guidance._schema import TokenUsage
+
+
+def _usage(**kwargs) -> TokenUsage:
+    return TokenUsage(round_trips=1, **kwargs)
+
+
+def test_ttft_keeps_the_first_measurement():
+    """`ttft_ms`/`ttfm_ms` are "time to *first* token/mask", so accumulating must keep the earliest.
+
+    The producers set them once, guarded with `if usage.ttft_ms == 0`, so 0.0 means "not measured
+    in this chunk". `__add__` used to take `other`'s value unconditionally, which overwrote the
+    session's first-token latency with the latest chunk's on every addition.
+    """
+    first = _usage(forward_passes=10, ttft_ms=120.0, ttfm_ms=8.0, total_latency_ms=500.0)
+    second = _usage(forward_passes=5, ttft_ms=95.0, ttfm_ms=6.0, total_latency_ms=300.0)
+
+    total = first + second
+
+    assert total.ttft_ms == 120.0
+    assert total.ttfm_ms == 8.0
+
+
+def test_a_chunk_without_generated_tokens_does_not_erase_ttft():
+    """A chunk that generated nothing reports 0.0 and must not wipe an accumulated measurement.
+
+    This is reachable whenever a completion loop is entered but issues no token (fully
+    fast-forwarded or stopped immediately): `total_latency_ms` still accrues while `ttft_ms`
+    stays at its 0.0 default.
+    """
+    measured = _usage(forward_passes=10, ttft_ms=120.0, ttfm_ms=8.0, total_latency_ms=500.0)
+    no_tokens = _usage(forward_passes=0, ttft_ms=0.0, ttfm_ms=0.0, total_latency_ms=40.0)
+
+    total = measured + no_tokens
+
+    assert total.ttft_ms == 120.0
+    assert total.ttfm_ms == 8.0
+
+
+def test_ttft_is_taken_from_the_other_side_when_unset():
+    """Accumulating onto a fresh `TokenUsage()` still picks up the first real measurement."""
+    measured = _usage(forward_passes=10, ttft_ms=120.0, ttfm_ms=8.0)
+
+    assert (TokenUsage() + measured).ttft_ms == 120.0
+    assert (TokenUsage() + measured).ttfm_ms == 8.0
+
+
+def test_repeated_accumulation_keeps_the_first_and_sums_the_rest():
+    """The shape `State.add_usage` uses: `self._token_usage += usage` in a loop."""
+    chunks = [
+        _usage(forward_passes=10, ttft_ms=120.0, ttfm_ms=8.0, total_latency_ms=500.0),
+        _usage(forward_passes=5, ttft_ms=95.0, ttfm_ms=6.0, total_latency_ms=300.0),
+        _usage(forward_passes=0, ttft_ms=0.0, ttfm_ms=0.0, total_latency_ms=40.0),
+    ]
+
+    total = TokenUsage()
+    for chunk in chunks:
+        total += chunk
+
+    assert total.ttft_ms == 120.0
+    assert total.ttfm_ms == 8.0
+    # the additive fields must keep adding
+    assert total.round_trips == 3
+    assert total.forward_passes == 15
+    assert total.total_latency_ms == 840.0


### PR DESCRIPTION
## The problem

`TokenUsage.__add__` takes `other`'s `ttft_ms` and `ttfm_ms` unconditionally:

```python
ttft_ms = other.ttft_ms
ttfm_ms = other.ttfm_ms
```

so every accumulation replaces the session's time-to-first-token with the latest chunk's:

```
after 1st step        ttft= 120.0  ttfm=  8.0
after 2nd step        ttft=  95.0  ttfm=  6.0   <- should still be 120.0 / 8.0
after a no-token step ttft=   0.0  ttfm=  0.0   <- measurement erased
sums intact: round_trips=3 forward_passes=15 total_latency_ms=840.0
```

`State.add_usage` does `self._token_usage += usage` for every chunk, so this is the normal accumulation path rather than an edge case.

The third row is the one that bites hardest. A completion loop that issues no token (fully fast-forwarded, or stopped immediately) still accrues `total_latency_ms` while `ttft_ms` stays at its `0.0` default, and adding that chunk zeroes whatever had been measured earlier.

## Why `or` is the right rule here

`0.0` already means "not measured in this chunk" everywhere else in the codebase. All three producers set the field once and guard against overwriting:

```python
_engine.py:536       if usage.ttft_ms == 0: usage.ttft_ms += (time.monotonic() - t0) * 1000
_engine.py:220       if usage.ttfm_ms == 0: usage.ttfm_ms  = (time.monotonic() - t0) * 1000
_openai_base.py:478  if usage.ttft_ms == 0: usage.ttft_ms  = (time.time() - _t0) * 1000
```

`__add__` was the one place that did not follow that convention. Keeping the earliest non-zero value makes it agree with the producers, and `TokenUsage() + measured` still picks up the measurement.

The additive fields are untouched; only these two lines change.

## Tests

`tests/unit/test_token_usage.py`, four cases:

- the first measurement survives a later chunk that has its own `ttft`
- a chunk with no generated tokens does not erase an accumulated measurement
- accumulating onto a fresh `TokenUsage()` still picks up the first real value
- the `State.add_usage` shape (`total += chunk` in a loop) keeps the first `ttft` *and* keeps summing `round_trips` / `forward_passes` / `total_latency_ms`

The last one is there so the fix cannot be "made to pass" by dropping `other`'s contribution entirely.

Reverting only `_schema.py`:

```
FAILED tests/unit/test_token_usage.py::test_ttft_keeps_the_first_measurement
FAILED tests/unit/test_token_usage.py::test_a_chunk_without_generated_tokens_does_not_erase_ttft
FAILED tests/unit/test_token_usage.py::test_repeated_accumulation_keeps_the_first_and_sums_the_rest
3 failed, 1 passed
```

and with the fix, `4 passed`. The one that passes either way is the `TokenUsage() + measured` case, which already worked.

`ruff check` and `ruff format --check` clean on both files.
