### PR TITLE
Block cloud metadata endpoints in validate_uri

### DIFF
--- a/guidance/_uri_validation.py
+++ b/guidance/_uri_validation.py
@@ -9,6 +9,27 @@ from collections.abc import Sequence
 DEFAULT_ALLOWED_SCHEMES: tuple[str, ...] = ("https",)
 
 
+# Cloud metadata / credential endpoints. Most sit inside the ranges `_check_ip_address`
+# already rejects, but `168.63.129.16` (Azure) and `100.100.100.200` (Alibaba) do not: the
+# first is publicly routable and the second is in `100.64.0.0/10`, which Python does not
+# report as private. They are listed explicitly so a range check is not the only thing
+# standing between a URL and a credential endpoint.
+_CLOUD_METADATA_ADDRESSES: frozenset[ipaddress.IPv4Address | ipaddress.IPv6Address] = frozenset(
+    ipaddress.ip_address(ip)
+    for ip in (
+        "169.254.169.254",  # AWS IMDS, GCP, Azure, OCI, DigitalOcean, Hetzner, IBM, OpenStack
+        "169.254.170.2",  # AWS ECS task IAM role credentials
+        "169.254.170.23",  # AWS EKS Pod Identity Agent
+        "168.63.129.16",  # Azure WireServer / platform channel (publicly routable)
+        "100.100.100.200",  # Alibaba Cloud
+        "192.0.0.192",  # Oracle Cloud (Classic)
+        "169.254.42.42",  # Scaleway
+        "fd00:ec2::254",  # AWS IMDS over IPv6
+        "fd00:ec2::23",  # AWS EKS Pod Identity Agent over IPv6
+    )
+)
+
+
 class URIValidationError(ValueError):
     """Raised when a URI fails security validation."""
 
@@ -55,20 +76,21 @@ def validate_uri(
     if scheme not in [s.lower() for s in allowed_schemes]:
         raise URIValidationError(f"URI scheme '{scheme}' is not in allowed schemes {list(allowed_schemes)}: {url}")
 
-    # For network URIs, validate the host against private IP ranges
-    if not allow_private:
-        hostname = parsed.hostname
-        if hostname is None:
-            raise URIValidationError(f"URI has no hostname: {url}")
-        _validate_hostname_not_private(hostname, url)
+    # For network URIs, validate the host. Cloud metadata endpoints are checked even when
+    # `allow_private` is set: reaching a host on your own network and reaching the instance's
+    # credential endpoint are different requests, and only the first is what the flag is for.
+    hostname = parsed.hostname
+    if hostname is None:
+        raise URIValidationError(f"URI has no hostname: {url}")
+    _validate_hostname_not_private(hostname, url, allow_private=allow_private)
 
 
-def _validate_hostname_not_private(hostname: str, original_url: str) -> None:
-    """Resolve hostname and verify it doesn't point to a private/loopback/link-local address."""
+def _validate_hostname_not_private(hostname: str, original_url: str, allow_private: bool = False) -> None:
+    """Resolve hostname and verify it doesn't point to a metadata/private/loopback/link-local address."""
     # First, check if the hostname is already an IP literal
     try:
         addr = ipaddress.ip_address(hostname)
-        _check_ip_address(addr, original_url)
+        _check_ip_address(addr, original_url, allow_private=allow_private)
         return
     except ValueError:
         pass  # Not an IP literal, proceed with DNS resolution
@@ -86,11 +108,17 @@ def _validate_hostname_not_private(hostname: str, original_url: str) -> None:
     for addrinfo in addrinfos:
         ip_str = addrinfo[4][0]
         addr = ipaddress.ip_address(ip_str)
-        _check_ip_address(addr, original_url)
+        _check_ip_address(addr, original_url, allow_private=allow_private)
 
 
-def _check_ip_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address, original_url: str) -> None:
-    """Raise if the IP address is private, loopback, or link-local."""
+def _check_ip_address(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address, original_url: str, allow_private: bool = False
+) -> None:
+    """Raise if the IP address is a cloud metadata endpoint, private, loopback, or link-local."""
+    if addr in _CLOUD_METADATA_ADDRESSES:
+        raise URIValidationError(f"URI resolves to a cloud metadata endpoint ({addr}): {original_url}")
+    if allow_private:
+        return
     if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
         raise URIValidationError(
             f"URI resolves to a private/loopback/link-local/reserved address ({addr}): {original_url}"

--- a/guidance/_uri_validation.py
+++ b/guidance/_uri_validation.py
@@ -115,6 +115,14 @@ def _check_ip_address(
     addr: ipaddress.IPv4Address | ipaddress.IPv6Address, original_url: str, allow_private: bool = False
 ) -> None:
     """Raise if the IP address is a cloud metadata endpoint, private, loopback, or link-local."""
+    # `::ffff:168.63.129.16` and `168.63.129.16` are the same destination, so unwrap before the
+    # membership test. This matters most for the two addresses the list above exists for: both are
+    # publicly routable, so the range checks below never see them and equality against the list is
+    # the only thing in the way. The link-local entries survive the wrapper on their own because
+    # Python reports an IPv4-mapped address as link-local, which is what hid this.
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+
     if addr in _CLOUD_METADATA_ADDRESSES:
         raise URIValidationError(f"URI resolves to a cloud metadata endpoint ({addr}): {original_url}")
     if allow_private:

--- a/tests/unit/test_uri_validation.py
+++ b/tests/unit/test_uri_validation.py
@@ -179,3 +179,21 @@ class TestCloudMetadataEndpoints:
             pytest.raises(URIValidationError, match="cloud metadata endpoint"),
         ):
             validate_uri("https://metadata.example.com/x")
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "168.63.129.16",  # Azure WireServer, publicly routable
+            "100.100.100.200",  # Alibaba Cloud, inside 100.64.0.0/10 which Python calls public
+        ],
+    )
+    def test_metadata_endpoint_not_reachable_through_ipv4_mapped_ipv6(self, ip):
+        """Wrapping the address in `::ffff:` must not walk past the list.
+
+        These are the two entries that motivated the list: both are publicly routable, so the
+        private/loopback/link-local/reserved checks never catch them and the membership test is
+        the only guard. The link-local entries hide this, because Python reports an IPv4-mapped
+        link-local address as link-local and blocks it on the range check regardless.
+        """
+        with pytest.raises(URIValidationError, match="cloud metadata endpoint"):
+            validate_uri(f"https://[::ffff:{ip}]/latest/meta-data/")

