### PR TITLE
Allow special tokens as stop conditions in gen()

### DIFF
--- a/guidance/_ast.py
+++ b/guidance/_ast.py
@@ -468,7 +468,7 @@ class RuleNode(GrammarNode):
     list_append: bool = False
     temperature: float | None = None
     max_tokens: int | None = None
-    stop: RegexNode | LiteralNode | None = None
+    stop: RegexNode | LiteralNode | SpecialToken | None = None
     suffix: LiteralNode | None = None
     stop_capture: str | None = None
     lazy: bool = False
@@ -656,6 +656,28 @@ class LarkSerializer:
         self.rules: dict[str, str] = {}
         self.names: dict[RuleNode, str] = {}
 
+    def _split_special_stop(self, node: RuleNode) -> RuleNode:
+        """
+        Special tokens can't be stop tokens, which makes stopping a reasoning channel hard.
+        However, other terminal-only attrs also can't be in the same node as a capture based
+        on stopping on the special token. So we have to split such cases into two rules.
+
+        attrs stay on the inner rule, and the special token goes to an outer rule
+        """
+        assert isinstance(node.stop, SpecialToken)
+        if node.stop_capture is not None or node.lazy:
+            raise ValueError("stop_capture and lazy are not supported with a special-token stop")
+        inner = RuleNode(
+            name=f"{node.name}_body",
+            value=node.value,
+            list_append=node.list_append,
+            temperature=node.temperature,
+            max_tokens=node.max_tokens,
+            suffix=node.suffix,
+            capture=node.capture,
+        )
+        return RuleNode(name=node.name, value=JoinNode((inner, node.stop)))
+
     def serialize(self, node: GrammarNode) -> str:
         if isinstance(node, RuleNode) and node.name == "start":
             self.visit(node)
@@ -683,6 +705,8 @@ class LarkSerializer:
         if isinstance(node, RuleNode):
             if node in self.names:
                 return self.names[node]
+            if isinstance(node.stop, SpecialToken):
+                return self.visit(self._split_special_stop(node), top=top)
 
             name = self.normalize_name(node.name, node.is_allowed_in_lark_terminal)
             names = set(self.names.values())

