### PR TITLE
docs: quote the pip extras in the onnxruntime-genai notebook

### DIFF
--- a/notebooks/tutorials/onnxruntime_models.ipynb
+++ b/notebooks/tutorials/onnxruntime_models.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Requirements:\n",
     "```\n",
-    "pip install -e .[onnxruntime_genai]\n",
+    "pip install -e '.[onnxruntime_genai]'\n",
     "pip install huggingface_hub\n",
     "```"
    ]


### PR DESCRIPTION
The requirements block at the top of `notebooks/tutorials/onnxruntime_models.ipynb` tells the reader to run:

```
pip install -e .[onnxruntime_genai]
```

Under zsh the unquoted brackets are a glob pattern, so the shell reports `no matches found` and never hands the string to pip. Quoting it fixes that and is a no-op on bash.

**This is a follow-on to #1495, not a replacement for it.** @nyxst4ck's PR fixes the same pattern in `CONTRIBUTING.md`, and the rationale here is theirs; I am only carrying it to the one place their sweep and my review of it both missed. The files do not overlap, so the two can merge in either order. If you would rather have it as one change, say so and I will close this and hand the line to @nyxst4ck for #1495.

**Why this line and not the others.** Swept the tree on current `main` for `-e .[`:

| location | occurrences | action |
|---|---:|---|
| `CONTRIBUTING.md` | 3 | fixed by #1495 |
| `notebooks/tutorials/onnxruntime_models.ipynb` | 1 | this PR |
| `.github/workflows/` | 11 across 7 files | left alone, deliberately |

The workflow occurrences run under the Actions default shell. Bash leaves an unmatched bracket pattern as a literal rather than erroring, and nobody copies from CI config, so quoting them would be churn in files that are not the problem and would make a docs fix look like a CI change.

With this merged alongside #1495, no unquoted `-e .[` remains on any surface a reader copies from.

**Scope.** One line in one markdown cell. The notebook still parses as valid JSON (10 cells) and no execution counts, outputs or metadata were touched, so the diff is a single line rather than a reserialised notebook.

```diff
-    "pip install -e .[onnxruntime_genai]\n",
+    "pip install -e '.[onnxruntime_genai]'\n",
```