--- a/tests/unit/test_uri_validation.py
+++ b/tests/unit/test_uri_validation.py
@@ -82,7 +82,9 @@ class TestPrivateIPBlocking:
         "ip",
         [
             "169.254.0.1",
-            "169.254.169.254",  # AWS metadata endpoint
+            "169.254.1.1",
+            # 169.254.169.254 lives in this range too, but it is now rejected by the metadata
+            # check first and reports a different message. See TestCloudMetadataEndpoints.
         ],
     )
     def test_link_local_blocked(self, ip):
@@ -135,3 +137,45 @@ class TestPrivateIPBlocking:
         with patch("socket.getaddrinfo", return_value=addrinfos):
             with pytest.raises(URIValidationError, match="private/loopback/link-local/reserved"):
                 validate_uri("https://tricky.example.com/resource")
+
+
+METADATA_ADDRESSES = [
+    "169.254.169.254",  # AWS IMDS, GCP, Azure, OCI, DigitalOcean
+    "169.254.170.2",  # AWS ECS task IAM role credentials
+    "169.254.170.23",  # AWS EKS Pod Identity Agent
+    "168.63.129.16",  # Azure WireServer (publicly routable)
+    "100.100.100.200",  # Alibaba Cloud (100.64.0.0/10, not reported as private)
+    "192.0.0.192",  # Oracle Cloud (Classic)
+    "169.254.42.42",  # Scaleway
+]
+
+
+class TestCloudMetadataEndpoints:
+    @pytest.mark.parametrize("ip", METADATA_ADDRESSES)
+    def test_metadata_endpoints_blocked_by_default(self, ip):
+        with pytest.raises(URIValidationError):
+            validate_uri(f"https://{ip}/latest/meta-data/")
+
+    @pytest.mark.parametrize("ip", METADATA_ADDRESSES)
+    def test_metadata_endpoints_blocked_even_with_allow_private(self, ip):
+        """`allow_private` is for reaching your own network, not the credential endpoint."""
+        with pytest.raises(URIValidationError, match="cloud metadata endpoint"):
+            validate_uri(f"https://{ip}/latest/meta-data/", allow_private=True)
+
+    def test_allow_private_still_permits_rfc1918(self):
+        validate_uri("https://10.0.0.5/resource", allow_private=True)
+
+    def test_allow_private_still_permits_loopback(self):
+        validate_uri("https://127.0.0.1/resource", allow_private=True)
+
+    def test_public_address_still_allowed(self):
+        validate_uri("https://1.1.1.1/resource")
+
+    def test_metadata_endpoint_via_dns_blocked(self):
+        """The check runs on every resolved address, not just on IP literals."""
+        addrinfo = [(2, 1, 6, "", ("168.63.129.16", 0))]
+        with (
+            patch("guidance._uri_validation.socket.getaddrinfo", return_value=addrinfo),
+            pytest.raises(URIValidationError, match="cloud metadata endpoint"),
+        ):
+            validate_uri("https://metadata.example.com/x")


