### PR TITLE
fix(tools): catch Exception not BaseException in Tool.call (#1485)

### DIFF
--- a/guidance/_tools.py
+++ b/guidance/_tools.py
@@ -84,10 +84,14 @@ class Tool(BaseModel):
     def call(self, *args, **kwargs) -> Any:
         try:
             return self.callable(*args, **kwargs)
-        except BaseException as e:  # noqa: BLE001
-            # Skip the current stack frame to make sure our traceback starts inside of self.callable
-            tb = e.__traceback__.tb_next
-            assert tb is not None  # must exist
+        except Exception as e:  # noqa: BLE001
+            # Skip the current stack frame so the traceback starts inside self.callable.
+            # If the error was raised at the call expression itself (e.g. self.callable
+            # is not actually callable), there is no inner frame to skip to, so fall back
+            # to the full traceback instead of asserting.
+            tb = e.__traceback__.tb_next if e.__traceback__ is not None else None
+            if tb is None:
+                tb = e.__traceback__
             if self.exc_formatter is None:
                 return "".join(traceback.format_exception(type(e), e, tb))
             return self.exc_formatter(type(e), e, tb)

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,55 @@
+"""Regression tests for guidance._tools.Tool.call error handling.
+
+See https://github.com/guidance-ai/guidance/issues/1485: ``Tool.call`` used to
+catch ``BaseException`` (swallowing ``KeyboardInterrupt``/``SystemExit`` and
+turning them into tool-output strings) and asserted that the traceback always
+had an inner frame (crashing with a bare ``AssertionError`` when the callable
+was not actually callable).
+"""
+
+import pytest
+from guidance._tools import Tool
+
+
+def _tool(fn):
+    return Tool.from_callable(fn, name="t", description="d")
+
+
+def test_call_propagates_keyboard_interrupt():
+    def raises_keyboard_interrupt():
+        raise KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        _tool(raises_keyboard_interrupt).call()
+
+
+def test_call_propagates_system_exit():
+    def raises_system_exit():
+        raise SystemExit(2)
+
+    with pytest.raises(SystemExit):
+        _tool(raises_system_exit).call()
+
+
+def test_call_formats_regular_exception():
+    def raises_value_error():
+        raise ValueError("kaboom")
+
+    result = _tool(raises_value_error).call()
+    assert isinstance(result, str)
+    assert "ValueError: kaboom" in result
+    # The traceback should start inside the callable, not inside Tool.call.
+    assert "raises_value_error" in result
+
+
+def test_call_non_callable_reports_type_error():
+    class NotCallable:
+        pass
+
+    tool = _tool(lambda: None)
+    # Simulate a non-callable value assigned to .callable: the TypeError is then
+    # raised at the call expression itself, so there is no inner traceback frame.
+    tool.callable = NotCallable()
+    result = tool.call()
+    assert isinstance(result, str)
+    assert "not callable" in result

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -3,8 +3,10 @@
 See https://github.com/guidance-ai/guidance/issues/1485: ``Tool.call`` used to
 catch ``BaseException`` (swallowing ``KeyboardInterrupt``/``SystemExit`` and
 turning them into tool-output strings) and asserted that the traceback always
-had an inner frame (crashing with a bare ``AssertionError`` when the callable
-was not actually callable).
+had an inner frame. That assert fired whenever the error was raised at the call
+expression itself rather than inside the callable -- most reachably when the
+provider returns an argument set that does not match the tool's signature, which
+raises ``TypeError`` before the callable's frame is ever entered.
 """
 
 import pytest
@@ -40,6 +42,27 @@ def test_call_formats_regular_exception():
     assert "ValueError: kaboom" in result
     # The traceback should start inside the callable, not inside Tool.call.
     assert "raises_value_error" in result
+
+
+def test_call_with_mismatched_arguments_is_formatted_not_asserted():
+    def get_weather(city: str, units: str = "c"):
+        return f"{city}:{units}"
+
+    tool = _tool(get_weather)
+
+    # A provider can return an argument dict that does not match the signature; it is
+    # splatted straight into Tool.call, so the TypeError is raised at the call
+    # expression and never enters get_weather's frame.
+    missing_required = tool.call()
+    assert isinstance(missing_required, str)
+    assert "missing 1 required positional argument" in missing_required
+
+    unexpected = tool.call(city="Rome", zoom=3)
+    assert isinstance(unexpected, str)
+    assert "unexpected keyword argument" in unexpected
+
+    # A well-formed call is unaffected.
+    assert tool.call(city="Rome") == "Rome:c"
 
 
 def test_call_non_callable_reports_type_error():


### PR DESCRIPTION
Fixes #1485.

`Tool.call` in `guidance/_tools.py` caught `BaseException`, which also matches `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. Those were caught, formatted into a traceback string, and returned as the tool's output — so hitting Ctrl+C (or a `sys.exit()`) inside a tool's callable didn't stop anything; the model just received the traceback as "tool output" and kept going.

It also did `tb = e.__traceback__.tb_next` followed by `assert tb is not None`. That assumption only holds when the callable executes at least one line before raising. When `Tool.callable` isn't actually callable, the `TypeError` is raised at the call expression itself (inside `call`'s own frame), so `tb_next` is `None` and the bare `assert` blew up with a message-less `AssertionError` instead of surfacing the real problem.

## Fix

- Catch `Exception` instead of `BaseException`, so interpreter-control exceptions propagate.
- Replace the `assert` with a fallback to the full traceback when there is no inner frame.

Regular exceptions still behave exactly as before (formatted string, traceback starting inside the callable, `exc_formatter` honored when set).

## Tests

Adds `tests/unit/test_tools.py`:
- `KeyboardInterrupt` and `SystemExit` raised inside a tool propagate out of `call()`.
- A regular `ValueError` is still returned as a formatted traceback string starting inside the callable.
- A non-callable `.callable` yields a clean "not callable" traceback string rather than an `AssertionError`.

Note: the previous PR for this issue (#1486) was closed by its author for inactivity, not rejected; the issue is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
