### PR TITLE
fix(models/_base): drop __all__ names the module does not define

### DIFF
--- a/guidance/models/_base/__init__.py
+++ b/guidance/models/_base/__init__.py
@@ -3,12 +3,7 @@ from ._model import Model
 from ._state import State
 
 __all__ = [
-    "ASTNode",
-    "ContentChunk",
     "Interpreter",
-    "Message",
-    "MessageChunk",
     "Model",
     "State",
-    "role",
 ]


### PR DESCRIPTION
### Problem

`guidance/models/_base/__init__.py` declares eight names in `__all__` but binds only three:

```python
from ._interpreter import Interpreter
from ._model import Model
from ._state import State

__all__ = [
    "ASTNode",        # never bound here
    "ContentChunk",   # no longer exists anywhere in the package
    "Interpreter",
    "Message",        # not bound here
    "MessageChunk",   # no longer exists anywhere in the package
    "Model",
    "State",
    "role",           # never bound here
]
```

Because `__all__` drives `import *`, this is not a silent partial export — the star import fails outright on the first missing name:

```
AttributeError: module 'guidance.models._base' has no attribute 'ASTNode'
```

(Reproduced against the real `__init__.py` with the three submodules stubbed; after the change, `from ... import *` succeeds and binds `['Interpreter', 'Model', 'State']`.)

### How it drifted

- `953cd69` imported `ContentChunk, Message, MessageChunk, State` from `._state`, so those three names resolved.
- `8ec4fec` ("Model/State/Client Architecture", #1136) narrowed that to `from ._state import State`. `__all__` was left as-is — this is the regression point.
- `ASTNode` and `role` were already unbound before that; they have never resolved from this module.
- `ContentChunk` and `MessageChunk` are no longer defined anywhere in the package today.

Nothing in the repo does `from ._base import *` — every internal consumer imports explicitly (`from ._base import Model`, `from ._base import Interpreter, State`), which is why this has gone unnoticed.

It is also invisible to CI: `ruff.toml` selects `RUF022` (sort `__all__`), so the list gets *sorted* but its contents are never validated. Ruff's `F822` (undefined name in `__all__`) is both unselected and skipped inside `__init__.py` by design.

### Fix

Reduce `__all__` to the names the module actually binds. Kept sorted for `RUF022`; `ruff check --config ruff.toml` passes.

I deliberately did **not** fix this by adding the missing imports: `ASTNode` lives in `guidance._ast` and `Message` in `guidance.models._openai_base`, and both of those modules already import *from* `._base`, so re-exporting them here would introduce import cycles.

If any of these were intended as part of this subpackage's public surface, happy to switch to whichever re-export shape you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