### PR DESCRIPTION
Closes #1498.

`_check_ip_address` rejects cloud metadata endpoints only as a side effect of the private-range check, so the two that sit on publicly routable addresses aren't covered. `bytes_from` calls `urlopen` on anything `validate_uri` lets past, and `src` there comes from `image(...)` / `audio(...)`, i.e. model- or user-supplied.

Every metadata endpoint I could name, on `main` @ 21b1d90:

| endpoint | before | after | `is_private` / `is_link_local` / `is_reserved` |
|---|---|---|---|
| `169.254.169.254` (AWS/GCP/Azure/OCI/DO IMDS) | blocked | blocked | T / T / F |
| `169.254.170.2` (AWS ECS task creds) | blocked | blocked | T / T / F |
| `169.254.170.23` (AWS EKS Pod Identity) | blocked | blocked | T / T / F |
| `169.254.42.42` (Scaleway) | blocked | blocked | T / T / F |
| `192.0.0.192` (Oracle Cloud Classic) | blocked | blocked | T / F / F |
| **`168.63.129.16`** (Azure WireServer) | **allowed** | blocked | F / F / F |
| **`100.100.100.200`** (Alibaba) | **allowed** | blocked | F / F / F |

`168.63.129.16` is a real public address Microsoft routes to the host agent on every Azure VM. `100.100.100.200` is in `100.64.0.0/10`, which Python doesn't report as private. No range check reaches either, so they're listed explicitly.

The denylist is checked before the range logic and **also runs when `allow_private=True`**. That flag reads as "let me reach hosts on my own network", and reaching the instance's credential endpoint is a different request. RFC1918 and loopback still pass with it set:

| | default | `allow_private=True` |
|---|---|---|
| `10.0.0.5` | blocked | allowed |
| `127.0.0.1` | blocked | allowed |
| `1.1.1.1` | allowed | allowed |
| any metadata address | blocked | blocked |

Behaviour change worth calling out: anyone currently using `allow_private=True` to reach a metadata endpoint will now get an error. That seemed like the right default for a security control, but say the word and I'll gate it behind a separate flag instead.

### Tests

`TestCloudMetadataEndpoints` in `tests/unit/test_uri_validation.py`: the seven addresses parametrised twice (default and `allow_private=True`), the RFC1918/loopback/public controls so the flag isn't accidentally neutered, and a DNS case proving the check runs on resolved addresses rather than only on IP literals.

Stashing only `_uri_validation.py` gives `10 failed, 36 passed`; with the change, `46 passed`. `tests/unit/test_bytes_from.py` is 13 passed either way.

One existing test changed: `169.254.169.254` came out of `test_link_local_blocked`'s parameters. It's still blocked — it now reports the metadata message rather than `private/loopback/link-local/reserved`, and the new class asserts on it with a stricter `match`. I put a second plain link-local address in its place so that parametrisation still has two cases.

`ruff check` reports the same 7 findings on these two files before and after (6 × `SIM117`, 1 × `PIE790`, all pre-existing). The repo has no ruff config and `ruff format --check` wants to reformat both files untouched, so I left formatting alone rather than mixing an unrelated reformat into this.