--- a/guidance/_grammar.py
+++ b/guidance/_grammar.py
@@ -26,7 +26,7 @@ def regex(pattern: str) -> RegexNode:
 
 def gen(
     regex: str | None = None,
-    stop: str | None = None,
+    stop: str | SpecialToken | None = None,
     stop_regex: str | None = None,
     suffix: str | None = None,
     stop_capture: str | None = None,
@@ -38,8 +38,10 @@ def gen(
     if stop is not None and stop_regex is not None:
         raise ValueError("You cannot specify both a stop and a stop_regex")
 
-    stop_value: LiteralNode | RegexNode | None = None
-    if stop is not None:
+    stop_value: LiteralNode | RegexNode | SpecialToken | None = None
+    if isinstance(stop, SpecialToken):
+        stop_value = stop
+    elif stop is not None:
         stop_value = LiteralNode(stop)
     elif stop_regex is not None:
         stop_value = RegexNode(stop_regex)

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Literal
 
-from .._ast import ToolCallNode
+from .._ast import SpecialToken, ToolCallNode
 from .._grammar import capture, quote_regex
 from .._grammar import gen as grammar_gen
 from .._grammar import regex as regex_node
@@ -18,7 +18,7 @@ def gen(
     regex=None,
     tools=None,
     hide_tool_call=False,
-    stop: str | list[str] | None = None,
+    stop: str | SpecialToken | list[str | SpecialToken] | None = None,
     stop_regex: str | list[str] | None = None,
     suffix: str | None = None,
     n=1,
@@ -60,8 +60,11 @@ def gen(
             as the model generates anything that does not match the pattern (this ending behavior may change a bit we
             update guidance to maintain the grammar parsing state between calls).
 
-        stop : str or list or None
+        stop : str or SpecialToken or list or None
             The stop string (or list of strings) we should use for terminating this generation segment.
+            A `guidance.special_token(...)` may be given instead, to stop on a model's own terminator
+            (for example the token that closes a reasoning channel). A special token stop cannot be
+            combined with text stops, `stop_regex`, `save_stop_text`, or another special token.
 
         stop_regex : str or list or None
             The stop regular expression (or list of regular expressions) we should use for terminating this generation segment.
@@ -124,9 +127,20 @@ def gen(
 
     if stop is not None and stop_regex is not None:
         raise ValueError("Cannot use both stop and stop_regex")
-    if isinstance(stop, list):
-        stop_regex = [quote_regex(s) for s in stop]
-        stop = None
+    if isinstance(stop, (str, SpecialToken)):
+        stop = [stop]
+    special = [s for s in (stop or []) if isinstance(s, SpecialToken)]
+    plain = [s for s in (stop or []) if not isinstance(s, SpecialToken)]
+    if special and (plain or stop_regex):
+        raise ValueError("Cannot mix special tokens with plain text or regex stops")
+    if special and save_stop_text is not False:
+        raise ValueError("Can't use save stop text alongside a special stop token")
+    if len(special) > 1:
+        raise ValueError("Only one special token stop is supported")
+    if plain:
+        stop_regex = "|".join(quote_regex(s) for s in plain)
+    stop = special[0] if special else None
+
     if isinstance(stop_regex, list):
         stop_regex = "|".join(list(stop_regex))
 

--- a/tests/unit/library/test_gen.py
+++ b/tests/unit/library/test_gen.py
@@ -1,6 +1,6 @@
 import pytest
 
-from guidance import gen, models
+from guidance import gen, models, special_token
 
 
 def test_basic():
@@ -153,3 +153,55 @@ def test_multiline():
     model = models.Mock(b"<s>this\nis\na\ntest<s>")
     model += gen(max_tokens=20)
     assert str(model) == "this\nis\na\ntest"
+
+
+class TestSpecialTokenStop:
+    """`gen(stop=...)` compiles stops into a regex, and llguidance forbids special tokens at
+    that level -- so a model whose reasoning channel closes with a special token can never
+    emit its own terminator. These cover routing a special-token stop into the rule body
+    instead, and rejecting the combinations whose semantics we haven't defined.
+
+    Mock's only special token is `<s>` (id 0), so that stands in for e.g. Gemma's `<channel|>`.
+    """
+
+    def test_terminates_and_excludes_terminator(self):
+        lm = models.Mock(b"<s>hello<s>")
+        lm += gen("text", stop=special_token("<s>"), max_tokens=20)
+        # Stopped on the token rather than running to max_tokens...
+        assert str(lm) == "hello<s>"
+        # ...and the terminator is excluded from the capture, as with an ordinary text stop.
+        assert lm["text"] == "hello"
+
+    def test_accepts_single_element_list(self):
+        lm = models.Mock(b"<s>hello<s>")
+        lm += gen("text", stop=[special_token("<s>")], max_tokens=20)
+        assert lm["text"] == "hello"
+
+    def test_text_stop_still_works(self):
+        # Regression: the ordinary path must be untouched.
+        lm = models.Mock(b"<s>Count to 10: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10")
+        lm += "Count to 10: 1, 2, 3, 4, 5, 6, 7, " + gen("text", stop=", 9")
+        assert lm["text"] == "8"
+
+    def test_rejects_mixed_with_text_stop(self):
+        # A regex stop and a special-token stop can't share RuleNode.stop, and nesting them
+        # would mean "END, then the token" rather than "whichever comes first".
+        with pytest.raises(ValueError, match="special"):
+            gen("text", stop=["END", special_token("<s>")])
+
+    def test_rejects_mixed_with_stop_regex(self):
+        # Caught by the pre-existing stop/stop_regex mutual exclusion rather than by a
+        # special-token-specific message, which is accurate enough for this combination.
+        with pytest.raises(ValueError, match="both stop and stop_regex"):
+            gen("text", stop=special_token("<s>"), stop_regex="END")
+
+    def test_rejects_multiple_special_tokens(self):
+        # RuleNode.stop holds one node; supporting several needs a SelectNode in the body.
+        with pytest.raises(ValueError, match="special"):
+            gen("text", stop=[special_token("<s>"), special_token("<s>")])
+
+    def test_rejects_save_stop_text(self):
+        # save_stop_text maps to stop_capture, which is lexer-level and has no home once the
+        # terminator moves into the rule body. Must not silently return nothing.
+        with pytest.raises(ValueError, match="special"):
+            gen("text", stop=special_token("<s>"), save_stop_text=True)

--- a/tests/unit/test_ast.py
+++ b/tests/unit/test_ast.py
@@ -1,4 +1,5 @@
 import pydantic
+import pytest
 from llguidance import LLMatcher
 
 from guidance._ast import (
@@ -11,6 +12,7 @@ from guidance._ast import (
     RuleNode,
     RuleRefNode,
     SelectNode,
+    SpecialToken,
     SubgrammarNode,
 )
 from guidance.library._pydantic import pydantic_to_json_schema
@@ -169,6 +171,94 @@ MY_RULE: /.*/
         grm = LLMatcher.grammar_from_lark(result)
         is_err, _ = LLMatcher.validate_grammar_with_warnings(grm)
         assert not is_err
+
+    def test_special_token_stop_rule_node(self):
+        # A special token can't be a `stop=` attribute: `stop=` is lexer-level and llguidance
+        # rejects special tokens in terminals. It has to go in the rule body instead -- and
+        # because temperature=/max_tokens= force terminal treatment, they can't share a rule
+        # with it, so the node is split in two.
+        target = LarkSerializer(enforce_max_tokens=True)
+        ren = RegexNode(".*")
+        st = SpecialToken(text="channel|")
+        rule_node = RuleNode("my_rule", value=ren, capture="my_capture", temperature=0.7, max_tokens=300, stop=st)
+
+        result = target.serialize(rule_node.simplify())
+        print(result)
+
+        expected = """%llguidance {}
+
+start: my_rule
+my_rule: my_rule_body <channel|>
+my_rule_body[capture="my_capture", temperature=0.7, max_tokens=300]: MY_RULE_BODY
+MY_RULE_BODY: /.*/
+"""
+        assert result == expected
+        grm = LLMatcher.grammar_from_lark(result)
+        is_err, _ = LLMatcher.validate_grammar_with_warnings(grm)
+        assert not is_err
+
+    def test_special_token_stop_select_body(self):
+        # The select body must end up wrapped in its own terminal, otherwise the token would
+        # bind to the last alternative only.
+        target = LarkSerializer(enforce_max_tokens=True)
+        sn = SelectNode((LiteralNode("A"), LiteralNode("B")))
+        st = SpecialToken(text="channel|")
+        rule_node = RuleNode("my_rule", value=sn, capture="my_capture", stop=st)
+
+        result = target.serialize(rule_node.simplify())
+        print(result)
+
+        expected = """%llguidance {}
+
+start: my_rule
+my_rule: my_rule_body <channel|>
+my_rule_body[capture="my_capture"]: MY_RULE_BODY
+
+MY_RULE_BODY: "A"
+     | "B"
+
+"""
+        assert result == expected
+        grm = LLMatcher.grammar_from_lark(result)
+        is_err, _ = LLMatcher.validate_grammar_with_warnings(grm)
+        assert not is_err
+
+    def test_special_token_stop_with_suffix(self):
+        # suffix= is terminal-only, so it stays on the inner rule -- meaning the suffix is
+        # matched *before* the special token, which is the ordering a caller would expect
+        # from "generate, then the suffix, then the thing that terminates it".
+        target = LarkSerializer(enforce_max_tokens=True)
+        ren = RegexNode(".*")
+        st = SpecialToken(text="channel|")
+        rule_node = RuleNode(
+            "my_rule", value=ren, capture="my_capture", max_tokens=300, suffix=LiteralNode("DONE"), stop=st
+        )
+
+        result = target.serialize(rule_node.simplify())
+        print(result)
+
+        expected = """%llguidance {}
+
+start: my_rule
+my_rule: my_rule_body <channel|>
+my_rule_body[capture="my_capture", max_tokens=300, suffix="DONE"]: MY_RULE_BODY
+MY_RULE_BODY: /.*/
+"""
+        assert result == expected
+        grm = LLMatcher.grammar_from_lark(result)
+        is_err, _ = LLMatcher.validate_grammar_with_warnings(grm)
+        assert not is_err
+
+    def test_special_token_stop_rejects_stop_capture_and_lazy(self):
+        # Both are lexer-level and have no home once the terminator moves into the rule body,
+        # so the split must refuse them rather than silently dropping them.
+        target = LarkSerializer(enforce_max_tokens=True)
+        st = SpecialToken(text="channel|")
+
+        for kwargs in ({"stop_capture": "my_stop"}, {"lazy": True}):
+            rule_node = RuleNode("my_rule", value=RegexNode(".*"), stop=st, **kwargs)
+            with pytest.raises(ValueError, match="special-token stop"):
+                target.serialize(rule_node.simplify())
 
     def test_suffix_rule_node(self):
         target = LarkSerializer()

--- a/tests/unit/test_grammar.py
+++ b/tests/unit/test_grammar.py
@@ -2,6 +2,7 @@ import pytest
 
 import guidance
 from guidance import gen, lark, models, optional, select
+from guidance._ast import RegexNode, RuleNode, SpecialToken
 from guidance._parser import ByteParserException
 
 
@@ -144,3 +145,21 @@ class TestMatch:
         # Shold raise since we don't allow partial
         with pytest.raises(ByteParserException):
             g.match(b"123", raise_exceptions=True)
+
+
+def test_special_token_stop_terminates_generation():
+    # A special token can only terminate a rule if it lands in the rule body rather than in a
+    # `stop=` attribute (llguidance forbids special tokens in terminals). Mock's token 0 is
+    # `<s>`, its only special token, so we stop on that.
+    lm = models.Mock(b"<s>hello<s>")
+    lm += RuleNode(
+        "my_rule",
+        value=RegexNode("[a-z]*"),
+        capture="my_capture",
+        stop=SpecialToken(id=0),
+        max_tokens=20,
+    )
+    # Terminated on the token rather than running to max_tokens...
+    assert str(lm) == "hello<s>"
+    # ...and, as with an ordinary `stop=`, the terminator is excluded from the capture.
+    assert lm["my_capture"] == "hello"


### PR DESCRIPTION
gen(stop=...) compiles its argument into a regex terminal, and llguidance rejects special tokens inside terminals. This means that if I want to use a model that has a reasoning channel (e.g. Gemma4) I can't stop the reasoning on emission of the reasoning channel closing tag ("<channel|>")

Route a special-token stop into the rule body instead of the stop= attribute. Because temperature= and max_tokens= force terminal treatment, they cannot share a rule with the token, so the node is split: attributes stay on an inner rule, the token goes on the outer one. 

Combinations whose semantics are undefined raise ValueError. I wasn't sure how to handle these so went for least surprising. Mixing special and text/regex stops, multiple special tokens, save_stop_text, stop_capture and lazy will raise ValueErrors now. If that's not a good idea I'm happy to change that behaviour, I just didn't know what _should_ happen in those cases.

I think the added tests cover everything, and I don't think I had any regressions. I was able to control the reasoning channel using Gemma4 locally with a llama.cpp engine in some code I've been working on modernising.

Full disclosure: I got a some help from Claude, especially the tests, but I think everything looks sensible.