### PR TITLE
Fix 'the the' in the save_stop_text docstrings

### DIFF
--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -77,7 +77,7 @@ def select(
     Parameters
     ----------
     name : str or None
-        If this is not None then the the results of the generation will be saved as a variable on
+        If this is not None then the results of the generation will be saved as a variable on
         the Model object (so you can access the result as `lm["var_name"]`).
 
     options : list

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -40,7 +40,7 @@ def gen(
     ----------
 
         name : str or None
-            If this is not None then the the results of the generation will be saved as a variable on
+            If this is not None then the results of the generation will be saved as a variable on
             the Model object (so you can access the result as `lm["var_name"]`).
 
         max_tokens : int

--- a/guidance/library/_json.py
+++ b/guidance/library/_json.py
@@ -53,7 +53,7 @@ def json(
     ----------
 
     name : str or None
-        If this is not None then the the results of the generation will be saved as a variable on
+        If this is not None then the results of the generation will be saved as a variable on
         the Model object (so you can access the result as ``lm["var_name"]``).
 
     schema : Union[None, Mapping[str, Any], Type[pydantic.BaseModel], pydantic.TypeAdapter]


### PR DESCRIPTION
Three docstrings share the same sentence and the same typo in all three:

```
If this is not None then the the results of the generation will be saved as a variable on
the Model object.
```

- `guidance/_grammar.py:80`
- `guidance/library/_gen.py:43`
- `guidance/library/_json.py:56`

One word removed at each site; docstring-only, no behaviour change. A regex sweep for repeated adjacent words over `guidance/` returns nothing after this.

`ruff check` clean. `ruff format --check` reports the same three files as needing reformatting before and after — the hunks it wants are elsewhere in those files and none touch these lines, so I left formatting alone rather than mix an unrelated reformat into a typo fix.